### PR TITLE
Add column-scoped mobile search

### DIFF
--- a/examples/src/MobileTransformExample.tsx
+++ b/examples/src/MobileTransformExample.tsx
@@ -26,9 +26,11 @@ export default function MobileTransformExample() {
           index % 4
         ],
         note:
-          index % 7 === 0
-            ? "Renewal requires legal review and procurement approval."
-            : "Healthy account with regular product activity.",
+          index === 9000
+            ? "Reference: AC-09001"
+            : index % 7 === 0
+              ? "Renewal requires legal review and procurement approval."
+              : "Healthy account with regular product activity.",
       })),
     []
   );

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,12 +1,28 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "../../lib/utils"
-import { useDatagridThemeClassSuffix } from "../../theme/context"
+import { cn } from "../../lib/utils";
+import { useDatagridThemeClassSuffix } from "../../theme/context";
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, onFocus, onBlur, disabled, style, ...props }, ref) => {
-    const themeClassSuffix = useDatagridThemeClassSuffix()
-    const [focused, setFocused] = React.useState(false)
+type InputProps = React.ComponentProps<"input"> & {
+  inputClassName?: string;
+};
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      className,
+      inputClassName,
+      type,
+      onFocus,
+      onBlur,
+      disabled,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    const themeClassSuffix = useDatagridThemeClassSuffix();
+    const [focused, setFocused] = React.useState(false);
 
     return (
       <div
@@ -22,23 +38,26 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       >
         <input
           type={type}
-          className="inovua-react-toolkit-text-input__input flex-1 bg-transparent text-base text-[var(--tdg-input-color)] outline-none file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground md:text-sm"
+          className={cn(
+            "inovua-react-toolkit-text-input__input flex-1 bg-transparent text-base text-[var(--tdg-input-color)] outline-none file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground md:text-sm",
+            inputClassName
+          )}
           ref={ref}
           disabled={disabled}
           onFocus={(event) => {
-            setFocused(true)
-            onFocus?.(event)
+            setFocused(true);
+            onFocus?.(event);
           }}
           onBlur={(event) => {
-            setFocused(false)
-            onBlur?.(event)
+            setFocused(false);
+            onBlur?.(event);
           }}
           {...props}
         />
       </div>
-    )
+    );
   }
-)
-Input.displayName = "Input"
+);
+Input.displayName = "Input";
 
-export { Input }
+export { Input };

--- a/src/grid/components/MobileGridList.tsx
+++ b/src/grid/components/MobileGridList.tsx
@@ -33,7 +33,10 @@ import { getColumnId, getColumnSortName } from "../../utils/column";
 import { t } from "../../utils/helpers";
 import {
   buildMobileSearchText,
-  matchesMobileSearch,
+  matchesMobileSearchTokens,
+  parseMobileSearchQuery,
+  tokenizeMobileSearchQuery,
+  type MobileSearchColumn,
 } from "../utils/mobileSearch";
 
 type MobileGridListProps = {
@@ -63,6 +66,23 @@ function labelForColumn(column: TypeColumn): string {
   return column.name ?? column.id ?? "Value";
 }
 
+function searchAliasesForColumn(column: TypeColumn): string[] {
+  const aliases = [
+    getColumnId(column),
+    column.id,
+    column.name,
+    typeof column.header === "string" ? column.header : undefined,
+  ];
+
+  return Array.from(
+    new Set(
+      aliases
+        .map((alias) => alias?.trim() ?? "")
+        .filter((alias) => alias.length > 0)
+    )
+  );
+}
+
 export function MobileGridList({
   rows,
   columns,
@@ -84,25 +104,13 @@ export function MobileGridList({
   );
   const deferredQuery = React.useDeferredValue(query);
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
+  const searchInputRef = React.useRef<HTMLInputElement | null>(null);
   const sortPanelId = React.useId();
+  const [isSearchComposing, setIsSearchComposing] = React.useState(false);
+  const [searchScrollLeft, setSearchScrollLeft] = React.useState(0);
   const [hiddenMobileColumnIds, setHiddenMobileColumnIds] = React.useState<
     Set<string>
   >(() => new Set());
-  const searchIndex = React.useMemo(
-    () =>
-      rows.map((row) => ({ row, text: buildMobileSearchText(row.original) })),
-    [rows]
-  );
-  const filteredRows = React.useMemo(
-    () =>
-      searchIndex
-        .filter((entry) => matchesMobileSearch(entry.text, deferredQuery))
-        .map((entry) => entry.row),
-    [deferredQuery, searchIndex]
-  );
-  React.useEffect(() => {
-    onFilteredRowsCountChange?.(filteredRows.length);
-  }, [filteredRows.length, onFilteredRowsCountChange]);
   const columnMap = React.useMemo(
     () => new Map(columns.map((column) => [getColumnId(column), column])),
     [columns]
@@ -111,6 +119,75 @@ export function MobileGridList({
     () => columns.filter((column) => getColumnId(column) !== checkboxColumnId),
     [checkboxColumnId, columns]
   );
+  const mobileSearchColumns = React.useMemo<MobileSearchColumn[]>(
+    () =>
+      displayColumns.map((column) => ({
+        id: getColumnId(column),
+        aliases: searchAliasesForColumn(column),
+      })),
+    [displayColumns]
+  );
+  const parsedQuery = React.useMemo(
+    () => parseMobileSearchQuery(query, mobileSearchColumns),
+    [mobileSearchColumns, query]
+  );
+  const parsedDeferredQuery = React.useMemo(
+    () => parseMobileSearchQuery(deferredQuery, mobileSearchColumns),
+    [deferredQuery, mobileSearchColumns]
+  );
+  const deferredSearchTokens = React.useMemo(
+    () => tokenizeMobileSearchQuery(parsedDeferredQuery.searchQuery),
+    [parsedDeferredQuery.searchQuery]
+  );
+  const searchIndex = React.useMemo(
+    () =>
+      rows.map((row) => ({ row, text: buildMobileSearchText(row.original) })),
+    [rows]
+  );
+  const scopedColumnIdsKey =
+    parsedDeferredQuery.columnIds.length > 0 && deferredSearchTokens.length > 0
+      ? JSON.stringify(parsedDeferredQuery.columnIds)
+      : "[]";
+  const scopedSearchIndex = React.useMemo(() => {
+    const columnIds = JSON.parse(scopedColumnIdsKey) as string[];
+    if (columnIds.length === 0) return null;
+
+    return searchIndex.map((entry) => ({
+      row: entry.row,
+      texts: columnIds.map((columnId) =>
+        buildMobileSearchText(entry.row.getValue(columnId))
+      ),
+    }));
+  }, [scopedColumnIdsKey, searchIndex]);
+  const filteredRows = React.useMemo(() => {
+    if (parsedDeferredQuery.columnIds.length > 0) {
+      if (deferredSearchTokens.length === 0) {
+        return searchIndex.map((entry) => entry.row);
+      }
+
+      return (scopedSearchIndex ?? [])
+        .filter((entry) =>
+          entry.texts.some((text) =>
+            matchesMobileSearchTokens(text, deferredSearchTokens)
+          )
+        )
+        .map((entry) => entry.row);
+    }
+
+    return searchIndex
+      .filter((entry) =>
+        matchesMobileSearchTokens(entry.text, deferredSearchTokens)
+      )
+      .map((entry) => entry.row);
+  }, [
+    deferredSearchTokens,
+    parsedDeferredQuery.columnIds.length,
+    scopedSearchIndex,
+    searchIndex,
+  ]);
+  React.useEffect(() => {
+    onFilteredRowsCountChange?.(filteredRows.length);
+  }, [filteredRows.length, onFilteredRowsCountChange]);
   const visibleDisplayColumnCount = displayColumns.reduce(
     (count, column) =>
       count + (hiddenMobileColumnIds.has(getColumnId(column)) ? 0 : 1),
@@ -232,6 +309,8 @@ export function MobileGridList({
   const draftSortColumn = sortableColumns.find(
     (column) => getColumnId(column) === draftSortColumnId
   );
+  const highlightSearchQuery =
+    parsedQuery.prefixEnd !== null && !isSearchComposing;
 
   const toggleSortPanel = () => {
     if (!sortPanelOpen) {
@@ -282,27 +361,84 @@ export function MobileGridList({
     >
       <div className="shrink-0 border-b bg-background p-3 [border-color:var(--tdg-grid-border-color)]">
         <div className="flex items-center gap-2">
-          <div className="relative min-w-0 flex-1">
+          <div className="relative min-w-0 flex-1 rounded-md bg-[var(--tdg-input-bg)]">
             <Search
-              className="pointer-events-none absolute left-3 top-1/2 z-10 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute left-3 top-1/2 z-20 h-4 w-4 -translate-y-1/2 text-muted-foreground"
               aria-hidden="true"
             />
             <Input
-              className="h-10 pl-7 pr-9"
+              ref={searchInputRef}
+              className={cn(
+                "h-10 pl-7 pr-9",
+                highlightSearchQuery && "relative z-10 !bg-transparent"
+              )}
+              inputClassName={cn(
+                highlightSearchQuery &&
+                  "!text-transparent caret-[var(--tdg-input-color)]"
+              )}
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setSearchScrollLeft(event.currentTarget.scrollLeft);
+              }}
+              onScroll={(event) =>
+                setSearchScrollLeft(event.currentTarget.scrollLeft)
+              }
+              onSelect={(event) =>
+                setSearchScrollLeft(event.currentTarget.scrollLeft)
+              }
+              onCompositionStart={() => setIsSearchComposing(true)}
+              onCompositionEnd={(event) => {
+                setIsSearchComposing(false);
+                setSearchScrollLeft(event.currentTarget.scrollLeft);
+              }}
               placeholder="Search all fields"
               aria-label="Search all fields"
               type="text"
               role="searchbox"
             />
+            {highlightSearchQuery && parsedQuery.prefixEnd !== null ? (
+              <div
+                className="pointer-events-none absolute inset-y-0 left-7 right-9 z-0 flex items-center overflow-hidden text-base text-[var(--tdg-input-color)] md:text-sm"
+                data-slot="mobile-search-query-highlight"
+                aria-hidden="true"
+              >
+                <span
+                  className="inline-flex min-w-max whitespace-pre font-normal"
+                  style={{ transform: `translateX(${-searchScrollLeft}px)` }}
+                >
+                  <span className="relative inline-block">
+                    <span className="invisible">
+                      {query.slice(0, parsedQuery.prefixEnd)}
+                    </span>
+                    <strong
+                      className="absolute inset-0 whitespace-pre font-bold"
+                      data-slot="mobile-search-column-prefix"
+                    >
+                      {query.slice(0, parsedQuery.prefixEnd)}
+                    </strong>
+                  </span>
+                  <span
+                    className="font-normal"
+                    data-slot="mobile-search-query-value"
+                  >
+                    {query.slice(parsedQuery.prefixEnd)}
+                  </span>
+                </span>
+              </div>
+            ) : null}
             {query ? (
               <Button
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="absolute right-0 top-0 h-10 w-10"
-                onClick={() => setQuery("")}
+                className="absolute right-0 top-0 z-20 h-10 w-10"
+                onClick={() => {
+                  setQuery("");
+                  setIsSearchComposing(false);
+                  setSearchScrollLeft(0);
+                  searchInputRef.current?.focus();
+                }}
                 aria-label="Clear search"
                 title="Clear search"
               >

--- a/src/grid/utils/mobileSearch.ts
+++ b/src/grid/utils/mobileSearch.ts
@@ -1,5 +1,16 @@
 const COMBINING_MARKS = /[\u0300-\u036f]/g;
 
+export type MobileSearchColumn = {
+  id: string;
+  aliases: readonly string[];
+};
+
+export type ParsedMobileSearchQuery = {
+  columnIds: string[];
+  prefixEnd: number | null;
+  searchQuery: string;
+};
+
 export function normalizeMobileSearchText(value: string): string {
   return value
     .normalize("NFKD")
@@ -42,6 +53,65 @@ export function buildMobileSearchText(value: unknown): string {
   return normalizeMobileSearchText(output.join(" "));
 }
 
+export function parseMobileSearchQuery(
+  query: string,
+  columns: readonly MobileSearchColumn[]
+): ParsedMobileSearchQuery {
+  let colonIndex = query.indexOf(":");
+  let match: ParsedMobileSearchQuery | null = null;
+
+  while (colonIndex >= 0) {
+    const requestedAlias = normalizeMobileSearchText(
+      query.slice(0, colonIndex)
+    );
+
+    if (requestedAlias) {
+      const columnIds = Array.from(
+        new Set(
+          columns
+            .filter((column) =>
+              column.aliases.some(
+                (alias) => normalizeMobileSearchText(alias) === requestedAlias
+              )
+            )
+            .map((column) => column.id)
+        )
+      );
+
+      if (columnIds.length > 0) {
+        match = {
+          columnIds,
+          prefixEnd: colonIndex + 1,
+          searchQuery: query.slice(colonIndex + 1),
+        };
+      }
+    }
+
+    colonIndex = query.indexOf(":", colonIndex + 1);
+  }
+
+  return (
+    match ?? {
+      columnIds: [],
+      prefixEnd: null,
+      searchQuery: query,
+    }
+  );
+}
+
+export function tokenizeMobileSearchQuery(query: string): string[] {
+  return normalizeMobileSearchText(query).split(" ").filter(Boolean);
+}
+
+export function matchesMobileSearchTokens(
+  searchText: string,
+  tokens: readonly string[]
+): boolean {
+  return (
+    tokens.length === 0 || tokens.every((token) => searchText.includes(token))
+  );
+}
+
 function ReactIsElement(value: object): boolean {
   return "$$typeof" in value && "props" in value;
 }
@@ -50,8 +120,8 @@ export function matchesMobileSearch(
   searchText: string,
   query: string
 ): boolean {
-  const tokens = normalizeMobileSearchText(query).split(" ").filter(Boolean);
-  return (
-    tokens.length === 0 || tokens.every((token) => searchText.includes(token))
+  return matchesMobileSearchTokens(
+    searchText,
+    tokenizeMobileSearchQuery(query)
   );
 }

--- a/tests/playwright/mobile-transform.spec.ts
+++ b/tests/playwright/mobile-transform.spec.ts
@@ -1,6 +1,38 @@
 import { expect, test } from "@playwright/test";
 
+import { parseMobileSearchQuery } from "../../src/grid/utils/mobileSearch";
+
 test.describe("allowMobileTransform", () => {
+  test("recognizes punctuation-rich column headers and column keys", () => {
+    const columns = [{ id: "orgid", aliases: ["orgid", "Org #"] }];
+
+    expect(parseMobileSearchQuery("Org #: 154", columns)).toEqual({
+      columnIds: ["orgid"],
+      prefixEnd: 6,
+      searchQuery: " 154",
+    });
+    expect(parseMobileSearchQuery("ORGID: 154", columns)).toEqual({
+      columnIds: ["orgid"],
+      prefixEnd: 6,
+      searchQuery: " 154",
+    });
+    expect(parseMobileSearchQuery("Test: 123", columns)).toEqual({
+      columnIds: [],
+      prefixEnd: null,
+      searchQuery: "Test: 123",
+    });
+    expect(
+      parseMobileSearchQuery("Time: UTC: 12", [
+        { id: "localTime", aliases: ["Time"] },
+        { id: "utcTime", aliases: ["Time: UTC"] },
+      ])
+    ).toEqual({
+      columnIds: ["utcTime"],
+      prefixEnd: 10,
+      searchQuery: " 12",
+    });
+  });
+
   test("defaults to the table layout on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/examples/basic");
@@ -241,6 +273,77 @@ test.describe("allowMobileTransform", () => {
     await expect(page.getByTestId("mobile-action-output")).toHaveText(
       "Opened Aurora Clinic ZX-9001"
     );
+  });
+
+  test("scopes mobile search by column and bolds only a recognized prefix", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/examples/mobile-transform");
+
+    const grid = page.locator('.tdg-root[data-layout="mobile-list"]');
+    const search = grid.getByRole("searchbox", { name: "Search all fields" });
+    const resultCount = grid.locator('output[aria-live="polite"]');
+    const prefix = grid.locator(
+      'strong[data-slot="mobile-search-column-prefix"]'
+    );
+    const value = grid.locator('[data-slot="mobile-search-query-value"]');
+    const targetRow = grid.locator('article[data-row-id="AC-09001"]');
+    const composingRow = grid.locator('article[data-row-id="AC-00001"]');
+
+    await search.fill("Account ID: AC-09001");
+    await expect(resultCount).toHaveText("1 result");
+    await expect(targetRow).toBeVisible();
+    await expect(prefix).toHaveText("Account ID:");
+    await expect(value).toHaveText(" AC-09001");
+
+    const [weights, inputColors] = await Promise.all([
+      Promise.all([
+        prefix.evaluate((node) => Number(getComputedStyle(node).fontWeight)),
+        value.evaluate((node) => Number(getComputedStyle(node).fontWeight)),
+      ]),
+      search.evaluate((node) => ({
+        caret: getComputedStyle(node).caretColor,
+        text: getComputedStyle(node).color,
+      })),
+    ]);
+    expect(weights[0]).toBeGreaterThan(weights[1]);
+    expect(inputColors.text).toBe("rgba(0, 0, 0, 0)");
+    expect(inputColors.caret).not.toBe(inputColors.text);
+
+    await search.dispatchEvent("compositionstart");
+    await expect(prefix).toHaveCount(0);
+    await expect
+      .poll(() => search.evaluate((node) => getComputedStyle(node).color))
+      .not.toBe("rgba(0, 0, 0, 0)");
+    await search.fill("Account ID: AC-00001");
+    await expect(search).toHaveValue("Account ID: AC-00001");
+    await expect(resultCount).toHaveText("1 result");
+    await expect(composingRow).toBeVisible();
+    await expect(prefix).toHaveCount(0);
+    await search.dispatchEvent("compositionend");
+    await expect(prefix).toHaveText("Account ID:");
+    await expect
+      .poll(() => search.evaluate((node) => getComputedStyle(node).color))
+      .toBe("rgba(0, 0, 0, 0)");
+
+    await search.fill("Account: AC-09001");
+    await expect(resultCount).toHaveText("0 results");
+    await expect(prefix).toHaveText("Account:");
+
+    await search.fill("id: AC-09001");
+    await expect(resultCount).toHaveText("1 result");
+    await expect(targetRow).toBeVisible();
+    await expect(prefix).toHaveText("id:");
+
+    await search.fill("Reference: AC-09001");
+    await expect(search).toHaveValue("Reference: AC-09001");
+    await expect(resultCount).toHaveText("1 result");
+    await expect(targetRow).toBeVisible();
+    await expect(prefix).toHaveCount(0);
+    await expect
+      .poll(() => search.evaluate((node) => getComputedStyle(node).color))
+      .not.toBe("rgba(0, 0, 0, 0)");
   });
 
   test("uses icon-only toolbar actions and controls displayed columns", async ({


### PR DESCRIPTION
## Summary

- add mobile column-qualified search using exact, case-insensitive column header, `id`, or `name` aliases before a colon
- scope the suffix to the recognized column, so queries such as `Org #: 154` and `orgid: 154` search only that column
- render only the recognized typed prefix, including the colon, in bold while preserving the native accessible search input and caret
- keep unknown prefixes as ordinary all-fields queries with no visual emphasis
- cache scoped column text across suffix keystrokes and support IME composition, horizontal input scrolling, punctuation, and colon-bearing headers

## Why

The mobile transform previously flattened each row into one global search string, so users could not target a specific field. This adds an internal query grammar without changing the public ReactDataGrid prop surface.

## Review

The complete diff was reviewed for runtime correctness, cache invalidation, alias ambiguity, accessibility, caret and overlay synchronization, mobile IME behavior, and regression coverage. All findings were resolved; there are no remaining actionable findings.

Review-driven fixes include:

- caching normalized scoped-column values instead of rebuilding them on every suffix keystroke
- suppressing the visual mirror during IME composition so native composing text remains visible
- preferring the longest exact alias when a column header itself contains a colon
- proving positive unknown-prefix fallback and active-composition filtering end to end

## Validation

- `yarn test:types`
- changed-file ESLint — no errors; existing TanStack Virtual compiler warning only
- changed-file Prettier check
- `PLAYWRIGHT_NO_REUSE_SERVER=1 yarn test:e2e` — 50 passed
- package build and CSS scope validation
- `yarn build:site`
- `git diff --check`
