### PR TITLE
Fix filtered count loops and browser lifecycle leaks

### DIFF
--- a/examples/src/FilteredRowsCountCompatPage.tsx
+++ b/examples/src/FilteredRowsCountCompatPage.tsx
@@ -21,10 +21,12 @@ const rows = [
 ];
 
 export default function FilteredRowsCountCompatPage() {
+  const useRemoteDataSource =
+    new URLSearchParams(window.location.search).get("data-source") === "remote";
   const observerArmedRef = React.useRef(false);
   const observerCallsRef = React.useRef(0);
   const settleTimerRef = React.useRef<number | null>(null);
-  const [filtersVisible, setFiltersVisible] = React.useState(true);
+  const [rowLimit, setRowLimit] = React.useState(rows.length);
   const [liveObserverCalls, setLiveObserverCalls] = React.useState(0);
   const [lastReportedCount, setLastReportedCount] = React.useState<
     number | null
@@ -42,10 +44,26 @@ export default function FilteredRowsCountCompatPage() {
     []
   );
 
+  React.useLayoutEffect(() => {
+    (
+      window as typeof window & { __tdgFilteredDataSourceCalls?: number }
+    ).__tdgFilteredDataSourceCalls = 0;
+  }, []);
+
   const armObserver = () => {
     observerCallsRef.current = 0;
     observerArmedRef.current = true;
   };
+
+  const visibleRows = React.useMemo(() => rows.slice(0, rowLimit), [rowLimit]);
+  const remoteDataSource = React.useCallback(() => {
+    const target = window as typeof window & {
+      __tdgFilteredDataSourceCalls?: number;
+    };
+    target.__tdgFilteredDataSourceCalls =
+      (target.__tdgFilteredDataSourceCalls ?? 0) + 1;
+    return visibleRows;
+  }, [visibleRows]);
 
   // Intentionally render-local: issue #26 is caused by consumers passing an
   // otherwise valid callback whose identity changes after a parent update.
@@ -87,9 +105,13 @@ export default function FilteredRowsCountCompatPage() {
           type="button"
           variant="outline"
           data-testid="toggle-filter-feedback"
-          onClick={() => setFiltersVisible((visible) => !visible)}
+          onClick={() =>
+            setRowLimit((current) =>
+              current === rows.length ? 2 : rows.length
+            )
+          }
         >
-          Toggle filters
+          Change rows
         </Button>
         <dl className="flex flex-wrap gap-4 text-sm">
           <div>
@@ -117,12 +139,12 @@ export default function FilteredRowsCountCompatPage() {
         <ReactDataGrid
           idProperty="id"
           columns={columns}
-          dataSource={rows}
+          dataSource={useRemoteDataSource ? remoteDataSource : visibleRows}
           columnOrder={columnOrder}
           enableColumnFilterContextMenu
           enableColumnAutosize
           skipHeaderOnAutoSize={false}
-          enableFiltering={filtersVisible}
+          enableFiltering
           filteredRowsCount={reportFilteredRows}
           virtualized={false}
           allowMobileTransform

--- a/examples/src/FilteredRowsCountCompatPage.tsx
+++ b/examples/src/FilteredRowsCountCompatPage.tsx
@@ -1,0 +1,135 @@
+import * as React from "react";
+
+import ReactDataGrid, { type TypeColumns } from "../../src/main";
+import { Button } from "../../src/components/ui/button";
+
+const MAX_OBSERVER_CALLS = 8;
+const OBSERVER_QUIET_WINDOW_MS = 250;
+
+const columns: TypeColumns = [
+  { name: "id", header: "ID", defaultWidth: 72 },
+  { name: "name", header: "Name", defaultWidth: 180 },
+  { name: "team", header: "Team", defaultWidth: 160 },
+];
+
+const columnOrder = ["id", "name", "team"];
+
+const rows = [
+  { id: 1, name: "Ada Lovelace", team: "Analytics" },
+  { id: 2, name: "Grace Hopper", team: "Platform" },
+  { id: 3, name: "Katherine Johnson", team: "Research" },
+];
+
+export default function FilteredRowsCountCompatPage() {
+  const observerArmedRef = React.useRef(false);
+  const observerCallsRef = React.useRef(0);
+  const settleTimerRef = React.useRef<number | null>(null);
+  const [filtersVisible, setFiltersVisible] = React.useState(true);
+  const [liveObserverCalls, setLiveObserverCalls] = React.useState(0);
+  const [lastReportedCount, setLastReportedCount] = React.useState<
+    number | null
+  >(null);
+  const [settledObserverCalls, setSettledObserverCalls] = React.useState<
+    number | null
+  >(null);
+
+  React.useEffect(
+    () => () => {
+      if (settleTimerRef.current !== null) {
+        window.clearTimeout(settleTimerRef.current);
+      }
+    },
+    []
+  );
+
+  const armObserver = () => {
+    observerCallsRef.current = 0;
+    observerArmedRef.current = true;
+  };
+
+  // Intentionally render-local: issue #26 is caused by consumers passing an
+  // otherwise valid callback whose identity changes after a parent update.
+  function reportFilteredRows(count: number) {
+    if (!observerArmedRef.current) return;
+
+    const nextCallCount = observerCallsRef.current + 1;
+    observerCallsRef.current = nextCallCount;
+    setLiveObserverCalls(nextCallCount);
+    setLastReportedCount(count);
+
+    if (settleTimerRef.current !== null) {
+      window.clearTimeout(settleTimerRef.current);
+    }
+
+    if (nextCallCount >= MAX_OBSERVER_CALLS) {
+      observerArmedRef.current = false;
+      setSettledObserverCalls(nextCallCount);
+      return;
+    }
+
+    settleTimerRef.current = window.setTimeout(() => {
+      observerArmedRef.current = false;
+      setSettledObserverCalls(observerCallsRef.current);
+    }, OBSERVER_QUIET_WINDOW_MS);
+  }
+
+  return (
+    <main className="flex flex-col gap-4">
+      <section className="flex flex-wrap items-center gap-3 rounded-lg border bg-card p-4 shadow-sm">
+        <Button
+          type="button"
+          data-testid="arm-filtered-callback"
+          onClick={armObserver}
+        >
+          Arm observer
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          data-testid="toggle-filter-feedback"
+          onClick={() => setFiltersVisible((visible) => !visible)}
+        >
+          Toggle filters
+        </Button>
+        <dl className="flex flex-wrap gap-4 text-sm">
+          <div>
+            <dt className="text-muted-foreground">Live calls</dt>
+            <dd data-testid="filtered-callback-live-count">
+              {liveObserverCalls}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Settled calls</dt>
+            <dd data-testid="filtered-callback-settled-count">
+              {settledObserverCalls ?? "pending"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Reported rows</dt>
+            <dd data-testid="filtered-reported-row-count">
+              {lastReportedCount ?? "pending"}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="h-[520px] min-h-0 rounded-lg border bg-background p-4 shadow-sm">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          columnOrder={columnOrder}
+          enableColumnFilterContextMenu
+          enableColumnAutosize
+          skipHeaderOnAutoSize={false}
+          enableFiltering={filtersVisible}
+          filteredRowsCount={reportFilteredRows}
+          virtualized={false}
+          allowMobileTransform
+          columnUserSelect
+          showColumnMenuTool={false}
+        />
+      </section>
+    </main>
+  );
+}

--- a/examples/src/MemorySafetyCompatPage.tsx
+++ b/examples/src/MemorySafetyCompatPage.tsx
@@ -1,0 +1,514 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  type TypeColumns,
+  type TypeComputedProps,
+  type TypeDataSource,
+} from "../../src/main";
+import { Button } from "../../src/components/ui/button";
+
+const CALLBACK_CAP = 8;
+const columns: TypeColumns = [
+  { name: "id", header: "ID", defaultWidth: 80, filterable: true },
+  { name: "name", header: "Name", defaultWidth: 200, filterable: true },
+  { name: "team", header: "Team", defaultWidth: 160, filterable: true },
+];
+const columnOrder = ["id", "name", "team"];
+const smallRows = [
+  { id: 1, name: "Ada Lovelace", team: "Analytics" },
+  { id: 2, name: "Grace Hopper", team: "Platform" },
+  { id: 3, name: "Katherine Johnson", team: "Research" },
+];
+const virtualRows = Array.from({ length: 2_000 }, (_, index) => ({
+  id: index + 1,
+  name: `Memory row ${index + 1}`,
+  team: ["Analytics", "Platform", "Research"][index % 3],
+}));
+
+function ScenarioShell(props: {
+  controls?: React.ReactNode;
+  metrics?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="flex flex-col gap-4">
+      <section className="flex flex-wrap items-center gap-3 rounded-lg border bg-card p-4 shadow-sm">
+        {props.controls}
+        <dl className="flex flex-wrap gap-4 text-sm">{props.metrics}</dl>
+      </section>
+      <section className="h-[560px] min-h-0 rounded-lg border bg-background p-4 shadow-sm">
+        {props.children}
+      </section>
+    </main>
+  );
+}
+
+function Metric(props: {
+  label: string;
+  testId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{props.label}</dt>
+      <dd data-testid={props.testId}>{props.children}</dd>
+    </div>
+  );
+}
+
+function ReadyScenario() {
+  const readyCallsRef = React.useRef(0);
+  const handleCallsRef = React.useRef(0);
+  const readyRefRef = React.useRef<
+    React.MutableRefObject<TypeComputedProps | null> | undefined
+  >(undefined);
+  const firstApiRef = React.useRef<TypeComputedProps | null>(null);
+  const [readyCalls, setReadyCalls] = React.useState(0);
+  const [handleCalls, setHandleCalls] = React.useState(0);
+  const [scrollChecks, setScrollChecks] = React.useState(0);
+
+  function reportReady(ref: React.MutableRefObject<TypeComputedProps | null>) {
+    readyRefRef.current = ref;
+    firstApiRef.current ??= ref.current;
+    if (readyCallsRef.current >= CALLBACK_CAP) return;
+    readyCallsRef.current += 1;
+    setReadyCalls(readyCallsRef.current);
+  }
+
+  function reportHandle(ref: React.MutableRefObject<TypeComputedProps | null>) {
+    if (handleCallsRef.current >= CALLBACK_CAP) return;
+    handleCallsRef.current += 1;
+    setHandleCalls(handleCallsRef.current);
+    readyRefRef.current ??= ref;
+  }
+
+  const apiStable = Boolean(
+    firstApiRef.current && readyRefRef.current?.current === firstApiRef.current
+  );
+
+  return (
+    <ScenarioShell
+      controls={
+        <Button
+          type="button"
+          data-testid="ready-scroll"
+          onClick={() => {
+            readyRefRef.current?.current?.scrollToIndex(1_500);
+            setScrollChecks((current) => current + 1);
+          }}
+        >
+          Scroll API
+        </Button>
+      }
+      metrics={
+        <>
+          <Metric label="onReady calls" testId="ready-calls">
+            {readyCalls}
+          </Metric>
+          <Metric label="handle calls" testId="handle-calls">
+            {handleCalls}
+          </Metric>
+          <Metric label="API stable" testId="api-stable">
+            {String(apiStable)}
+          </Metric>
+          <Metric label="API live" testId="api-live">
+            {String(Boolean(readyRefRef.current?.current))}
+          </Metric>
+          <Metric label="Scroll checks" testId="ready-scroll-checks">
+            {scrollChecks}
+          </Metric>
+        </>
+      }
+    >
+      <ReactDataGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={virtualRows}
+        columnOrder={columnOrder}
+        enableFiltering
+        onReady={reportReady}
+        handle={reportHandle}
+        virtualized
+      />
+    </ScenarioShell>
+  );
+}
+
+function FilterScenario() {
+  const callsRef = React.useRef(0);
+  const [calls, setCalls] = React.useState(0);
+
+  React.useLayoutEffect(() => {
+    (
+      window as typeof window & { __tdgFilterCallbackCalls?: number }
+    ).__tdgFilterCallbackCalls = 0;
+  }, []);
+
+  function reportFilterChange() {
+    if (callsRef.current >= CALLBACK_CAP) return;
+    callsRef.current += 1;
+    (
+      window as typeof window & { __tdgFilterCallbackCalls?: number }
+    ).__tdgFilterCallbackCalls = callsRef.current;
+    setCalls(callsRef.current);
+  }
+
+  return (
+    <ScenarioShell
+      metrics={
+        <Metric label="Filter callbacks" testId="filter-calls">
+          {calls}
+        </Metric>
+      }
+    >
+      <ReactDataGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={smallRows}
+        columnOrder={columnOrder}
+        enableFiltering
+        defaultFilterValue={null}
+        onFilterValueChange={reportFilterChange}
+        virtualized={false}
+      />
+    </ScenarioShell>
+  );
+}
+
+function VolatileCountScenario() {
+  const armedRef = React.useRef(false);
+  const callsRef = React.useRef(0);
+  const timerRef = React.useRef<number | null>(null);
+  const [rowLimit, setRowLimit] = React.useState(smallRows.length);
+  const [liveCalls, setLiveCalls] = React.useState(0);
+  const [settledCalls, setSettledCalls] = React.useState<number | null>(null);
+
+  React.useEffect(
+    () => () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  const volatileColumns: TypeColumns = [
+    { name: "id", header: "ID", defaultWidth: 80 },
+    { name: "name", header: "Name", defaultWidth: 200 },
+  ];
+  const volatileRows = smallRows.slice(0, rowLimit);
+  const volatileOrder = ["id", "name"];
+
+  function reportCount() {
+    if (!armedRef.current || callsRef.current >= CALLBACK_CAP) return;
+    callsRef.current += 1;
+    setLiveCalls(callsRef.current);
+
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    if (callsRef.current >= CALLBACK_CAP) {
+      armedRef.current = false;
+      setSettledCalls(callsRef.current);
+      return;
+    }
+
+    setSettledCalls(null);
+    timerRef.current = window.setTimeout(() => {
+      armedRef.current = false;
+      setSettledCalls(callsRef.current);
+    }, 250);
+  }
+
+  return (
+    <ScenarioShell
+      controls={
+        <>
+          <Button
+            type="button"
+            data-testid="arm-volatile-count"
+            onClick={() => {
+              if (timerRef.current !== null) {
+                window.clearTimeout(timerRef.current);
+                timerRef.current = null;
+              }
+              callsRef.current = 0;
+              armedRef.current = true;
+              setLiveCalls(0);
+              setSettledCalls(null);
+            }}
+          >
+            Arm count observer
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="trigger-volatile-count"
+            onClick={() =>
+              setRowLimit((current) =>
+                current === smallRows.length ? 0 : smallRows.length
+              )
+            }
+          >
+            Change rows
+          </Button>
+        </>
+      }
+      metrics={
+        <>
+          <Metric label="Live count calls" testId="volatile-live-count">
+            {liveCalls}
+          </Metric>
+          <Metric label="Settled count calls" testId="volatile-settled-count">
+            {settledCalls ?? "pending"}
+          </Metric>
+        </>
+      }
+    >
+      <ReactDataGrid
+        idProperty="id"
+        columns={volatileColumns}
+        dataSource={volatileRows}
+        columnOrder={volatileOrder}
+        enableFiltering
+        filteredRowsCount={reportCount}
+        virtualized={false}
+      />
+    </ScenarioShell>
+  );
+}
+
+type RemoteMode = "initial" | "invalid-count" | "pending" | "race" | "reject";
+
+function RemoteScenario() {
+  const modeRef = React.useRef<RemoteMode>("initial");
+  const raceCallRef = React.useRef(0);
+  const pendingResolveRef = React.useRef<
+    ((value: { data: unknown[]; count: number }) => void) | null
+  >(null);
+  const apiRef = React.useRef<
+    React.MutableRefObject<TypeComputedProps | null> | undefined
+  >(undefined);
+  const observerCallsRef = React.useRef(0);
+  const [mounted, setMounted] = React.useState(true);
+  const [observerCalls, setObserverCalls] = React.useState(0);
+
+  const dataSource = React.useCallback<TypeDataSource>(() => {
+    const mode = modeRef.current;
+
+    if (mode === "reject") {
+      modeRef.current = "initial";
+      return Promise.reject(new Error("bounded remote rejection"));
+    }
+
+    if (mode === "invalid-count") {
+      modeRef.current = "initial";
+      return Promise.resolve({
+        data: [{ id: 204, name: "Invalid count response", team: "Remote" }],
+        count: Number.NaN,
+      });
+    }
+
+    if (mode === "pending") {
+      return new Promise((resolve) => {
+        pendingResolveRef.current = resolve;
+      });
+    }
+
+    if (mode === "race") {
+      raceCallRef.current += 1;
+      const latest = raceCallRef.current > 1;
+      return new Promise((resolve) => {
+        window.setTimeout(
+          () =>
+            resolve({
+              data: [
+                {
+                  id: latest ? 202 : 201,
+                  name: latest ? "Latest response" : "Stale response",
+                  team: "Remote",
+                },
+              ],
+              count: 1,
+            }),
+          latest ? 20 : 180
+        );
+      });
+    }
+
+    return Promise.resolve({
+      data: [{ id: 200, name: "Initial response", team: "Remote" }],
+      count: 1,
+    });
+  }, []);
+
+  const captureApi = React.useCallback(
+    (ref: React.MutableRefObject<TypeComputedProps | null>) => {
+      apiRef.current = ref;
+      (
+        window as typeof window & {
+          __tdgRemoteApiRef?: React.MutableRefObject<TypeComputedProps | null>;
+        }
+      ).__tdgRemoteApiRef = ref;
+    },
+    []
+  );
+
+  return (
+    <ScenarioShell
+      controls={
+        <>
+          <Button
+            type="button"
+            data-testid="remote-race"
+            onClick={() => {
+              modeRef.current = "race";
+              raceCallRef.current = 0;
+              apiRef.current?.current?.reload();
+              apiRef.current?.current?.reload();
+            }}
+          >
+            Race requests
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="remote-reject"
+            onClick={() => {
+              modeRef.current = "reject";
+              apiRef.current?.current?.reload();
+            }}
+          >
+            Reject request
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="remote-invalid-count"
+            onClick={() => {
+              modeRef.current = "invalid-count";
+              apiRef.current?.current?.reload();
+            }}
+          >
+            Invalid count
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="remote-pending-unmount"
+            onClick={() => {
+              modeRef.current = "pending";
+              apiRef.current?.current?.reload();
+              setMounted(false);
+            }}
+          >
+            Pending then unmount
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="remote-resolve"
+            onClick={() => {
+              modeRef.current = "initial";
+              pendingResolveRef.current?.({
+                data: [{ id: 203, name: "Late response", team: "Remote" }],
+                count: 1,
+              });
+              pendingResolveRef.current = null;
+            }}
+          >
+            Resolve pending
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="remote-toggle"
+            onClick={() => setMounted((current) => !current)}
+          >
+            Toggle remote grid
+          </Button>
+        </>
+      }
+      metrics={
+        <>
+          <Metric label="Observer calls" testId="remote-observer-calls">
+            {observerCalls}
+          </Metric>
+          <Metric label="Mounted" testId="remote-mounted">
+            {String(mounted)}
+          </Metric>
+        </>
+      }
+    >
+      {mounted ? (
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={dataSource}
+          columnOrder={columnOrder}
+          enableFiltering
+          filteredRowsCount={() => {
+            if (observerCallsRef.current >= CALLBACK_CAP) return;
+            observerCallsRef.current += 1;
+            setObserverCalls(observerCallsRef.current);
+          }}
+          onReady={captureApi}
+          virtualized={false}
+        />
+      ) : null}
+    </ScenarioShell>
+  );
+}
+
+function LifecycleScenario() {
+  const [mounted, setMounted] = React.useState(true);
+  const captureApi = React.useCallback(
+    (ref: React.MutableRefObject<TypeComputedProps | null>) => {
+      (
+        window as typeof window & {
+          __tdgLifecycleApiRef?: React.MutableRefObject<TypeComputedProps | null>;
+        }
+      ).__tdgLifecycleApiRef = ref;
+    },
+    []
+  );
+
+  return (
+    <ScenarioShell
+      controls={
+        <Button
+          type="button"
+          data-testid="lifecycle-toggle"
+          onClick={() => setMounted((current) => !current)}
+        >
+          Toggle grid
+        </Button>
+      }
+      metrics={
+        <Metric label="Mounted" testId="lifecycle-mounted">
+          {String(mounted)}
+        </Metric>
+      }
+    >
+      {mounted ? (
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={virtualRows}
+          columnOrder={columnOrder}
+          enableFiltering
+          allowMobileTransform
+          showColumnMenuTool
+          onReady={captureApi}
+          virtualized
+        />
+      ) : null}
+    </ScenarioShell>
+  );
+}
+
+export default function MemorySafetyCompatPage() {
+  const scenario = new URLSearchParams(window.location.search).get("scenario");
+
+  if (scenario === "filter") return <FilterScenario />;
+  if (scenario === "volatile-count") return <VolatileCountScenario />;
+  if (scenario === "remote") return <RemoteScenario />;
+  if (scenario === "lifecycle") return <LifecycleScenario />;
+  return <ReadyScenario />;
+}

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -501,7 +501,7 @@ const reactDataGridPropSections: ReferenceSection[] = [
         type: "(count: number) => void",
         defaultValue: "-",
         description:
-          "Reports the post-filter row count so host UIs can display totals.",
+          "Reports changes to the post-filter row count so host UIs can display totals.",
       },
     ],
   },

--- a/examples/src/router.tsx
+++ b/examples/src/router.tsx
@@ -13,6 +13,7 @@ import ComputedPropsCompatPage from "./ComputedPropsCompatPage";
 import DefaultPropsCompatPage from "./DefaultPropsCompatPage";
 import ExampleDetailPage from "./ExampleDetailPage";
 import ExamplesOverviewPage from "./ExamplesOverviewPage";
+import FilteredRowsCountCompatPage from "./FilteredRowsCountCompatPage";
 import MobileTransformExample from "./MobileTransformExample";
 import SelectionGridExample from "./SelectionGridExample";
 import UsersGridExample from "./UsersGridExample";
@@ -276,11 +277,18 @@ const compatDefaultPropsRoute = createRoute({
   component: DefaultPropsCompatPage,
 });
 
+const compatFilteredRowsCountRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/filtered-rows-count",
+  component: FilteredRowsCountCompatPage,
+});
+
 const routeTree = rootRoute.addChildren([
   homeRoute,
   docsRoute.addChildren([docsIndexRoute, docsPageRoute]),
   compatComputedPropsRoute,
   compatDefaultPropsRoute,
+  compatFilteredRowsCountRoute,
   examplesOverviewRoute,
   exampleActionsRoute,
   exampleBasicRoute,

--- a/examples/src/router.tsx
+++ b/examples/src/router.tsx
@@ -14,6 +14,7 @@ import DefaultPropsCompatPage from "./DefaultPropsCompatPage";
 import ExampleDetailPage from "./ExampleDetailPage";
 import ExamplesOverviewPage from "./ExamplesOverviewPage";
 import FilteredRowsCountCompatPage from "./FilteredRowsCountCompatPage";
+import MemorySafetyCompatPage from "./MemorySafetyCompatPage";
 import MobileTransformExample from "./MobileTransformExample";
 import SelectionGridExample from "./SelectionGridExample";
 import UsersGridExample from "./UsersGridExample";
@@ -283,12 +284,19 @@ const compatFilteredRowsCountRoute = createRoute({
   component: FilteredRowsCountCompatPage,
 });
 
+const compatMemorySafetyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/memory-safety",
+  component: MemorySafetyCompatPage,
+});
+
 const routeTree = rootRoute.addChildren([
   homeRoute,
   docsRoute.addChildren([docsIndexRoute, docsPageRoute]),
   compatComputedPropsRoute,
   compatDefaultPropsRoute,
   compatFilteredRowsCountRoute,
+  compatMemorySafetyRoute,
   examplesOverviewRoute,
   exampleActionsRoute,
   exampleBasicRoute,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovi/the-datagrid",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A modern, feature-rich React data grid component built with shadcn/ui and TanStack Table",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -297,6 +297,18 @@ function ReactDataGrid(props: TypeDataGridProps) {
     style,
   } = props;
 
+  const filteredRowsCountRef = React.useRef(filteredRowsCount);
+  React.useLayoutEffect(() => {
+    filteredRowsCountRef.current = filteredRowsCount;
+
+    return () => {
+      filteredRowsCountRef.current = undefined;
+    };
+  }, [filteredRowsCount]);
+  const notifyFilteredRowsCount = React.useCallback((count: number) => {
+    filteredRowsCountRef.current?.(count);
+  }, []);
+
   const themeName = normalizeThemeName(theme);
   const isMobileViewport = useMediaQuery("(max-width: 1024px)");
   const mobileTransformActive = allowMobileTransform && isMobileViewport;
@@ -614,7 +626,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
       setRows(sliced);
       setCount(totalCount);
-      filteredRowsCount?.(totalCount);
+      notifyFilteredRowsCount(totalCount);
       return;
     }
 
@@ -657,7 +669,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
         setRows(nextRows);
         setCount(totalCount);
-        filteredRowsCount?.(totalCount);
+        notifyFilteredRowsCount(totalCount);
       } else if (Array.isArray(result)) {
         const totalCount = result.length;
         const nextRows = sliceLocally
@@ -666,11 +678,11 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
         setRows(nextRows);
         setCount(totalCount);
-        filteredRowsCount?.(totalCount);
+        notifyFilteredRowsCount(totalCount);
       } else {
         setRows([]);
         setCount(0);
-        filteredRowsCount?.(0);
+        notifyFilteredRowsCount(0);
       }
     } finally {
       setInternalLoading(false);
@@ -680,7 +692,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     effectiveEnableFiltering,
     computedFilterForFetch,
     computedSortForFetch,
-    filteredRowsCount,
+    notifyFilteredRowsCount,
     idProperty,
     limit,
     orderedColumns,
@@ -2709,7 +2721,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                 sortInfo={sortInfo}
                 defaultSortDirection={defaultSortDir}
                 onSortInfoChange={setSortInfoAndResetPage}
-                onFilteredRowsCountChange={filteredRowsCount}
+                onFilteredRowsCountChange={notifyFilteredRowsCount}
                 onRowClick={(id, data, event) =>
                   handleRowClick(id, data, event)
                 }

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -298,6 +298,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
   } = props;
 
   const filteredRowsCountRef = React.useRef(filteredRowsCount);
+  const lastObservedFilteredRowsCountRef = React.useRef<number | undefined>(
+    undefined
+  );
   React.useLayoutEffect(() => {
     filteredRowsCountRef.current = filteredRowsCount;
 
@@ -306,7 +309,14 @@ function ReactDataGrid(props: TypeDataGridProps) {
     };
   }, [filteredRowsCount]);
   const notifyFilteredRowsCount = React.useCallback((count: number) => {
-    filteredRowsCountRef.current?.(count);
+    const previousCount = lastObservedFilteredRowsCountRef.current;
+    lastObservedFilteredRowsCountRef.current = count;
+    const callback = filteredRowsCountRef.current;
+    if (!callback || Object.is(previousCount, count)) {
+      return;
+    }
+
+    callback(count);
   }, []);
 
   const themeName = normalizeThemeName(theme);
@@ -587,6 +597,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const [loadingOverride, setLoadingOverride] = React.useState<boolean | null>(
     null
   );
+  const loadMountedRef = React.useRef(false);
+  const loadRequestIdRef = React.useRef(0);
   const loading = props.loading ?? loadingOverride ?? internalLoading;
 
   const computedFilterForFetch = filterValue;
@@ -605,34 +617,43 @@ function ReactDataGrid(props: TypeDataGridProps) {
   }, [checkboxColId, checkboxEnabled, effectiveColumnOrder]);
 
   const loadData = React.useCallback(async () => {
-    if (Array.isArray(dataSource)) {
-      let data = dataSource;
+    if (!loadMountedRef.current) return;
 
-      if (effectiveEnableFiltering && computedFilterForFetch) {
-        data = applyLocalFilter(data, computedFilterForFetch, {
-          filterTypes,
-          columns: orderedColumns,
-        });
-      }
-      if (computedSortForFetch) {
-        data = applyLocalSort(data, computedSortForFetch, orderedColumns);
-      }
+    const requestId = ++loadRequestIdRef.current;
+    const remoteDataSource = !Array.isArray(dataSource);
 
-      const totalCount = data.length;
-
-      const doPage = paginationMode !== false && paginationMode !== "remote";
-
-      const sliced = doPage ? data.slice(skip, skip + limit) : data;
-
-      setRows(sliced);
-      setCount(totalCount);
-      notifyFilteredRowsCount(totalCount);
-      return;
+    if (remoteDataSource) {
+      setInternalLoading(true);
+    } else {
+      setInternalLoading(false);
     }
 
-    setInternalLoading(true);
-
     try {
+      if (Array.isArray(dataSource)) {
+        let data = dataSource;
+
+        if (effectiveEnableFiltering && computedFilterForFetch) {
+          data = applyLocalFilter(data, computedFilterForFetch, {
+            filterTypes,
+            columns: orderedColumns,
+          });
+        }
+        if (computedSortForFetch) {
+          data = applyLocalSort(data, computedSortForFetch, orderedColumns);
+        }
+
+        const totalCount = data.length;
+
+        const doPage = paginationMode !== false && paginationMode !== "remote";
+
+        const sliced = doPage ? data.slice(skip, skip + limit) : data;
+
+        setRows(sliced);
+        setCount(totalCount);
+        notifyFilteredRowsCount(totalCount);
+        return;
+      }
+
       const ds = dataSource;
 
       const dsIsFn = typeof ds === "function";
@@ -651,18 +672,29 @@ function ReactDataGrid(props: TypeDataGridProps) {
         theme: themeName,
       };
 
-      let result: any = ds;
+      let result: any;
 
-      if (dsIsFn) {
-        result = ds(dsArg);
+      try {
+        result = dsIsFn ? ds(dsArg) : ds;
+
+        if (result && typeof result.then === "function") {
+          result = await result;
+        }
+      } catch {
+        // Remote data-source failures have no public error callback. Preserve
+        // the last committed rows and contain the rejected request here.
+        return;
       }
 
-      if (result && typeof result.then === "function") {
-        result = await result;
+      if (!loadMountedRef.current || requestId !== loadRequestIdRef.current) {
+        return;
       }
 
       if (result && typeof result === "object" && Array.isArray(result.data)) {
-        const totalCount = Number(result.count ?? result.data.length);
+        const reportedCount = Number(result.count ?? result.data.length);
+        const totalCount = Number.isFinite(reportedCount)
+          ? reportedCount
+          : result.data.length;
         const nextRows = sliceLocally
           ? result.data.slice(skip, skip + limit)
           : result.data;
@@ -685,7 +717,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
         notifyFilteredRowsCount(0);
       }
     } finally {
-      setInternalLoading(false);
+      if (
+        remoteDataSource &&
+        loadMountedRef.current &&
+        requestId === loadRequestIdRef.current
+      ) {
+        setInternalLoading(false);
+      }
     }
   }, [
     dataSource,
@@ -704,19 +742,28 @@ function ReactDataGrid(props: TypeDataGridProps) {
     filterTypes,
   ]);
 
+  React.useLayoutEffect(() => {
+    loadMountedRef.current = true;
+
+    return () => {
+      loadMountedRef.current = false;
+      loadRequestIdRef.current += 1;
+    };
+  }, []);
+
   React.useEffect(() => {
     void loadData();
   }, [loadData]);
 
   React.useEffect(() => {
-    if (filterControlled) return;
+    if (filterControlled || Object.is(draftFilterValue, filterValue)) return;
 
     const handle = window.setTimeout(() => {
       setFilterValue(draftFilterValue);
     }, 300);
 
     return () => window.clearTimeout(handle);
-  }, [draftFilterValue, filterControlled, setFilterValue]);
+  }, [draftFilterValue, filterControlled, filterValue, setFilterValue]);
 
   const autosizeSample = React.useMemo(() => {
     if (Array.isArray(dataSource)) {
@@ -1444,6 +1491,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
           });
         }
       };
+      const handleWindowBlur = () => {
+        stopColumnResize();
+      };
 
       resizeCleanupRef.current = () => {
         headerCell.draggable = previousDraggable;
@@ -1451,10 +1501,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
         document.body.style.userSelect = previousUserSelect;
         window.removeEventListener("mousemove", handleMouseMove);
         window.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("blur", handleWindowBlur);
       };
 
       window.addEventListener("mousemove", handleMouseMove);
       window.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener("blur", handleWindowBlur);
       setResizingColumnId(columnId);
       setResizeProxyLeft(columnLeft + startWidth);
     },
@@ -1467,11 +1519,35 @@ function ReactDataGrid(props: TypeDataGridProps) {
     ]
   );
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     return () => {
       resizeCleanupRef.current?.();
     };
   }, []);
+
+  React.useEffect(() => {
+    if (!resizingColumnId) return;
+
+    const resizingColumnExists = orderedColumns.some(
+      (column) => getColumnId(column) === resizingColumnId
+    );
+
+    if (
+      mobileTransformActive ||
+      !resizable ||
+      !showHeader ||
+      !resizingColumnExists
+    ) {
+      stopColumnResize();
+    }
+  }, [
+    mobileTransformActive,
+    orderedColumns,
+    resizable,
+    resizingColumnId,
+    showHeader,
+    stopColumnResize,
+  ]);
 
   /** ---------------- header drag/drop reorder ---------------- */
 
@@ -1526,6 +1602,53 @@ function ReactDataGrid(props: TypeDataGridProps) {
   /** ---------------- imperative API / compat surface ---------------- */
 
   const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [stableApiTarget] = React.useState<TypeComputedProps>(
+    () => ({}) as TypeComputedProps
+  );
+  const [stableApi] = React.useState<TypeComputedProps>(
+    () =>
+      new Proxy(stableApiTarget, {
+        get(target, property, receiver) {
+          if (Reflect.has(target, property)) {
+            return Reflect.get(target, property, receiver);
+          }
+
+          if (
+            typeof property === "string" &&
+            COMPAT_METHOD_NAME_RE.test(property)
+          ) {
+            return () => undefined;
+          }
+
+          return undefined;
+        },
+      })
+  );
+  const onReadyRef = React.useRef(props.onReady);
+  const handleRef = React.useRef(props.handle);
+  const onReadyNotifiedRef = React.useRef(false);
+  const handleNotifiedRef = React.useRef(false);
+
+  React.useLayoutEffect(() => {
+    onReadyRef.current = props.onReady;
+    handleRef.current = props.handle;
+
+    return () => {
+      onReadyRef.current = undefined;
+      handleRef.current = undefined;
+    };
+  }, [props.handle, props.onReady]);
+
+  React.useLayoutEffect(() => {
+    return () => {
+      apiRef.current = null;
+
+      for (const property of Reflect.ownKeys(stableApiTarget)) {
+        Reflect.deleteProperty(stableApiTarget, property);
+      }
+    };
+  }, [stableApiTarget]);
+
   const originalData = React.useMemo(
     () => (Array.isArray(dataSource) ? dataSource : rows),
     [dataSource, rows]
@@ -2569,28 +2692,25 @@ function ReactDataGrid(props: TypeDataGridProps) {
       getVirtualList: () => virtualListCompat,
     };
 
-    const proxy = new Proxy(baseApi, {
-      get(target, property, receiver) {
-        if (Reflect.has(target, property)) {
-          return Reflect.get(target, property, receiver);
-        }
+    baseApi.publicAPI = stableApi;
 
-        if (
-          typeof property === "string" &&
-          COMPAT_METHOD_NAME_RE.test(property)
-        ) {
-          return () => undefined;
-        }
+    for (const property of Reflect.ownKeys(stableApiTarget)) {
+      Reflect.deleteProperty(stableApiTarget, property);
+    }
+    Object.assign(stableApiTarget, baseApi);
+    apiRef.current = stableApi;
 
-        return undefined;
-      },
-    }) as TypeComputedProps;
+    const handle = handleRef.current;
+    if (!handleNotifiedRef.current && handle) {
+      handleNotifiedRef.current = true;
+      handle(apiRef);
+    }
 
-    baseApi.publicAPI = proxy;
-    apiRef.current = proxy;
-
-    props.handle?.(apiRef);
-    props.onReady?.(apiRef);
+    const onReady = onReadyRef.current;
+    if (!onReadyNotifiedRef.current && onReady) {
+      onReadyNotifiedRef.current = true;
+      onReady(apiRef);
+    }
   }, [
     allComputedColumns,
     canNext,
@@ -2651,6 +2771,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
     showCellBorders,
     skip,
     sortInfo,
+    stableApi,
+    stableApiTarget,
     toggleColumnSortCompat,
     scrollToCellCompat,
     scrollToColumnCompat,

--- a/src/hooks/useControllableState.ts
+++ b/src/hooks/useControllableState.ts
@@ -1,23 +1,32 @@
-import * as React from "react"
+import * as React from "react";
 
 export function useControllableState<T>(args: {
-  value: T | undefined
-  defaultValue: T
-  onChange?: (next: T) => void
+  value: T | undefined;
+  defaultValue: T;
+  onChange?: (next: T) => void;
 }): [T, (next: T) => void, boolean] {
-  const { value, defaultValue, onChange } = args
-  const isControlled = value !== undefined
-  const [internal, setInternal] = React.useState<T>(defaultValue)
+  const { value, defaultValue, onChange } = args;
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState<T>(defaultValue);
+  const onChangeRef = React.useRef(onChange);
 
-  const state = (isControlled ? (value as T) : internal) as T
+  React.useLayoutEffect(() => {
+    onChangeRef.current = onChange;
+
+    return () => {
+      onChangeRef.current = undefined;
+    };
+  }, [onChange]);
+
+  const state = (isControlled ? (value as T) : internal) as T;
 
   const setState = React.useCallback(
     (next: T) => {
-      if (!isControlled) setInternal(next)
-      onChange?.(next)
+      if (!isControlled) setInternal(next);
+      onChangeRef.current?.(next);
     },
-    [isControlled, onChange]
-  )
+    [isControlled]
+  );
 
-  return [state, setState, isControlled]
+  return [state, setState, isControlled];
 }

--- a/tests/playwright/filtered-rows-count.spec.ts
+++ b/tests/playwright/filtered-rows-count.spec.ts
@@ -19,16 +19,59 @@ test.describe("filteredRowsCount callback identity", () => {
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
-    await page.goto("/compat/filtered-rows-count");
+    await page.goto("/compat/filtered-rows-count?data-source=remote");
 
     await expect(page.locator(".tdg-root")).toHaveAttribute(
       "data-layout",
       "table"
     );
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as typeof window & {
+                __tdgFilteredDataSourceCalls?: number;
+              }
+            ).__tdgFilteredDataSourceCalls ?? 0
+        )
+      )
+      .toBeGreaterThan(0);
+    const callsBeforeChange = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __tdgFilteredDataSourceCalls?: number;
+          }
+        ).__tdgFilteredDataSourceCalls ?? 0
+    );
     await page.getByTestId("arm-filtered-callback").click();
     await page.getByTestId("toggle-filter-feedback").click();
 
-    await expectSingleSettledObserverCall(page, 3);
+    await expectSingleSettledObserverCall(page, 2);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as typeof window & {
+                __tdgFilteredDataSourceCalls?: number;
+              }
+            ).__tdgFilteredDataSourceCalls ?? 0
+        )
+      )
+      .toBe(callsBeforeChange + 1);
+    await page.waitForTimeout(350);
+    expect(
+      await page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __tdgFilteredDataSourceCalls?: number;
+            }
+          ).__tdgFilteredDataSourceCalls ?? 0
+      )
+    ).toBe(callsBeforeChange + 1);
   });
 
   test("does not refilter when a mobile observer is recreated", async ({

--- a/tests/playwright/filtered-rows-count.spec.ts
+++ b/tests/playwright/filtered-rows-count.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function expectSingleSettledObserverCall(
+  page: Page,
+  expectedRows: number
+) {
+  const settledCount = page.getByTestId("filtered-callback-settled-count");
+  await expect(settledCount).toHaveText(/^\d+$/);
+
+  const calls = Number((await settledCount.textContent())?.trim());
+  expect(calls).toBe(1);
+  await expect(page.getByTestId("filtered-reported-row-count")).toHaveText(
+    String(expectedRows)
+  );
+}
+
+test.describe("filteredRowsCount callback identity", () => {
+  test("does not reload when a desktop observer is recreated", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/compat/filtered-rows-count");
+
+    await expect(page.locator(".tdg-root")).toHaveAttribute(
+      "data-layout",
+      "table"
+    );
+    await page.getByTestId("arm-filtered-callback").click();
+    await page.getByTestId("toggle-filter-feedback").click();
+
+    await expectSingleSettledObserverCall(page, 3);
+  });
+
+  test("does not refilter when a mobile observer is recreated", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/compat/filtered-rows-count");
+
+    const grid = page.locator(".tdg-root");
+    await expect(grid).toHaveAttribute("data-layout", "mobile-list");
+    await expect(grid.getByText("3 results", { exact: true })).toBeVisible();
+
+    await page.getByTestId("arm-filtered-callback").click();
+    await grid
+      .getByRole("searchbox", { name: "Search all fields" })
+      .fill("Grace");
+    await expect(grid.getByText("1 result", { exact: true })).toBeVisible();
+
+    await expectSingleSettledObserverCall(page, 1);
+  });
+});

--- a/tests/playwright/memory-safety.spec.ts
+++ b/tests/playwright/memory-safety.spec.ts
@@ -1,0 +1,600 @@
+import { expect, test, type Page } from "@playwright/test";
+
+type LifecycleSnapshot = {
+  windowListeners: Record<string, number>;
+  windowListenerAdds: Record<string, number>;
+  windowListenerRemoves: Record<string, number>;
+  mediaQueryListeners: number;
+  mutationObservers: number;
+  resizeObservers: number;
+};
+
+async function installLifecycleAudit(page: Page) {
+  await page.addInitScript(() => {
+    const audit = {
+      windowListeners: {
+        blur: new Set<EventListenerOrEventListenerObject>(),
+        mousemove: new Set<EventListenerOrEventListenerObject>(),
+        mouseup: new Set<EventListenerOrEventListenerObject>(),
+      },
+      windowListenerAdds: { blur: 0, mousemove: 0, mouseup: 0 },
+      windowListenerRemoves: { blur: 0, mousemove: 0, mouseup: 0 },
+      mediaQueryListeners: 0,
+      mutationObservers: 0,
+      resizeObservers: 0,
+    };
+
+    const originalWindowAdd = window.addEventListener.bind(window);
+    const originalWindowRemove = window.removeEventListener.bind(window);
+
+    window.addEventListener = ((type, listener, options) => {
+      const tracked =
+        audit.windowListeners[type as keyof typeof audit.windowListeners];
+      tracked?.add(listener);
+      if (tracked) {
+        audit.windowListenerAdds[
+          type as keyof typeof audit.windowListenerAdds
+        ] += 1;
+      }
+      originalWindowAdd(type, listener, options);
+    }) as typeof window.addEventListener;
+
+    window.removeEventListener = ((type, listener, options) => {
+      const tracked =
+        audit.windowListeners[type as keyof typeof audit.windowListeners];
+      tracked?.delete(listener);
+      if (tracked) {
+        audit.windowListenerRemoves[
+          type as keyof typeof audit.windowListenerRemoves
+        ] += 1;
+      }
+      originalWindowRemove(type, listener, options);
+    }) as typeof window.removeEventListener;
+
+    const originalMatchMedia = window.matchMedia.bind(window);
+    window.matchMedia = ((query: string) => {
+      const mediaQuery = originalMatchMedia(query);
+      const originalAdd = mediaQuery.addEventListener.bind(mediaQuery);
+      const originalRemove = mediaQuery.removeEventListener.bind(mediaQuery);
+      const activeListeners = new Set<EventListenerOrEventListenerObject>();
+
+      mediaQuery.addEventListener = ((type, listener, options) => {
+        if (type === "change" && !activeListeners.has(listener)) {
+          activeListeners.add(listener);
+          audit.mediaQueryListeners += 1;
+        }
+        originalAdd(type, listener, options);
+      }) as typeof mediaQuery.addEventListener;
+
+      mediaQuery.removeEventListener = ((type, listener, options) => {
+        if (type === "change" && activeListeners.delete(listener)) {
+          audit.mediaQueryListeners -= 1;
+        }
+        originalRemove(type, listener, options);
+      }) as typeof mediaQuery.removeEventListener;
+
+      return mediaQuery;
+    }) as typeof window.matchMedia;
+
+    const NativeMutationObserver = window.MutationObserver;
+    window.MutationObserver = class extends NativeMutationObserver {
+      private auditActive = false;
+
+      observe(target: Node, options?: MutationObserverInit) {
+        if (!this.auditActive) {
+          this.auditActive = true;
+          audit.mutationObservers += 1;
+        }
+        super.observe(target, options);
+      }
+
+      disconnect() {
+        if (this.auditActive) {
+          this.auditActive = false;
+          audit.mutationObservers -= 1;
+        }
+        super.disconnect();
+      }
+    };
+
+    if (window.ResizeObserver) {
+      const NativeResizeObserver = window.ResizeObserver;
+      window.ResizeObserver = class extends NativeResizeObserver {
+        private auditTargets = new Set<Element>();
+
+        observe(target: Element, options?: ResizeObserverOptions) {
+          if (this.auditTargets.size === 0) {
+            audit.resizeObservers += 1;
+          }
+          this.auditTargets.add(target);
+          super.observe(target, options);
+        }
+
+        unobserve(target: Element) {
+          const removed = this.auditTargets.delete(target);
+          if (removed && this.auditTargets.size === 0) {
+            audit.resizeObservers -= 1;
+          }
+          super.unobserve(target);
+        }
+
+        disconnect() {
+          if (this.auditTargets.size > 0) audit.resizeObservers -= 1;
+          this.auditTargets.clear();
+          super.disconnect();
+        }
+      };
+    }
+
+    Object.defineProperty(window, "__tdgLifecycleAudit", {
+      configurable: false,
+      value: audit,
+    });
+  });
+}
+
+async function readLifecycleAudit(page: Page): Promise<LifecycleSnapshot> {
+  return page.evaluate(() => {
+    const audit = (
+      window as typeof window & {
+        __tdgLifecycleAudit: {
+          windowListeners: Record<
+            string,
+            Set<EventListenerOrEventListenerObject>
+          >;
+          windowListenerAdds: Record<string, number>;
+          windowListenerRemoves: Record<string, number>;
+          mediaQueryListeners: number;
+          mutationObservers: number;
+          resizeObservers: number;
+        };
+      }
+    ).__tdgLifecycleAudit;
+
+    return {
+      windowListeners: Object.fromEntries(
+        Object.entries(audit.windowListeners).map(([type, listeners]) => [
+          type,
+          listeners.size,
+        ])
+      ),
+      windowListenerAdds: { ...audit.windowListenerAdds },
+      windowListenerRemoves: { ...audit.windowListenerRemoves },
+      mediaQueryListeners: audit.mediaQueryListeners,
+      mutationObservers: audit.mutationObservers,
+      resizeObservers: audit.resizeObservers,
+    };
+  });
+}
+
+function monitorBrowserHealth(page: Page) {
+  const errors: string[] = [];
+  let crashed = false;
+
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("crash", () => {
+    crashed = true;
+  });
+
+  return () => {
+    expect(crashed, "the Chromium renderer crashed").toBe(false);
+    expect(errors, "uncaught page errors or promise rejections").toEqual([]);
+  };
+}
+
+test.describe("browser memory safety", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test("bounds ready, filter, and volatile-input callback feedback", async ({
+    page,
+  }) => {
+    const assertHealthy = monitorBrowserHealth(page);
+
+    await page.goto("/compat/memory-safety?scenario=ready");
+    await expect(page.locator(".tdg-root")).toBeVisible();
+    await page.waitForTimeout(400);
+    expect(Number(await page.getByTestId("ready-calls").textContent())).toBe(1);
+    expect(Number(await page.getByTestId("handle-calls").textContent())).toBe(
+      1
+    );
+    await expect(page.getByTestId("api-stable")).toHaveText("true");
+    await expect(page.getByTestId("api-live")).toHaveText("true");
+
+    await page.getByTestId("ready-scroll").click();
+    await expect(page.getByTestId("ready-scroll-checks")).toHaveText("1");
+    await expect(
+      page.locator('[data-slot="grid-row"][data-row-index="1500"]')
+    ).toBeVisible();
+    await page.waitForTimeout(300);
+    expect(Number(await page.getByTestId("ready-calls").textContent())).toBe(1);
+    expect(Number(await page.getByTestId("handle-calls").textContent())).toBe(
+      1
+    );
+    await expect(page.getByTestId("api-stable")).toHaveText("true");
+
+    await page.goto("/compat/memory-safety?scenario=filter");
+    await page.waitForTimeout(650);
+    expect(Number(await page.getByTestId("filter-calls").textContent())).toBe(
+      0
+    );
+    await page
+      .locator(".tdg-filter-cell")
+      .nth(1)
+      .getByRole("textbox")
+      .fill("Grace");
+    await page.waitForTimeout(700);
+    expect(Number(await page.getByTestId("filter-calls").textContent())).toBe(
+      1
+    );
+    await page.waitForTimeout(450);
+    expect(Number(await page.getByTestId("filter-calls").textContent())).toBe(
+      1
+    );
+
+    await page.reload();
+    await page
+      .locator(".tdg-filter-cell")
+      .nth(1)
+      .getByRole("textbox")
+      .fill("Ada");
+    await page.getByRole("link", { name: "Docs", exact: true }).click();
+    await expect(page.locator(".tdg-root")).toHaveCount(0);
+    await page.waitForTimeout(450);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as typeof window & { __tdgFilterCallbackCalls?: number })
+            .__tdgFilterCallbackCalls
+      )
+    ).toBe(0);
+
+    await page.goto("/compat/memory-safety?scenario=volatile-count");
+    await page.getByTestId("arm-volatile-count").click();
+    await page.getByTestId("trigger-volatile-count").click();
+    const settled = page.getByTestId("volatile-settled-count");
+    await expect(settled).toHaveText(/^\d+$/);
+    expect(Number(await settled.textContent())).toBe(1);
+    await expect(page.getByTestId("volatile-live-count")).toHaveText("1");
+
+    await page.getByTestId("arm-volatile-count").click();
+    await expect(settled).toHaveText("pending");
+    await page.getByTestId("trigger-volatile-count").click();
+    await expect(settled).toHaveText(/^\d+$/);
+    expect(Number(await settled.textContent())).toBe(1);
+    await expect(page.getByTestId("volatile-live-count")).toHaveText("1");
+    assertHealthy();
+  });
+
+  test("discards stale, rejected, and post-unmount remote completions", async ({
+    page,
+  }) => {
+    const assertHealthy = monitorBrowserHealth(page);
+    await page.goto("/compat/memory-safety?scenario=remote");
+
+    const grid = page.locator(".tdg-root");
+    await expect(
+      grid.getByText("Initial response", { exact: true })
+    ).toBeVisible();
+    const observerCallsBeforeRace = Number(
+      await page.getByTestId("remote-observer-calls").textContent()
+    );
+
+    await page.getByTestId("remote-race").click();
+    await expect(
+      grid.getByText("Latest response", { exact: true })
+    ).toBeVisible();
+    await page.waitForTimeout(250);
+    await expect(
+      grid.getByText("Latest response", { exact: true })
+    ).toBeVisible();
+    await expect(grid.getByText("Stale response", { exact: true })).toHaveCount(
+      0
+    );
+
+    await page.getByTestId("remote-reject").click();
+    await page.waitForTimeout(100);
+    await expect(
+      grid.getByText("Latest response", { exact: true })
+    ).toBeVisible();
+
+    await page.getByTestId("remote-invalid-count").click();
+    await expect(
+      grid.getByText("Invalid count response", { exact: true })
+    ).toBeVisible();
+    await expect(grid).not.toContainText("NaN");
+    expect(
+      Number(await page.getByTestId("remote-observer-calls").textContent())
+    ).toBe(observerCallsBeforeRace);
+
+    const observerCallsBeforeUnmount = Number(
+      await page.getByTestId("remote-observer-calls").textContent()
+    );
+    expect(observerCallsBeforeUnmount).toBe(observerCallsBeforeRace);
+    await page.getByTestId("remote-pending-unmount").click();
+    await expect(page.getByTestId("remote-mounted")).toHaveText("false");
+    await expect(grid).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            !(
+              window as typeof window & {
+                __tdgRemoteApiRef?: { current: unknown };
+              }
+            ).__tdgRemoteApiRef?.current
+        )
+      )
+      .toBe(true);
+
+    await page.getByTestId("remote-resolve").click();
+    await page.waitForTimeout(100);
+    expect(
+      Number(await page.getByTestId("remote-observer-calls").textContent())
+    ).toBe(observerCallsBeforeUnmount);
+    await page.getByTestId("remote-toggle").click();
+    await expect(page.getByTestId("remote-mounted")).toHaveText("true");
+    await expect(
+      page.locator(".tdg-root").getByText("Initial response", { exact: true })
+    ).toBeVisible();
+    assertHealthy();
+  });
+
+  test("plateaus retained DOM, listeners, observers, APIs, and portals", async ({
+    context,
+    page,
+  }) => {
+    await installLifecycleAudit(page);
+    const assertHealthy = monitorBrowserHealth(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/compat/memory-safety?scenario=lifecycle");
+
+    const toggle = page.getByTestId("lifecycle-toggle");
+    const grid = page.locator(".tdg-root");
+    await expect(grid).toBeVisible();
+    await toggle.click();
+    await expect(grid).toHaveCount(0);
+
+    const cdp = await context.newCDPSession(page);
+    const collectMemory = async () => {
+      await cdp.send("HeapProfiler.collectGarbage");
+      const [dom, heap] = await Promise.all([
+        cdp.send("Memory.getDOMCounters"),
+        cdp.send("Runtime.getHeapUsage"),
+      ]);
+      return { dom, heap };
+    };
+    const runBatch = async () => {
+      for (let iteration = 0; iteration < 6; iteration += 1) {
+        await toggle.click();
+        await expect(grid).toBeVisible();
+        const menuButton = grid
+          .getByRole("button", { name: "Column menu" })
+          .first();
+        const menuContent = page.locator('[data-slot="dropdown-menu-content"]');
+        await expect(menuButton).toBeVisible();
+        await expect
+          .poll(async () => {
+            if (await menuContent.isVisible()) return true;
+
+            await menuButton.click();
+            return menuContent.isVisible();
+          })
+          .toBe(true);
+        await toggle.dispatchEvent("click");
+        await expect(grid).toHaveCount(0);
+        await expect(
+          page.locator('[data-slot="dropdown-menu-content"]')
+        ).toHaveCount(0);
+      }
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              !(
+                window as typeof window & {
+                  __tdgLifecycleApiRef?: { current: unknown };
+                }
+              ).__tdgLifecycleApiRef?.current
+          )
+        )
+        .toBe(true);
+      return {
+        audit: await readLifecycleAudit(page),
+        memory: await collectMemory(),
+      };
+    };
+
+    await collectMemory();
+    const afterFirstBatch = await runBatch();
+    const afterSecondBatch = await runBatch();
+
+    expect(
+      afterSecondBatch.memory.dom.nodes - afterFirstBatch.memory.dom.nodes
+    ).toBeLessThanOrEqual(100);
+    expect(
+      afterSecondBatch.memory.dom.jsEventListeners -
+        afterFirstBatch.memory.dom.jsEventListeners
+    ).toBeLessThanOrEqual(5);
+    expect(
+      afterSecondBatch.memory.dom.documents -
+        afterFirstBatch.memory.dom.documents
+    ).toBeLessThanOrEqual(1);
+    expect(
+      afterSecondBatch.memory.heap.usedSize -
+        afterFirstBatch.memory.heap.usedSize
+    ).toBeLessThanOrEqual(4 * 1024 * 1024);
+    expect(
+      afterSecondBatch.audit.mediaQueryListeners -
+        afterFirstBatch.audit.mediaQueryListeners
+    ).toBe(0);
+    expect(
+      afterSecondBatch.audit.mutationObservers -
+        afterFirstBatch.audit.mutationObservers
+    ).toBeLessThanOrEqual(1);
+    expect(
+      afterSecondBatch.audit.resizeObservers -
+        afterFirstBatch.audit.resizeObservers
+    ).toBeLessThanOrEqual(2);
+    for (const type of ["blur", "mousemove", "mouseup"]) {
+      expect(
+        (afterSecondBatch.audit.windowListeners[type] ?? 0) -
+          (afterFirstBatch.audit.windowListeners[type] ?? 0)
+      ).toBeLessThanOrEqual(1);
+    }
+    assertHealthy();
+  });
+
+  test("cleans an interrupted resize on responsive transition and blur", async ({
+    page,
+  }) => {
+    await installLifecycleAudit(page);
+    const assertHealthy = monitorBrowserHealth(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/examples/mobile-transform");
+
+    const grid = page.locator(".tdg-root");
+    const baseline = await readLifecycleAudit(page);
+    const startResize = async () => {
+      const resizer = grid.locator('[data-slot="column-resizer"]').first();
+      const box = await resizer.boundingBox();
+      expect(box).not.toBeNull();
+      await resizer.dispatchEvent("mousedown", {
+        button: 0,
+        clientX: (box?.x ?? 0) + (box?.width ?? 0) / 2,
+        clientY: (box?.y ?? 0) + (box?.height ?? 0) / 2,
+      });
+      await expect(grid).toHaveAttribute("data-column-resizing", "true");
+      await expect
+        .poll(() =>
+          page.evaluate(() => ({
+            cursor: document.body.style.cursor,
+            userSelect: document.body.style.userSelect,
+          }))
+        )
+        .toEqual({ cursor: "col-resize", userSelect: "none" });
+    };
+
+    await startResize();
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(grid).toHaveAttribute("data-layout", "mobile-list");
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+    await expect
+      .poll(async () => (await readLifecycleAudit(page)).windowListeners.blur)
+      .toBe(baseline.windowListeners.blur);
+    const mobileListeners = (await readLifecycleAudit(page)).windowListeners;
+    expect(mobileListeners.mousemove ?? 0).toBeLessThanOrEqual(
+      (baseline.windowListeners.mousemove ?? 0) + 1
+    );
+    expect(mobileListeners.mouseup ?? 0).toBeLessThanOrEqual(
+      (baseline.windowListeners.mouseup ?? 0) + 1
+    );
+    const afterMobileCleanup = await readLifecycleAudit(page);
+    for (const type of ["blur", "mousemove", "mouseup"]) {
+      expect(
+        (afterMobileCleanup.windowListenerRemoves[type] ?? 0) -
+          (baseline.windowListenerRemoves[type] ?? 0)
+      ).toBeGreaterThanOrEqual(1);
+    }
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          cursor: document.body.style.cursor,
+          userSelect: document.body.style.userSelect,
+        }))
+      )
+      .toEqual({ cursor: "", userSelect: "" });
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expect(grid).toHaveAttribute("data-layout", "table");
+    const beforeBlurResize = await readLifecycleAudit(page);
+    await startResize();
+    await page.evaluate(() => window.dispatchEvent(new Event("blur")));
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(async () => (await readLifecycleAudit(page)).windowListeners.blur)
+      .toBe(baseline.windowListeners.blur);
+    const afterBlurCleanup = await readLifecycleAudit(page);
+    for (const type of ["blur", "mousemove", "mouseup"]) {
+      expect(
+        (afterBlurCleanup.windowListenerRemoves[type] ?? 0) -
+          (beforeBlurResize.windowListenerRemoves[type] ?? 0)
+      ).toBeGreaterThanOrEqual(1);
+    }
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          cursor: document.body.style.cursor,
+          userSelect: document.body.style.userSelect,
+        }))
+      )
+      .toEqual({ cursor: "", userSelect: "" });
+    assertHealthy();
+  });
+
+  test("keeps responsive virtualization and menu observers bounded", async ({
+    page,
+  }) => {
+    await installLifecycleAudit(page);
+    const assertHealthy = monitorBrowserHealth(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/examples/mobile-transform");
+
+    const grid = page.locator(".tdg-root");
+    await expect(grid).toHaveAttribute("data-layout", "mobile-list");
+    const baseline = await readLifecycleAudit(page);
+
+    for (let iteration = 0; iteration < 8; iteration += 1) {
+      await grid.getByRole("button", { name: "Display columns" }).click();
+      await expect(
+        grid.locator('[data-slot="dropdown-menu-content"]')
+      ).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(
+        grid.locator('[data-slot="dropdown-menu-content"]')
+      ).toHaveCount(0);
+
+      const search = grid.getByRole("searchbox", {
+        name: "Search all fields",
+      });
+      await search.fill(`no-such-customer-${iteration}`);
+      const resultCount = grid
+        .locator('[data-slot="mobile-grid-list"] output')
+        .first();
+      await expect(resultCount).toHaveText("0 results");
+      await grid.getByRole("button", { name: "Clear search" }).click();
+      await expect(resultCount).not.toHaveText("0 results");
+
+      await page.setViewportSize({ width: 1025, height: 900 });
+      await expect(grid).toHaveAttribute("data-layout", "table");
+      await expect
+        .poll(() => grid.locator('[data-slot="grid-row"]').count())
+        .toBeGreaterThan(0);
+      expect(await grid.locator('[data-slot="grid-row"]').count()).toBeLessThan(
+        100
+      );
+
+      await page.setViewportSize({ width: 1024, height: 900 });
+      await expect(grid).toHaveAttribute("data-layout", "mobile-list");
+      await expect
+        .poll(() => grid.getByRole("listitem").count())
+        .toBeGreaterThan(0);
+      expect(await grid.getByRole("listitem").count()).toBeLessThan(20);
+    }
+
+    await expect(
+      grid.locator('[data-slot="dropdown-menu-content"]')
+    ).toHaveCount(0);
+    const finalAudit = await readLifecycleAudit(page);
+    expect(finalAudit.windowListeners).toEqual(baseline.windowListeners);
+    expect(finalAudit.mediaQueryListeners).toBe(baseline.mediaQueryListeners);
+    expect(finalAudit.mutationObservers).toBe(baseline.mutationObservers);
+    expect(finalAudit.resizeObservers).toBe(baseline.resizeObservers);
+    assertHealthy();
+  });
+});


### PR DESCRIPTION
## Summary

- fix #26 by keeping `filteredRowsCount` out of data-loading dependencies and reporting only actual count changes
- keep `onReady`, `handle`, and controllable-state callbacks current without recreating feedback-producing effects
- reuse one live computed API proxy and clear its target on unmount
- discard stale and post-unmount remote results, contain rejected remote requests, and normalize non-finite remote counts
- cancel idle filter debounce work and clean interrupted resize listeners/body state on blur, responsive transforms, column removal, and unmount
- document the count-change callback semantics
- bump the package version from `0.0.6` to `0.0.7`

## Browser memory-safety coverage

The new bounded E2E stress suite covers:

- render-local callback and volatile columns/data feedback
- `onReady` / `handle` call bounds and stable live API behavior
- uncontrolled filter debounce and timer cleanup on unmount
- 3 → 0 → 3 count transitions and malformed `NaN` counts
- stale remote races, rejected requests, and late completion after unmount
- repeated grid/menu mount-unmount cycles with forced GC and CDP heap/DOM plateau checks
- active window listeners, media-query listeners, MutationObservers, ResizeObservers, and portal cleanup
- interrupted column resizing across mobile transforms and window blur
- repeated 1024/1025 responsive transitions with virtualization, mobile search, and column menus
- uncaught page errors, console errors, and Chromium renderer crashes

The grid cannot forcibly cancel an arbitrary Promise/fetch created by a consumer because the public data-source contract has no abort signal. Its work may remain alive until settlement, but late results no longer retain or mutate live grid state.

## Validation

- `yarn test:types`
- `yarn build`
- targeted ESLint, Prettier, and `git diff --check`
- focused memory/count suite repeated 3×: 21/21 passed
- full `yarn test:e2e`: 57/57 passed
- local in-app browser verification of the stable computed API and virtual scroll

Closes #26
