### PR TITLE
Complete Inovua compatibility and grid stabilization for 0.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ method allowlists.
   `defaultWidth`/`defaultFlex`, `minWidth`/`maxWidth` clamps, proportional flex
   allocation, the upstream 40px implicit column minimum (while preserving an
   explicit `minWidth={0}`), deterministic autosizing from a bounded row sample,
-  mouse drag resizing with `onColumnResize`, and double-click autosizing. Rows
-  support numeric, functional, and natural measured heights with
+  mouse/pen/touch drag resizing with `onColumnResize`, opt-in
+  animation-frame-coalesced `liveColumnResize`, and double-click autosizing.
+  Rows support numeric, functional, and natural measured heights with
   minimum/maximum bounds and width-change remeasurement.
 - **Filtering and sorting:** controlled and uncontrolled state, local operators,
   custom filter registries and editors, filter operator menus, single sorting,
@@ -572,16 +573,17 @@ sentinels (`-1`, `false`, and `0`).
 
 ### Columns
 
-| Prop                   | Type                        | Default | Description                                                                 |
-| ---------------------- | --------------------------- | ------- | --------------------------------------------------------------------------- |
-| `columnOrder`          | `string[]`                  | -       | Ordered array of column ids/names                                           |
-| `onColumnOrderChange`  | `(order: string[]) => void` | -       | Fired when column order changes; drag reordering requires this callback     |
-| `reorderColumns`       | `boolean`                   | `true`  | Disable user drag reordering while continuing to render `columnOrder`       |
-| `resizable`            | `boolean`                   | `true`  | Enable header resize handles                                                |
-| `onColumnResize`       | `(info, context) => void`   | -       | Reports proposed width/flex and reserved viewport width                     |
-| `enableColumnAutosize` | `boolean`                   | `true`  | Estimate widths from a bounded row sample when no numeric width is supplied |
-| `skipHeaderOnAutoSize` | `boolean`                   | `false` | Skip header text when estimating an automatic width                         |
-| `showColumnMenuTool`   | `boolean`                   | `false` | Show the header menu tool                                                   |
+| Prop                   | Type                        | Default | Description                                                                   |
+| ---------------------- | --------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `columnOrder`          | `string[]`                  | -       | Ordered array of column ids/names                                             |
+| `onColumnOrderChange`  | `(order: string[]) => void` | -       | Fired when column order changes; drag reordering requires this callback       |
+| `reorderColumns`       | `boolean`                   | `true`  | Disable user drag reordering while continuing to render `columnOrder`         |
+| `resizable`            | `boolean`                   | `true`  | Enable header resize handles                                                  |
+| `liveColumnResize`     | `boolean`                   | `false` | Resize header and body geometry during drag; callbacks remain completion-only |
+| `onColumnResize`       | `(info, context) => void`   | -       | Reports proposed width/flex and reserved viewport width                       |
+| `enableColumnAutosize` | `boolean`                   | `true`  | Estimate widths from a bounded row sample when no numeric width is supplied   |
+| `skipHeaderOnAutoSize` | `boolean`                   | `false` | Skip header text when estimating an automatic width                           |
+| `showColumnMenuTool`   | `boolean`                   | `false` | Show the header menu tool                                                     |
 
 ### Filtering
 

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -12,6 +12,7 @@ import {
   DialogContent,
   DialogDescription,
   DialogTitle,
+  DialogTrigger,
 } from "../../src/components/ui/dialog";
 import { examplePages } from "./exampleMeta";
 import GlobalSearch from "./GlobalSearch";
@@ -123,16 +124,17 @@ function AppHeader(props: {
             </Link>
           </h1>
 
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="!rounded-none border-0 shadow-none"
-            aria-label="Open navigation menu"
-            onClick={() => setMobileNavOpen(true)}
-          >
-            <Menu className="h-5 w-5" aria-hidden="true" />
-          </Button>
+          <DialogTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="!rounded-none border-0 shadow-none"
+              aria-label="Open navigation menu"
+            >
+              <Menu className="h-5 w-5" aria-hidden="true" />
+            </Button>
+          </DialogTrigger>
         </div>
 
         <DialogContent className="tdg-mobile-nav-content !inset-0 !w-screen !max-w-none !translate-x-0 !translate-y-0 gap-0 !rounded-none border-0 bg-background/98 p-0 shadow-2xl sm:!rounded-none">
@@ -359,6 +361,7 @@ export default function App() {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
+  const isDocsRoute = pathname === "/docs" || pathname.startsWith("/docs/");
   const [gridTheme, setGridTheme] = useState<GridTheme>("default");
   const [siteTheme, setSiteTheme] = useState<SiteTheme>(getInitialSiteTheme);
   const [showCellBorders, setShowCellBorders] =
@@ -372,6 +375,25 @@ export default function App() {
     root.style.colorScheme = siteTheme;
     window.localStorage.setItem(SITE_THEME_STORAGE_KEY, siteTheme);
   }, [siteTheme]);
+
+  useEffect(() => {
+    if (!isDocsRoute) {
+      return;
+    }
+
+    const root = document.documentElement;
+    const body = document.body;
+    const previousRootOverflow = root.style.overflow;
+    const previousBodyOverflow = body.style.overflow;
+
+    root.style.overflow = "hidden";
+    body.style.overflow = "hidden";
+
+    return () => {
+      root.style.overflow = previousRootOverflow;
+      body.style.overflow = previousBodyOverflow;
+    };
+  }, [isDocsRoute]);
 
   const i18n: TypeI18n = useMemo(
     () => ({
@@ -405,8 +427,6 @@ export default function App() {
     }),
     [gridTheme, i18n, resizable, showCellBorders]
   );
-  const isDocsRoute = pathname === "/docs" || pathname.startsWith("/docs/");
-
   return (
     <ExamplesUiContext.Provider value={contextValue}>
       <div

--- a/examples/src/ColumnsGridExample.tsx
+++ b/examples/src/ColumnsGridExample.tsx
@@ -405,6 +405,8 @@ export default function ColumnsGridExample() {
           filteredRowsCount={setFilteredRows}
           onColumnOrderChange={setColumnOrder}
           virtualized
+          rowHeight={naturalHeight ? null : 56}
+          minRowHeight={52}
           columnUserSelect
           showCellBorders={showCellBorders}
           i18n={i18n}

--- a/examples/src/ComputedPropsCompatPage.tsx
+++ b/examples/src/ComputedPropsCompatPage.tsx
@@ -96,6 +96,94 @@ const initialStatus: CompatStatus = {
   virtualListTanStackLeak: "unknown",
 };
 
+const visibilityProbeRows = [
+  {
+    id: "visibility-row",
+    locked: "Locked column",
+    alpha: "Imperative column",
+    beta: "Prop-driven column",
+  },
+];
+
+function VisibilityReconciliationProbe() {
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [apiReady, setApiReady] = React.useState(false);
+  const [betaVisible, setBetaVisible] = React.useState(true);
+  const stableColumns = React.useMemo<TypeColumns>(
+    () => [
+      {
+        name: "locked",
+        header: "Locked",
+        defaultWidth: 150,
+        hideable: false,
+      },
+      { name: "alpha", header: "Alpha", defaultWidth: 170 },
+    ],
+    []
+  );
+  const visibilityColumns = React.useMemo<TypeColumns>(
+    () => [
+      ...stableColumns,
+      {
+        name: "beta",
+        header: "Beta",
+        defaultWidth: 190,
+        visible: betaVisible,
+      },
+    ],
+    [betaVisible, stableColumns]
+  );
+
+  return (
+    <section
+      className="rounded-3xl border bg-background/95 p-4 shadow-sm"
+      data-testid="visibility-reconciliation-probe"
+    >
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          data-testid="visibility-hide-locked"
+          disabled={!apiReady}
+          onClick={() => apiRef.current?.setColumnVisible?.("locked", false)}
+        >
+          Imperatively hide locked
+        </Button>
+        <Button
+          type="button"
+          data-testid="visibility-hide-alpha"
+          disabled={!apiReady}
+          onClick={() => apiRef.current?.setColumnVisible?.("alpha", false)}
+        >
+          Imperatively hide alpha
+        </Button>
+        <Button
+          type="button"
+          data-testid="visibility-toggle-beta-prop"
+          onClick={() => setBetaVisible((current) => !current)}
+        >
+          Toggle beta visible prop
+        </Button>
+        <output data-testid="visibility-beta-prop">
+          {String(betaVisible)}
+        </output>
+      </div>
+      <div className="h-[220px] min-h-0">
+        <ReactDataGrid
+          idProperty="id"
+          columns={visibilityColumns}
+          dataSource={visibilityProbeRows}
+          columnOrder={["locked", "alpha", "beta"]}
+          virtualized={false}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+            setApiReady(Boolean(ref.current));
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
 export default function ComputedPropsCompatPage() {
   const apiRef = React.useRef<TypeComputedProps | null>(null);
   const [apiReady, setApiReady] = React.useState(false);
@@ -269,6 +357,8 @@ export default function ComputedPropsCompatPage() {
           />
         </div>
       </section>
+
+      <VisibilityReconciliationProbe />
     </main>
   );
 }

--- a/examples/src/DefaultPropsCompatPage.tsx
+++ b/examples/src/DefaultPropsCompatPage.tsx
@@ -25,8 +25,10 @@ export default function DefaultPropsCompatPage() {
   const defaultValues = [
     `theme=${defaultProps.theme}`,
     `virtualized=${String(defaultProps.virtualized)}`,
+    `virtualizeColumnsThreshold=${defaultProps.virtualizeColumnsThreshold}`,
     `allowMobileTransform=${String(defaultProps.allowMobileTransform)}`,
     `rowHeight=${defaultProps.rowHeight}`,
+    `emptyText=${String(defaultProps.emptyText)}`,
   ].join(",");
 
   return (

--- a/examples/src/DefaultPropsCompatPage.tsx
+++ b/examples/src/DefaultPropsCompatPage.tsx
@@ -27,6 +27,7 @@ export default function DefaultPropsCompatPage() {
     `virtualized=${String(defaultProps.virtualized)}`,
     `virtualizeColumnsThreshold=${defaultProps.virtualizeColumnsThreshold}`,
     `allowMobileTransform=${String(defaultProps.allowMobileTransform)}`,
+    `liveColumnResize=${String(defaultProps.liveColumnResize)}`,
     `rowHeight=${defaultProps.rowHeight}`,
     `emptyText=${String(defaultProps.emptyText)}`,
   ].join(",");

--- a/examples/src/InovuaParityCompatPage.tsx
+++ b/examples/src/InovuaParityCompatPage.tsx
@@ -19,6 +19,7 @@ import ReactDataGrid, {
   type TypeEditInfo,
 } from "../../src/main";
 import { Button } from "../../src/components/ui/button";
+import { cn } from "../../src/lib/utils";
 import { useExamplesUi } from "./App";
 
 type ParityScenario =
@@ -114,7 +115,7 @@ const scenarioGroups: ScenarioGroup[] = [
         label: "Resize remeasurement",
         summary: "Natural rows remeasure after controlled width changes.",
         instructions:
-          "Capture the narrow layout, widen Description, then capture again. The wrapped row and total virtual height should shrink.",
+          "Drag the Description edge or focus its resize handle and use the arrow keys, then capture again. The wrapped row and total virtual height should shrink; the 360px button remains a deterministic comparison.",
       },
     ],
   },
@@ -325,7 +326,10 @@ function FixtureFrame(props: {
 }): React.ReactNode {
   return (
     <div
-      className={`h-[360px] w-[720px] max-w-full min-w-0 overflow-hidden rounded-2xl border bg-background shadow-sm ${props.className ?? ""}`}
+      className={cn(
+        "h-[360px] w-[720px] max-w-full min-w-0 overflow-hidden rounded-2xl border bg-background shadow-sm",
+        props.className
+      )}
       data-testid="parity-grid-frame"
     >
       {props.children}
@@ -404,6 +408,10 @@ function NaturalHeightScenario(): React.ReactNode {
     tall: NaturalMeasurement;
     short: NaturalMeasurement;
   }>({ tall: emptyNaturalMeasurement, short: emptyNaturalMeasurement });
+  const [smoothScrollReport, setSmoothScrollReport] = React.useState<{
+    target: number | null;
+    completed: number | null;
+  }>({ target: null, completed: null });
 
   const rows = React.useMemo(
     () => [
@@ -425,6 +433,7 @@ function NaturalHeightScenario(): React.ReactNode {
         name: "contentHeight",
         header: "Measured content",
         width: 260,
+        editable: true,
         render: ({ data }: CellProps) => {
           const row = data as (typeof rows)[number];
           return (
@@ -486,6 +495,11 @@ function NaturalHeightScenario(): React.ReactNode {
       short: captureAt("natural-short", 1),
     });
   }, []);
+  const captureAfterLayout = React.useCallback(() => {
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(captureMeasurements);
+    });
+  }, [captureMeasurements]);
 
   return (
     <div ref={scopeRef} className="space-y-3">
@@ -501,11 +515,20 @@ function NaturalHeightScenario(): React.ReactNode {
           type="button"
           variant="outline"
           data-testid="smooth-scroll-natural"
-          onClick={() =>
-            apiRef.current
-              ?.getVirtualList()
-              .smoothScrollTo(10, { direction: "top" })
-          }
+          onClick={() => {
+            const virtualList = apiRef.current?.getVirtualList();
+            if (!virtualList) return;
+
+            const target = virtualList.getRowAt(10)?.start;
+            if (target == null) return;
+
+            setSmoothScrollReport({ target, completed: null });
+            virtualList.smoothScrollTo(
+              target,
+              { duration: 100, orientation: "vertical" },
+              (completed) => setSmoothScrollReport({ target, completed })
+            );
+          }}
         >
           Smooth-scroll to row 11
         </Button>
@@ -517,6 +540,14 @@ function NaturalHeightScenario(): React.ReactNode {
         <MetricOutput label="Short row" testId="natural-short-measurement">
           {JSON.stringify(measurements.short)}
         </MetricOutput>
+        <div className="md:col-span-2">
+          <MetricOutput
+            label="Smooth-scroll pixel contract"
+            testId="natural-smooth-scroll-report"
+          >
+            {JSON.stringify(smoothScrollReport)}
+          </MetricOutput>
+        </div>
       </div>
       <FixtureFrame className="h-[320px] w-[560px]">
         <CommonGrid
@@ -527,6 +558,10 @@ function NaturalHeightScenario(): React.ReactNode {
           virtualized
           rowHeight={null}
           minRowHeight={52}
+          editable
+          onEditStart={captureAfterLayout}
+          onEditCancel={captureAfterLayout}
+          onEditComplete={captureAfterLayout}
           onReady={(ref) => {
             apiRef.current = ref.current;
           }}
@@ -662,6 +697,7 @@ function NaturalResizeScenario(): React.ReactNode {
   const apiRef = React.useRef<TypeComputedProps | null>(null);
   const scopeRef = React.useRef<HTMLDivElement | null>(null);
   const [descriptionWidth, setDescriptionWidth] = React.useState(140);
+  const [resizeEventCount, setResizeEventCount] = React.useState(0);
   const [measurement, setMeasurement] = React.useState<NaturalMeasurement>(
     emptyNaturalMeasurement
   );
@@ -696,7 +732,7 @@ function NaturalResizeScenario(): React.ReactNode {
           </span>
         ),
       },
-      { name: "filler", header: "Filler", width: 500 },
+      { name: "filler", header: "Filler", defaultWidth: 500 },
     ],
     [descriptionWidth]
   );
@@ -745,7 +781,7 @@ function NaturalResizeScenario(): React.ReactNode {
           data-testid="widen-natural-column"
           onClick={() => setDescriptionWidth(360)}
         >
-          Widen description
+          Set Description to 360px
         </Button>
         <Button
           type="button"
@@ -758,6 +794,12 @@ function NaturalResizeScenario(): React.ReactNode {
       <div className="grid gap-2 md:grid-cols-[11rem_minmax(0,1fr)]">
         <MetricOutput label="Description width" testId="natural-resize-width">
           {descriptionWidth}
+        </MetricOutput>
+        <MetricOutput
+          label="Resize callbacks"
+          testId="natural-resize-event-count"
+        >
+          {resizeEventCount}
         </MetricOutput>
         <MetricOutput
           label="Virtual measurement"
@@ -777,6 +819,20 @@ function NaturalResizeScenario(): React.ReactNode {
           minRowHeight={36}
           onReady={(ref) => {
             apiRef.current = ref.current;
+          }}
+          onColumnResize={(info) => {
+            setResizeEventCount((current) => current + 1);
+            const columnId = String(info.column.name ?? info.column.id ?? "");
+            const nextWidth = info.width;
+            if (
+              columnId === "description" &&
+              typeof nextWidth === "number" &&
+              Number.isFinite(nextWidth)
+            ) {
+              setDescriptionWidth((current) =>
+                current === nextWidth ? current : nextWidth
+              );
+            }
           }}
         />
       </FixtureFrame>
@@ -989,36 +1045,38 @@ function ContractEditor(
     thirdCellSame: boolean;
   }
 ): React.ReactNode {
-  const reportedRef = React.useRef(false);
+  const initialPropsRef = React.useRef(props);
   React.useLayoutEffect(() => {
-    if (reportedRef.current) return;
-    reportedRef.current = true;
-    window.requestAnimationFrame(() => {
-      const domNode = props.cell?.getDOMNode?.() ?? null;
-      props.onContract({
-        topLevelMarker: props.customMarker ?? null,
-        nestedMarker: props.editorProps?.customMarker ?? null,
-        theme: props.theme ?? null,
-        rtl: props.rtl ?? null,
-        nativeScroll: props.nativeScroll ?? null,
-        hasCell: Boolean(props.cell),
-        hasCellProps: Boolean(props.cellProps),
+    const initialProps = initialPropsRef.current;
+    const frame = window.requestAnimationFrame(() => {
+      const domNode = initialProps.cell?.getDOMNode?.() ?? null;
+      initialProps.onContract({
+        topLevelMarker: initialProps.customMarker ?? null,
+        nestedMarker: initialProps.editorProps?.customMarker ?? null,
+        theme: initialProps.theme ?? null,
+        rtl: initialProps.rtl ?? null,
+        nativeScroll: initialProps.nativeScroll ?? null,
+        hasCell: Boolean(initialProps.cell),
+        hasCellProps: Boolean(initialProps.cellProps),
         getDOMNodeColumnId: domNode?.getAttribute("data-column-id") ?? null,
-        secondCellPropsSame: props.secondCellPropsSame,
-        thirdCellSame: props.thirdCellSame,
-        hasGotoNext: typeof props.gotoNext === "function",
-        hasGotoPrev: typeof props.gotoPrev === "function",
-        hasClickHandler: typeof props.onClick === "function",
+        secondCellPropsSame: initialProps.secondCellPropsSame,
+        thirdCellSame: initialProps.thirdCellSame,
+        hasGotoNext: typeof initialProps.gotoNext === "function",
+        hasGotoPrev: typeof initialProps.gotoPrev === "function",
+        hasClickHandler: typeof initialProps.onClick === "function",
       });
     });
-  }, [props]);
+    return () => window.cancelAnimationFrame(frame);
+  }, []);
 
   return (
     <input
       autoFocus={props.autoFocus}
-      className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+      className="tdg-cell-editor InovuaReactDataGrid__cell__editor InovuaReactDataGrid__cell__editor--text"
+      data-slot="cell-editor"
       data-testid="compat-custom-editor"
       value={String(props.value ?? "")}
+      onBlur={() => props.onComplete()}
       onChange={(event) => props.onChange(event.target.value)}
       onClick={props.onClick as React.MouseEventHandler<HTMLInputElement>}
       onKeyDown={(event) => {
@@ -1032,9 +1090,29 @@ function ContractEditor(
 }
 
 function CustomEditorScenario(): React.ReactNode {
+  const editorOutput =
+    typeof window === "undefined"
+      ? null
+      : new URLSearchParams(window.location.search).get("editorOutput");
   const [contract, setContract] =
     React.useState<CustomEditorContractReport | null>(null);
   const [bubbleCount, setBubbleCount] = React.useState(0);
+  const [events, setEvents] = React.useState<EditEvent[]>([]);
+  const handleContract = React.useCallback(
+    (report: CustomEditorContractReport) => {
+      // The contract is invariant across cells. Keeping the first report
+      // avoids rerendering the scenario on every rapid editor replacement.
+      setContract((current) => current ?? report);
+    },
+    []
+  );
+  const appendEvent = React.useCallback(
+    (type: EditEvent["type"], info: TypeEditInfo) => {
+      const event = sanitizeEditEvent(type, info);
+      setEvents((current) => [...current, event]);
+    },
+    []
+  );
   const columns = React.useMemo(
     () =>
       [
@@ -1050,13 +1128,15 @@ function CustomEditorScenario(): React.ReactNode {
             secondCellProps?: CellProps,
             thirdCell?: CompatEditorCell
           ) => {
+            if (editorOutput === "zero") return 0;
+
             const editorProps = rawEditorProps as InovuaCompatEditorProps;
             const { key: editorKey, ...contractEditorProps } = editorProps;
             return (
               <ContractEditor
                 key={String(editorKey ?? "editor")}
                 {...contractEditorProps}
-                onContract={setContract}
+                onContract={handleContract}
                 secondCellPropsSame={secondCellProps === editorProps.cellProps}
                 thirdCellSame={thirdCell === editorProps.cell}
               />
@@ -1065,12 +1145,45 @@ function CustomEditorScenario(): React.ReactNode {
         },
         { name: "city", header: "City", width: 220, editable: false },
       ] as unknown as TypeColumns,
-    []
+    [editorOutput, handleContract]
+  );
+  const gridFixture = React.useMemo(
+    () => (
+      <FixtureFrame className="h-[280px] w-[620px]">
+        <CommonGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={baseRows}
+          columnOrder={["id", "name", "city"]}
+          virtualized={false}
+          editable
+          onEditStart={(info) => appendEvent("start", info)}
+          onEditStop={(info) => appendEvent("stop", info)}
+          onEditComplete={(info) => appendEvent("complete", info)}
+          onEditCancel={(info) => appendEvent("cancel", info)}
+          onEditValueChange={(info) => appendEvent("value", info)}
+        />
+      </FixtureFrame>
+    ),
+    [appendEvent, columns]
   );
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-2 md:grid-cols-[9rem_minmax(0,1fr)]">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          data-testid="custom-editor-outside-target"
+        >
+          Complete with outside click
+        </Button>
+        <span className="text-sm text-muted-foreground">
+          Custom editors opt into blur completion by calling their supplied
+          onComplete callback.
+        </span>
+      </div>
+      <div className="grid gap-2 md:grid-cols-[9rem_minmax(0,1fr)_minmax(0,1fr)]">
         <MetricOutput label="Outer click count" testId="custom-editor-bubbles">
           {bubbleCount}
         </MetricOutput>
@@ -1081,18 +1194,16 @@ function CustomEditorScenario(): React.ReactNode {
         >
           {contract ? JSON.stringify(contract, null, 2) : "none"}
         </MetricOutput>
+        <MetricOutput
+          label="Editor lifecycle"
+          testId="custom-editor-events"
+          wrap
+        >
+          {JSON.stringify(events, null, 2)}
+        </MetricOutput>
       </div>
       <div onClick={() => setBubbleCount((current) => current + 1)}>
-        <FixtureFrame className="h-[280px] w-[620px]">
-          <CommonGrid
-            idProperty="id"
-            columns={columns}
-            dataSource={baseRows}
-            columnOrder={["id", "name", "city"]}
-            virtualized={false}
-            editable
-          />
-        </FixtureFrame>
+        {gridFixture}
       </div>
     </div>
   );
@@ -2115,6 +2226,7 @@ function RowStyleContractScenario(): React.ReactNode {
 function FlexScenario(): React.ReactNode {
   const apiRef = React.useRef<TypeComputedProps | null>(null);
   const [events, setEvents] = React.useState<ResizeEvent[]>([]);
+  const [showEdgeCases, setShowEdgeCases] = React.useState(false);
   const columns: TypeColumns = [
     { name: "fixed", header: "Fixed", width: 120 },
     { name: "one", header: "Flex one", defaultFlex: 1, minWidth: 60 },
@@ -2144,7 +2256,16 @@ function FlexScenario(): React.ReactNode {
           {JSON.stringify(events)}
         </MetricOutput>
       </div>
-      <FixtureFrame className="h-[240px] w-[720px]">
+      <div className="rounded-xl border bg-muted/20 p-3 text-sm leading-relaxed text-muted-foreground">
+        <p className="font-medium text-foreground">Compatibility behavior</p>
+        <p>
+          Flex one starts as grid-owned defaultFlex. Resizing it converts it to
+          a fixed width without redistributing the delta, while controlled Flex
+          two remains authoritative. Growing can create a real horizontal scroll
+          range; shrinking can intentionally preserve reserved space.
+        </p>
+      </div>
+      <FixtureFrame className="h-[240px] w-full">
         <CommonGrid
           idProperty="id"
           columns={columns}
@@ -2161,31 +2282,68 @@ function FlexScenario(): React.ReactNode {
           }}
         />
       </FixtureFrame>
-      <div data-testid="flex-constrained">
-        <FixtureFrame className="h-[180px] !w-[60px]">
-          <CommonGrid
-            idProperty="id"
-            columns={[
-              { name: "defaultMin", header: "", flex: 1 },
-              { name: "zeroMin", header: "", flex: 1, minWidth: 0 },
-            ]}
-            dataSource={[{ id: "constrained", defaultMin: "", zeroMin: "" }]}
-            columnOrder={["defaultMin", "zeroMin"]}
-            virtualized={false}
-          />
-        </FixtureFrame>
-      </div>
-      <div className="max-w-full overflow-x-auto" data-testid="flex-unbounded">
-        <FixtureFrame className="!h-[160px] !w-[10050px] !max-w-none">
-          <CommonGrid
-            idProperty="id"
-            columns={[{ name: "wide", header: "", flex: 1 }]}
-            dataSource={[{ id: "unbounded", wide: "" }]}
-            columnOrder={["wide"]}
-            virtualized={false}
-          />
-        </FixtureFrame>
-      </div>
+      <details
+        className="overflow-hidden rounded-xl border bg-muted/10"
+        data-testid="flex-edge-cases"
+        onToggle={(event) => setShowEdgeCases(event.currentTarget.open)}
+      >
+        <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium text-foreground hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60">
+          Advanced width stress probes
+        </summary>
+        {showEdgeCases ? (
+          <div className="space-y-5 border-t p-4">
+            <section className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+              <div className="space-y-1 text-sm">
+                <h3 className="font-medium">Minimum-width compression</h3>
+                <p className="max-w-2xl text-muted-foreground">
+                  This deliberately narrow 60px host verifies the default 40px
+                  minimum alongside an explicit zero minimum.
+                </p>
+              </div>
+              <div data-testid="flex-constrained">
+                <FixtureFrame className="h-[180px] !w-[60px]">
+                  <CommonGrid
+                    idProperty="id"
+                    columns={[
+                      { name: "defaultMin", header: "", flex: 1 },
+                      { name: "zeroMin", header: "", flex: 1, minWidth: 0 },
+                    ]}
+                    dataSource={[
+                      { id: "constrained", defaultMin: "", zeroMin: "" },
+                    ]}
+                    columnOrder={["defaultMin", "zeroMin"]}
+                    virtualized={false}
+                  />
+                </FixtureFrame>
+              </div>
+            </section>
+            <section className="space-y-2 text-sm">
+              <div className="space-y-1">
+                <h3 className="font-medium">Unbounded-width stress check</h3>
+                <p className="max-w-2xl text-muted-foreground">
+                  The 10,050px host checks that flex allocation has no
+                  artificial 10,000px cap. The local scrollbar below is
+                  intentional and belongs only to this diagnostic.
+                </p>
+              </div>
+              <div
+                className="max-w-full overflow-x-auto"
+                data-testid="flex-unbounded"
+              >
+                <FixtureFrame className="!h-[160px] !w-[10050px] !max-w-none">
+                  <CommonGrid
+                    idProperty="id"
+                    columns={[{ name: "wide", header: "", flex: 1 }]}
+                    dataSource={[{ id: "unbounded", wide: "" }]}
+                    columnOrder={["wide"]}
+                    virtualized={false}
+                  />
+                </FixtureFrame>
+              </div>
+            </section>
+          </div>
+        ) : null}
+      </details>
     </div>
   );
 }
@@ -2476,7 +2634,7 @@ export default function InovuaParityCompatPage({
           </Button>
         </div>
 
-        <div className="min-w-0 overflow-x-auto pb-1">
+        <div className="min-w-0">
           <ScenarioContent
             key={`${scenario}-${scenarioRevision}`}
             scenario={scenario}

--- a/examples/src/InovuaParityCompatPage.tsx
+++ b/examples/src/InovuaParityCompatPage.tsx
@@ -28,6 +28,7 @@ type ParityScenario =
   | "bounded-row-height"
   | "natural-resize"
   | "resize-callback"
+  | "live-resize"
   | "zebra-default"
   | "zebra-disabled"
   | "editing-default"
@@ -42,7 +43,8 @@ type ParityScenario =
   | "row-style-static"
   | "row-style-contract"
   | "flex"
-  | "controlled-width";
+  | "controlled-width"
+  | "controlled-live-resize";
 
 const scenarios = new Set<ParityScenario>([
   "natural-height",
@@ -50,6 +52,7 @@ const scenarios = new Set<ParityScenario>([
   "bounded-row-height",
   "natural-resize",
   "resize-callback",
+  "live-resize",
   "zebra-default",
   "zebra-disabled",
   "editing-default",
@@ -65,6 +68,7 @@ const scenarios = new Set<ParityScenario>([
   "row-style-contract",
   "flex",
   "controlled-width",
+  "controlled-live-resize",
 ]);
 
 type ScenarioGroupId = "rows" | "columns" | "appearance" | "editing";
@@ -132,6 +136,13 @@ const scenarioGroups: ScenarioGroup[] = [
           "Drag the Description header edge and compare the latest callback width with the rendered header width.",
       },
       {
+        id: "live-resize",
+        label: "Live column resize",
+        summary: "The column follows the pointer without a resize proxy.",
+        instructions:
+          "Drag the Description header edge. Header and body geometry should update together before release, while the completion callback still fires exactly once on drop.",
+      },
+      {
         id: "flex",
         label: "Flex allocation",
         summary: "Remaining width split through flex and defaultFlex.",
@@ -144,6 +155,13 @@ const scenarioGroups: ScenarioGroup[] = [
         summary: "A supplied width remains authoritative during drag.",
         instructions:
           "Drag Controlled to a proposed width and inspect the clamped callback payload—it should render at 180px until the button supplies 300px.",
+      },
+      {
+        id: "controlled-live-resize",
+        label: "Controlled live resize",
+        summary: "A controlled width previews live without losing ownership.",
+        instructions:
+          "Drag Controlled and hold to inspect the live preview. On release it returns to 180px unless the consumer applies the completion proposal.",
       },
     ],
   },
@@ -862,8 +880,25 @@ function sanitizeResizeEvent(
   };
 }
 
-function ResizeCallbackScenario(): React.ReactNode {
+function ResizeCallbackScenario(props: {
+  liveColumnResize?: boolean;
+}): React.ReactNode {
   const [events, setEvents] = React.useState<ResizeEvent[]>([]);
+  const rows = React.useMemo(
+    () =>
+      props.liveColumnResize
+        ? Array.from({ length: 500 }, (_, index) => ({
+            id: `live-resize-${index + 1}`,
+            description: `Interactive resize row ${index + 1}`,
+            filler: `Stable virtualized content ${index + 1}`,
+          }))
+        : baseRows.map((row) => ({
+            ...row,
+            description: `${row.name} description`,
+            filler: row.city,
+          })),
+    [props.liveColumnResize]
+  );
   const columns = React.useMemo<TypeColumns>(
     () => [
       {
@@ -892,14 +927,11 @@ function ResizeCallbackScenario(): React.ReactNode {
         <CommonGrid
           idProperty="id"
           columns={columns}
-          dataSource={baseRows.map((row) => ({
-            ...row,
-            description: `${row.name} description`,
-            filler: row.city,
-          }))}
+          dataSource={rows}
           columnOrder={["description", "filler"]}
-          virtualized={false}
+          virtualized={Boolean(props.liveColumnResize)}
           resizable
+          liveColumnResize={props.liveColumnResize}
           onColumnResize={(info, context) => {
             const event = sanitizeResizeEvent(info, context);
             setEvents((current) => [...current, event]);
@@ -2348,7 +2380,9 @@ function FlexScenario(): React.ReactNode {
   );
 }
 
-function ControlledWidthScenario(): React.ReactNode {
+function ControlledWidthScenario(props: {
+  liveColumnResize?: boolean;
+}): React.ReactNode {
   const [controlledWidth, setControlledWidth] = React.useState(180);
   const [events, setEvents] = React.useState<ResizeEvent[]>([]);
   const columns = React.useMemo<TypeColumns>(
@@ -2399,6 +2433,7 @@ function ControlledWidthScenario(): React.ReactNode {
           columnOrder={["controlled", "filler"]}
           virtualized={false}
           resizable
+          liveColumnResize={props.liveColumnResize}
           onColumnResize={(info, context) => {
             const event = sanitizeResizeEvent(info, context);
             setEvents((current) => [...current, event]);
@@ -2421,6 +2456,8 @@ function ScenarioContent(props: { scenario: ParityScenario }): React.ReactNode {
       return <NaturalResizeScenario />;
     case "resize-callback":
       return <ResizeCallbackScenario />;
+    case "live-resize":
+      return <ResizeCallbackScenario liveColumnResize />;
     case "zebra-default":
       return <ZebraScenario disabled={false} />;
     case "zebra-disabled":
@@ -2451,6 +2488,8 @@ function ScenarioContent(props: { scenario: ParityScenario }): React.ReactNode {
       return <FlexScenario />;
     case "controlled-width":
       return <ControlledWidthScenario />;
+    case "controlled-live-resize":
+      return <ControlledWidthScenario liveColumnResize />;
     default:
       return null;
   }

--- a/examples/src/InovuaPendingParityCompatPage.tsx
+++ b/examples/src/InovuaPendingParityCompatPage.tsx
@@ -1,0 +1,967 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  type TypeColumns,
+  type TypeComputedProps,
+  type TypeDataGridProps,
+  type TypeEditInfo,
+  type TypeFilterValue,
+  type TypeOnSelectionChangeArg,
+  type TypeRowStyleArgs,
+  type TypeSingleFilterValue,
+} from "../../src/main";
+import { Button } from "../../src/components/ui/button";
+import { useExamplesUi } from "./App";
+
+type PendingScenario =
+  | "filter-callback"
+  | "selection-enable"
+  | "selection-derived"
+  | "selection-disable"
+  | "selection-disable-controlled"
+  | "selection-callback-only"
+  | "columns-default-15"
+  | "columns-default-14"
+  | "columns-threshold-at"
+  | "columns-threshold-below"
+  | "columns-force-on"
+  | "columns-force-off"
+  | "columns-function-height"
+  | "columns-natural-height"
+  | "columns-scroll"
+  | "empty-literal"
+  | "empty-key"
+  | "empty-node"
+  | "empty-function"
+  | "empty-null"
+  | "empty-false"
+  | "empty-string"
+  | "empty-loading"
+  | "empty-filtered"
+  | "empty-remote"
+  | "empty-mobile"
+  | "row-height-authority"
+  | "editing-column-coordinate"
+  | "editing-row-coordinate"
+  | "zebra-imperative";
+
+const scenarios = new Set<PendingScenario>([
+  "filter-callback",
+  "selection-enable",
+  "selection-derived",
+  "selection-disable",
+  "selection-disable-controlled",
+  "selection-callback-only",
+  "columns-default-15",
+  "columns-default-14",
+  "columns-threshold-at",
+  "columns-threshold-below",
+  "columns-force-on",
+  "columns-force-off",
+  "columns-function-height",
+  "columns-natural-height",
+  "columns-scroll",
+  "empty-literal",
+  "empty-key",
+  "empty-node",
+  "empty-function",
+  "empty-null",
+  "empty-false",
+  "empty-string",
+  "empty-loading",
+  "empty-filtered",
+  "empty-remote",
+  "empty-mobile",
+  "row-height-authority",
+  "editing-column-coordinate",
+  "editing-row-coordinate",
+  "zebra-imperative",
+]);
+
+type PendingColumnFilterValueChange = {
+  filterValue: TypeSingleFilterValue;
+  columnId: string;
+  columnIndex: number;
+  cellProps?: Record<string, unknown>;
+};
+
+type PendingCompatGridProps = TypeDataGridProps & {
+  onColumnFilterValueChange?: (event: PendingColumnFilterValueChange) => void;
+  enableSelection?: boolean;
+  virtualizeColumnsThreshold?: number;
+  virtualizeColumns?: boolean;
+  emptyText?: React.ReactNode | (() => React.ReactNode);
+};
+
+const PendingCompatGrid =
+  ReactDataGrid as React.ComponentType<PendingCompatGridProps>;
+
+const baseRows = [
+  { id: "row-1", name: "Ada Lovelace", team: "Analytics" },
+  { id: "row-2", name: "Grace Hopper", team: "Compilers" },
+  { id: "row-3", name: "Katherine Johnson", team: "Flight" },
+];
+
+const baseColumns: TypeColumns = [
+  { name: "id", header: "ID", width: 110 },
+  { name: "name", header: "Name", width: 220 },
+  { name: "team", header: "Team", width: 180 },
+];
+
+function readScenario(): PendingScenario {
+  if (typeof window === "undefined") return "filter-callback";
+  const value = new URLSearchParams(window.location.search).get("scenario");
+  return scenarios.has(value as PendingScenario)
+    ? (value as PendingScenario)
+    : "filter-callback";
+}
+
+function FixtureFrame(props: {
+  children: React.ReactNode;
+  className?: string;
+  testId?: string;
+}) {
+  return (
+    <div
+      className={`h-[320px] w-[620px] max-w-full min-w-0 overflow-hidden rounded-xl border bg-background ${props.className ?? ""}`}
+      data-testid={props.testId ?? "pending-grid-frame"}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+function CommonPendingGrid(props: PendingCompatGridProps) {
+  const { gridTheme, i18n, resizable, showCellBorders } = useExamplesUi();
+
+  return (
+    <PendingCompatGrid
+      enableColumnFilterContextMenu={false}
+      enableColumnAutosize={false}
+      skipHeaderOnAutoSize={false}
+      enableFiltering={false}
+      columnUserSelect="text"
+      showColumnMenuTool={false}
+      {...props}
+      theme={props.theme ?? gridTheme}
+      i18n={props.i18n ?? i18n}
+      resizable={props.resizable ?? resizable}
+      showCellBorders={props.showCellBorders ?? showCellBorders}
+    />
+  );
+}
+
+function JsonOutput(props: { testId: string; value: unknown }) {
+  return (
+    <output
+      className="block max-h-52 overflow-auto whitespace-pre-wrap rounded-lg border bg-muted/25 p-3 font-mono text-xs"
+      data-testid={props.testId}
+    >
+      {JSON.stringify(props.value, null, 2)}
+    </output>
+  );
+}
+
+function PendingNameFilterEditor(props: Record<string, unknown>) {
+  const onChange = props.onChange as ((value: unknown) => void) | undefined;
+
+  return (
+    <input
+      className="h-8 w-full rounded-md border bg-background px-2 text-sm"
+      data-testid="pending-name-filter"
+      disabled={Boolean(props.disabled)}
+      value={String(props.value ?? "")}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  );
+}
+
+type FilterLogEvent =
+  | {
+      kind: "column";
+      columnId: string;
+      columnIndex: number;
+      filterValue: Pick<
+        TypeSingleFilterValue,
+        "name" | "type" | "operator" | "value"
+      > & { active: boolean | null };
+      cellPropsPresent: boolean;
+      cellPropsId: string | null;
+      cellPropsColumnIndex: number | null;
+    }
+  | { kind: "aggregate"; filterValue: TypeFilterValue };
+
+function sanitizeColumnFilterEvent(
+  event: PendingColumnFilterValueChange
+): FilterLogEvent {
+  const cellProps = event.cellProps;
+  const nestedColumn = cellProps?.column as Record<string, unknown> | undefined;
+  const rawId =
+    cellProps?.id ??
+    cellProps?.columnId ??
+    nestedColumn?.id ??
+    nestedColumn?.name;
+  const rawIndex =
+    cellProps?.computedVisibleIndex ?? cellProps?.columnIndex ?? null;
+
+  return {
+    kind: "column",
+    columnId: String(event.columnId),
+    columnIndex: event.columnIndex,
+    filterValue: {
+      name: event.filterValue.name,
+      type: event.filterValue.type,
+      operator: event.filterValue.operator,
+      value: event.filterValue.value,
+      active: event.filterValue.active ?? null,
+    },
+    cellPropsPresent: Boolean(cellProps),
+    cellPropsId: rawId == null ? null : String(rawId),
+    cellPropsColumnIndex: typeof rawIndex === "number" ? rawIndex : null,
+  };
+}
+
+const defaultNameFilter: TypeSingleFilterValue = {
+  name: "name",
+  type: "string",
+  operator: "contains",
+  value: "Ada",
+};
+
+function FilterCallbackScenario() {
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [events, setEvents] = React.useState<FilterLogEvent[]>([]);
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      baseColumns[0]!,
+      {
+        ...baseColumns[1]!,
+        filterable: true,
+        filterEditor: PendingNameFilterEditor,
+      },
+      { ...baseColumns[2]!, filterable: true },
+    ],
+    []
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          data-testid="set-column-filter"
+          onClick={() =>
+            apiRef.current?.setColumnFilterValue?.("name", "Grace")
+          }
+        >
+          Set Name filter
+        </Button>
+        <Button
+          type="button"
+          data-testid="clear-column-filter"
+          onClick={() => apiRef.current?.clearColumnFilter?.("name")}
+        >
+          Clear Name filter
+        </Button>
+      </div>
+      <JsonOutput testId="filter-event-log" value={events} />
+      <FixtureFrame>
+        <CommonPendingGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={baseRows}
+          columnOrder={["id", "name", "team"]}
+          virtualized={false}
+          enableFiltering
+          enableColumnFilterContextMenu
+          defaultFilterValue={[defaultNameFilter]}
+          onColumnFilterValueChange={(event) =>
+            setEvents((current) => [
+              ...current,
+              sanitizeColumnFilterEvent(event),
+            ])
+          }
+          onFilterValueChange={(filterValue) =>
+            setEvents((current) => [
+              ...current,
+              { kind: "aggregate", filterValue },
+            ])
+          }
+          i18n={{
+            noRecords: "No matching rows",
+            filter: "Filter",
+            clear: "Clear",
+            contains: "Contains",
+            eq: "Equals",
+            operator: "Operator",
+          }}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+          }}
+        />
+      </FixtureFrame>
+    </div>
+  );
+}
+
+type SelectionMode =
+  | "enable"
+  | "derived"
+  | "disable"
+  | "disable-controlled"
+  | "callback-only";
+
+function SelectionScenario(props: { mode: SelectionMode }) {
+  const [events, setEvents] = React.useState<TypeOnSelectionChangeArg[]>([]);
+  const common: PendingCompatGridProps = {
+    idProperty: "id",
+    columns: baseColumns,
+    dataSource: baseRows,
+    columnOrder: ["id", "name", "team"],
+    virtualized: false,
+  };
+
+  if (props.mode === "enable") {
+    common.enableSelection = true;
+  } else if (props.mode === "derived") {
+    common.defaultSelected = {};
+  } else if (props.mode === "disable") {
+    common.enableSelection = false;
+    common.checkboxColumn = true;
+    common.checkboxOnlyRowSelect = false;
+    common.onSelectionChange = (event) =>
+      setEvents((current) => [...current, event]);
+  } else if (props.mode === "disable-controlled") {
+    common.enableSelection = false;
+    common.selected = { "row-1": baseRows[0] };
+    common.onSelectionChange = (event) =>
+      setEvents((current) => [...current, event]);
+  } else {
+    common.onSelectionChange = (event) =>
+      setEvents((current) => [...current, event]);
+  }
+
+  return (
+    <div className="space-y-3">
+      <JsonOutput testId="selection-event-log" value={events} />
+      <FixtureFrame>
+        <CommonPendingGrid {...common} />
+      </FixtureFrame>
+    </div>
+  );
+}
+
+function LastColumnFilterEditor(props: Record<string, unknown>) {
+  const onChange = props.onChange as ((value: unknown) => void) | undefined;
+
+  return (
+    <input
+      className="h-8 w-full rounded-md border bg-background px-2 text-sm"
+      data-testid="last-column-filter"
+      value={String(props.value ?? "")}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  );
+}
+
+type ColumnScenarioConfig = {
+  count: number;
+  threshold?: number;
+  force?: boolean;
+  rowHeight: number | ((rowIndex: number) => number) | null;
+  interactive?: boolean;
+};
+
+function getColumnScenarioConfig(
+  scenario: PendingScenario
+): ColumnScenarioConfig {
+  switch (scenario) {
+    case "columns-default-15":
+      return { count: 15, rowHeight: 40 };
+    case "columns-default-14":
+      return { count: 14, rowHeight: 40 };
+    case "columns-threshold-at":
+      return { count: 20, threshold: 20, rowHeight: 40 };
+    case "columns-threshold-below":
+      return { count: 20, threshold: 21, rowHeight: 40 };
+    case "columns-force-on":
+      return { count: 14, threshold: 99, force: true, rowHeight: 40 };
+    case "columns-force-off":
+      return { count: 20, threshold: 1, force: false, rowHeight: 40 };
+    case "columns-function-height":
+      return {
+        count: 20,
+        threshold: 1,
+        force: true,
+        rowHeight: () => 40,
+      };
+    case "columns-natural-height":
+      return { count: 20, threshold: 1, force: true, rowHeight: null };
+    case "columns-scroll":
+      return {
+        count: 24,
+        threshold: 1,
+        rowHeight: 40,
+        interactive: true,
+      };
+    default:
+      return { count: 20, threshold: 20, rowHeight: 40 };
+  }
+}
+
+type ColumnStateSnapshot = {
+  computedVirtualizeColumns: boolean | null;
+  rowStyleVirtualizeColumns: boolean | null;
+  rowStyleColumnRenderCount: number | null;
+  rowStyleTotalColumnCount: number | null;
+};
+
+type EditorVirtualizationSnapshot = {
+  columnId: string;
+  columnIndex: number;
+  virtualizeColumns: boolean | null;
+};
+
+function ColumnVirtualizationScenario(props: { scenario: PendingScenario }) {
+  const config = getColumnScenarioConfig(props.scenario);
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const rowStyleSnapshotRef = React.useRef<{
+    virtualizeColumns: boolean;
+    columnRenderCount: number;
+    totalColumnCount: number;
+  } | null>(null);
+  const [snapshot, setSnapshot] = React.useState<ColumnStateSnapshot>({
+    computedVirtualizeColumns: null,
+    rowStyleVirtualizeColumns: null,
+    rowStyleColumnRenderCount: null,
+    rowStyleTotalColumnCount: null,
+  });
+  const [editorSnapshot, setEditorSnapshot] =
+    React.useState<EditorVirtualizationSnapshot | null>(null);
+
+  const columns = React.useMemo<TypeColumns>(
+    () =>
+      Array.from({ length: config.count }, (_, index) => {
+        const columnId = `col-${String(index).padStart(2, "0")}`;
+        return {
+          name: columnId,
+          header: `Column ${String(index).padStart(2, "0")}`,
+          width: 140,
+          editable: Boolean(config.interactive),
+          filterable: Boolean(config.interactive),
+          ...(config.interactive && index === config.count - 1
+            ? { filterEditor: LastColumnFilterEditor }
+            : {}),
+        };
+      }),
+    [config.count, config.interactive]
+  );
+  const rows = React.useMemo(
+    () =>
+      Array.from({ length: 4 }, (_, rowIndex) =>
+        Object.fromEntries([
+          ["id", `virtual-row-${rowIndex + 1}`],
+          ...columns.map((column, columnIndex) => [
+            String(column.name),
+            rowIndex === 0 && columnIndex === columns.length - 1
+              ? "needle"
+              : `r${rowIndex + 1}-c${columnIndex}`,
+          ]),
+        ])
+      ),
+    [columns]
+  );
+  const lastColumnIndex = config.count - 1;
+
+  const rowStyle = React.useCallback((args: TypeRowStyleArgs) => {
+    rowStyleSnapshotRef.current = {
+      virtualizeColumns: Boolean(args.props.virtualizeColumns),
+      columnRenderCount: args.props.columnRenderCount,
+      totalColumnCount: args.props.totalColumnCount,
+    };
+    return undefined;
+  }, []);
+
+  const captureState = React.useCallback(() => {
+    const rowStyleState = rowStyleSnapshotRef.current;
+
+    setSnapshot({
+      computedVirtualizeColumns:
+        typeof apiRef.current?.virtualizeColumns === "boolean"
+          ? apiRef.current.virtualizeColumns
+          : null,
+      rowStyleVirtualizeColumns: rowStyleState?.virtualizeColumns ?? null,
+      rowStyleColumnRenderCount: rowStyleState?.columnRenderCount ?? null,
+      rowStyleTotalColumnCount: rowStyleState?.totalColumnCount ?? null,
+    });
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          data-testid="capture-column-state"
+          onClick={captureState}
+        >
+          Capture column state
+        </Button>
+        <Button
+          type="button"
+          data-testid="scroll-last-column"
+          onClick={() => apiRef.current?.scrollToColumn?.(lastColumnIndex)}
+        >
+          Scroll to last column
+        </Button>
+        <Button
+          type="button"
+          data-testid="scroll-first-column"
+          onClick={() => apiRef.current?.scrollToColumn?.(0)}
+        >
+          Scroll to first column
+        </Button>
+      </div>
+      <JsonOutput testId="column-state" value={snapshot} />
+      <JsonOutput testId="column-editor-state" value={editorSnapshot} />
+      <FixtureFrame className="h-[330px] w-[560px]">
+        <CommonPendingGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          columnOrder={columns.map((column) => String(column.name))}
+          virtualized={false}
+          rowHeight={config.rowHeight}
+          virtualizeColumnsThreshold={config.threshold}
+          virtualizeColumns={config.force}
+          enableFiltering={Boolean(config.interactive)}
+          editable={Boolean(config.interactive)}
+          rowStyle={rowStyle}
+          onEditStart={(info) => {
+            const cellProps = info.cellProps as Record<string, unknown>;
+            setEditorSnapshot({
+              columnId: String(info.columnId),
+              columnIndex: info.columnIndex,
+              virtualizeColumns:
+                typeof cellProps.virtualizeColumns === "boolean"
+                  ? cellProps.virtualizeColumns
+                  : null,
+            });
+          }}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+          }}
+        />
+      </FixtureFrame>
+    </div>
+  );
+}
+
+type EmptyScenarioConfig = {
+  content?: React.ReactNode | (() => React.ReactNode);
+  loading?: boolean;
+  filtered?: boolean;
+  remote?: boolean;
+  mobile?: boolean;
+};
+
+function EmptyTextScenario(props: { scenario: PendingScenario }) {
+  const [actionCount, setActionCount] = React.useState(0);
+  const remoteResolverRef = React.useRef<(() => void) | null>(null);
+  const [loadingActive, setLoadingActive] = React.useState(
+    props.scenario === "empty-loading"
+  );
+  const handleAction = React.useCallback(
+    () => setActionCount((current) => current + 1),
+    []
+  );
+  const remoteSource = React.useCallback(() => {
+    return new Promise<unknown[]>((resolve) => {
+      remoteResolverRef.current = () => resolve([]);
+    });
+  }, []);
+
+  const config = React.useMemo<EmptyScenarioConfig>(() => {
+    switch (props.scenario) {
+      case "empty-literal":
+        return { content: "Literal empty state" };
+      case "empty-key":
+        return { content: "customEmptyKey" };
+      case "empty-node":
+        return {
+          content: (
+            <button
+              type="button"
+              data-testid="empty-node-action"
+              onClick={handleAction}
+            >
+              Node empty action
+            </button>
+          ),
+        };
+      case "empty-function":
+        return {
+          content: () => (
+            <button
+              type="button"
+              data-testid="empty-function-action"
+              onClick={handleAction}
+            >
+              Function empty action
+            </button>
+          ),
+        };
+      case "empty-null":
+        return { content: null };
+      case "empty-false":
+        return { content: false };
+      case "empty-string":
+        return { content: "" };
+      case "empty-loading":
+        return {
+          content: () => (
+            <span data-testid="loading-empty-content">Loaded empty state</span>
+          ),
+          loading: true,
+        };
+      case "empty-filtered":
+        return {
+          content: (
+            <span data-testid="filtered-empty-content">
+              No filtered matches
+            </span>
+          ),
+          filtered: true,
+        };
+      case "empty-remote":
+        return {
+          content: (
+            <span data-testid="remote-empty-content">Remote empty state</span>
+          ),
+          remote: true,
+        };
+      case "empty-mobile":
+        return {
+          content: (
+            <span data-testid="mobile-empty-content">Mobile empty state</span>
+          ),
+          mobile: true,
+        };
+      default:
+        return {};
+    }
+  }, [handleAction, props.scenario]);
+
+  const rows = config.filtered ? baseRows : [];
+  const dataSource = config.remote ? remoteSource : rows;
+  const emptyTextProps = {
+    emptyText: config.content,
+  } as Pick<PendingCompatGridProps, "emptyText">;
+
+  return (
+    <div className="space-y-3">
+      {props.scenario === "empty-loading" ? (
+        <Button
+          type="button"
+          data-testid="finish-empty-loading"
+          onClick={() => setLoadingActive(false)}
+        >
+          Finish loading
+        </Button>
+      ) : null}
+      {props.scenario === "empty-remote" ? (
+        <Button
+          type="button"
+          data-testid="resolve-remote-empty"
+          onClick={() => remoteResolverRef.current?.()}
+        >
+          Resolve remote empty data
+        </Button>
+      ) : null}
+      <output data-testid="empty-action-count">{actionCount}</output>
+      <FixtureFrame className="h-[280px] w-[560px]">
+        <CommonPendingGrid
+          idProperty="id"
+          columns={baseColumns}
+          dataSource={dataSource}
+          columnOrder={["id", "name", "team"]}
+          virtualized={false}
+          loading={config.loading ? loadingActive : undefined}
+          allowMobileTransform={Boolean(config.mobile)}
+          enableFiltering={Boolean(config.filtered)}
+          defaultFilterValue={
+            config.filtered
+              ? [
+                  {
+                    name: "name",
+                    type: "string",
+                    operator: "contains",
+                    value: "does-not-exist",
+                  },
+                ]
+              : undefined
+          }
+          i18n={{
+            noRecords: "Localized empty fallback",
+            customEmptyKey: "Localized custom empty",
+          }}
+          {...emptyTextProps}
+        />
+      </FixtureFrame>
+    </div>
+  );
+}
+
+type RowHeightSnapshot = {
+  domHeight: number | null;
+  virtualHeight: number | null;
+  totalHeight: number | null;
+};
+
+function RowHeightAuthorityScenario() {
+  const scopeRef = React.useRef<HTMLDivElement | null>(null);
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [snapshot, setSnapshot] = React.useState<RowHeightSnapshot>({
+    domHeight: null,
+    virtualHeight: null,
+    totalHeight: null,
+  });
+  const rows = React.useMemo(
+    () =>
+      Array.from({ length: 20 }, (_, index) => ({
+        id: `height-row-${index + 1}`,
+        name: `Height row ${index + 1}`,
+        team: "Sizing",
+      })),
+    []
+  );
+
+  const capture = React.useCallback(() => {
+    const firstRow = scopeRef.current?.querySelector<HTMLElement>(
+      '[data-slot="grid-row"][data-row-id="height-row-1"]'
+    );
+    const virtualList = apiRef.current?.getVirtualList();
+    const virtualRow = virtualList?.getRows().find((row) => row.rowIndex === 0);
+
+    setSnapshot({
+      domHeight: firstRow
+        ? Math.round(firstRow.getBoundingClientRect().height)
+        : null,
+      virtualHeight:
+        typeof virtualRow?.height === "number"
+          ? Math.round(virtualRow.height)
+          : null,
+      totalHeight:
+        typeof virtualList?.getTotalRowHeight() === "number"
+          ? Math.round(virtualList.getTotalRowHeight())
+          : null,
+    });
+  }, []);
+
+  return (
+    <div ref={scopeRef} className="space-y-3">
+      <Button
+        type="button"
+        data-testid="capture-row-height-authority"
+        onClick={capture}
+      >
+        Capture row height
+      </Button>
+      <JsonOutput testId="row-height-authority-state" value={snapshot} />
+      <FixtureFrame className="h-[300px] w-[560px]">
+        <CommonPendingGrid
+          idProperty="id"
+          columns={baseColumns}
+          dataSource={rows}
+          columnOrder={["id", "name", "team"]}
+          virtualized
+          rowHeight={60}
+          minRowHeight={80}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+          }}
+        />
+      </FixtureFrame>
+    </div>
+  );
+}
+
+type EditingCoordinateMode = "column" | "row";
+
+function EditingCoordinateScenario(props: { mode: EditingCoordinateMode }) {
+  const [columnOrder, setColumnOrder] = React.useState(["name", "team"]);
+  const [rows, setRows] = React.useState([
+    { id: "edit-r1", name: "Name one", team: "Team one" },
+    { id: "edit-r2", name: "Name two", team: "Team two" },
+  ]);
+  const [events, setEvents] = React.useState<
+    Array<{
+      type: "stop" | "complete";
+      rowId: string | number;
+      rowIndex: number;
+      columnId: string;
+      columnIndex: number;
+      value: unknown;
+    }>
+  >([]);
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "name", header: "Name", width: 220 },
+      { name: "team", header: "Team", width: 220 },
+    ],
+    []
+  );
+
+  const appendEvent = React.useCallback(
+    (type: "stop" | "complete", info: TypeEditInfo) => {
+      setEvents((current) => [
+        ...current,
+        {
+          type,
+          rowId: info.rowId,
+          rowIndex: info.rowIndex,
+          columnId: String(info.columnId),
+          columnIndex: info.columnIndex,
+          value: info.value ?? null,
+        },
+      ]);
+    },
+    []
+  );
+
+  return (
+    <div className="space-y-3">
+      <Button
+        type="button"
+        data-testid={
+          props.mode === "column" ? "reorder-edit-columns" : "reorder-edit-rows"
+        }
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => {
+          if (props.mode === "column") {
+            setColumnOrder(["team", "name"]);
+          } else {
+            setRows((current) => [current[1]!, current[0]!]);
+          }
+        }}
+      >
+        Reorder while editing
+      </Button>
+      <JsonOutput testId="editing-coordinate-events" value={events} />
+      <FixtureFrame className="h-[280px] w-[560px]">
+        <CommonPendingGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          columnOrder={columnOrder}
+          virtualized={false}
+          editable
+          onEditStop={(info) => appendEvent("stop", info)}
+          onEditComplete={(info) => appendEvent("complete", info)}
+        />
+      </FixtureFrame>
+    </div>
+  );
+}
+
+function ZebraImperativeScenario() {
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [hasSetter, setHasSetter] = React.useState<boolean | null>(null);
+
+  return (
+    <div className="space-y-3">
+      <Button
+        type="button"
+        data-testid="disable-zebra-imperatively"
+        onClick={() => {
+          const setter = apiRef.current?.setShowZebraRows;
+          setHasSetter(typeof setter === "function");
+          setter?.((current: boolean) => !current);
+        }}
+      >
+        Disable zebra rows
+      </Button>
+      <output data-testid="zebra-setter-present">
+        {hasSetter == null ? "unknown" : String(hasSetter)}
+      </output>
+      <FixtureFrame className="h-[260px] w-[560px]">
+        <CommonPendingGrid
+          idProperty="id"
+          columns={baseColumns}
+          dataSource={baseRows}
+          columnOrder={["id", "name", "team"]}
+          virtualized={false}
+          defaultShowZebraRows
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+          }}
+        />
+      </FixtureFrame>
+    </div>
+  );
+}
+
+function ScenarioContent(props: { scenario: PendingScenario }) {
+  switch (props.scenario) {
+    case "filter-callback":
+      return <FilterCallbackScenario />;
+    case "selection-enable":
+      return <SelectionScenario mode="enable" />;
+    case "selection-derived":
+      return <SelectionScenario mode="derived" />;
+    case "selection-disable":
+      return <SelectionScenario mode="disable" />;
+    case "selection-disable-controlled":
+      return <SelectionScenario mode="disable-controlled" />;
+    case "selection-callback-only":
+      return <SelectionScenario mode="callback-only" />;
+    case "columns-default-15":
+    case "columns-default-14":
+    case "columns-threshold-at":
+    case "columns-threshold-below":
+    case "columns-force-on":
+    case "columns-force-off":
+    case "columns-function-height":
+    case "columns-natural-height":
+    case "columns-scroll":
+      return <ColumnVirtualizationScenario scenario={props.scenario} />;
+    case "empty-literal":
+    case "empty-key":
+    case "empty-node":
+    case "empty-function":
+    case "empty-null":
+    case "empty-false":
+    case "empty-string":
+    case "empty-loading":
+    case "empty-filtered":
+    case "empty-remote":
+    case "empty-mobile":
+      return <EmptyTextScenario scenario={props.scenario} />;
+    case "row-height-authority":
+      return <RowHeightAuthorityScenario />;
+    case "editing-column-coordinate":
+      return <EditingCoordinateScenario mode="column" />;
+    case "editing-row-coordinate":
+      return <EditingCoordinateScenario mode="row" />;
+    case "zebra-imperative":
+      return <ZebraImperativeScenario />;
+    default:
+      return null;
+  }
+}
+
+export default function InovuaPendingParityCompatPage() {
+  const scenario = readScenario();
+
+  return (
+    <main
+      className="flex min-w-0 flex-col gap-4 rounded-2xl border bg-background p-5"
+      data-testid="inovua-pending-parity-scenario"
+      data-scenario={scenario}
+    >
+      <h1 className="text-xl font-semibold">
+        Pending Inovua parity: {scenario}
+      </h1>
+      <ScenarioContent scenario={scenario} />
+    </main>
+  );
+}

--- a/examples/src/InovuaPendingParityCompatPage.tsx
+++ b/examples/src/InovuaPendingParityCompatPage.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import ReactDataGrid, {
   type TypeColumns,
+  type TypeColumnFilterValueChangeArg,
   type TypeComputedProps,
   type TypeDataGridProps,
   type TypeEditInfo,
@@ -78,23 +79,6 @@ const scenarios = new Set<PendingScenario>([
   "zebra-imperative",
 ]);
 
-type PendingColumnFilterValueChange = {
-  filterValue: TypeSingleFilterValue;
-  columnId: string;
-  columnIndex: number;
-  cellProps?: Record<string, unknown>;
-};
-
-type PendingCompatGridProps = TypeDataGridProps & {
-  onColumnFilterValueChange?: (event: PendingColumnFilterValueChange) => void;
-  enableSelection?: boolean;
-  virtualizeColumnsThreshold?: number;
-  virtualizeColumns?: boolean;
-};
-
-const PendingCompatGrid =
-  ReactDataGrid as React.ComponentType<PendingCompatGridProps>;
-
 const baseRows = [
   { id: "row-1", name: "Ada Lovelace", team: "Analytics" },
   { id: "row-2", name: "Grace Hopper", team: "Compilers" },
@@ -130,11 +114,11 @@ function FixtureFrame(props: {
   );
 }
 
-function CommonPendingGrid(props: PendingCompatGridProps) {
+function CommonPendingGrid(props: TypeDataGridProps) {
   const { gridTheme, i18n, resizable, showCellBorders } = useExamplesUi();
 
   return (
-    <PendingCompatGrid
+    <ReactDataGrid
       enableColumnFilterContextMenu={false}
       enableColumnAutosize={false}
       skipHeaderOnAutoSize={false}
@@ -191,7 +175,7 @@ type FilterLogEvent =
   | { kind: "aggregate"; filterValue: TypeFilterValue };
 
 function sanitizeColumnFilterEvent(
-  event: PendingColumnFilterValueChange
+  event: TypeColumnFilterValueChangeArg
 ): FilterLogEvent {
   const cellProps = event.cellProps;
   const nestedColumn = cellProps?.column as Record<string, unknown> | undefined;
@@ -312,7 +296,7 @@ type SelectionMode =
 
 function SelectionScenario(props: { mode: SelectionMode }) {
   const [events, setEvents] = React.useState<TypeOnSelectionChangeArg[]>([]);
-  const common: PendingCompatGridProps = {
+  const common: TypeDataGridProps = {
     idProperty: "id",
     columns: baseColumns,
     dataSource: baseRows,
@@ -654,7 +638,7 @@ function EmptyTextScenario(props: { scenario: PendingScenario }) {
   const dataSource = config.remote ? remoteSource : rows;
   const emptyTextProps = {
     emptyText: config.content,
-  } as Pick<PendingCompatGridProps, "emptyText">;
+  } satisfies Pick<TypeDataGridProps, "emptyText">;
 
   return (
     <div className="space-y-3">
@@ -958,7 +942,7 @@ export default function InovuaPendingParityCompatPage() {
       data-scenario={scenario}
     >
       <h1 className="text-xl font-semibold">
-        Pending Inovua parity: {scenario}
+        Inovua parity contract: {scenario}
       </h1>
       <ScenarioContent scenario={scenario} />
     </main>

--- a/examples/src/InovuaPendingParityCompatPage.tsx
+++ b/examples/src/InovuaPendingParityCompatPage.tsx
@@ -90,7 +90,6 @@ type PendingCompatGridProps = TypeDataGridProps & {
   enableSelection?: boolean;
   virtualizeColumnsThreshold?: number;
   virtualizeColumns?: boolean;
-  emptyText?: React.ReactNode | (() => React.ReactNode);
 };
 
 const PendingCompatGrid =

--- a/examples/src/SelectionGridExample.tsx
+++ b/examples/src/SelectionGridExample.tsx
@@ -297,7 +297,10 @@ export default function SelectionGridExample() {
     columns.map((column) => column.name ?? "")
   );
   const [filteredCount, setFilteredCount] = useState(rows.length);
-  const selectedMap = useMemo(() => extractSelectedMap(selectedRows), [selectedRows]);
+  const selectedMap = useMemo(
+    () => extractSelectedMap(selectedRows),
+    [selectedRows]
+  );
 
   const selectedAccounts = useMemo(() => {
     return Object.values(selectedMap);
@@ -405,6 +408,8 @@ export default function SelectionGridExample() {
           filteredRowsCount={setFilteredCount}
           onColumnOrderChange={setColumnOrder}
           virtualized={false}
+          rowHeight={null}
+          minRowHeight={52}
           columnUserSelect
           enableColumnAutosize={false}
           skipHeaderOnAutoSize={false}

--- a/examples/src/UsersGridExample.tsx
+++ b/examples/src/UsersGridExample.tsx
@@ -1,5 +1,5 @@
-import { Download, EyeOff, Filter, FilterX, Pencil, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Download, Filter, FilterX, Pencil, Trash2 } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import ReactDataGrid, {
   DateFilter,
@@ -7,6 +7,7 @@ import ReactDataGrid, {
   SelectFilter,
   type TypeColumn,
   type TypeColumns,
+  type TypeComputedProps,
   type TypeFilterValue,
   type TypeI18n,
   type TypeShowCellBorders,
@@ -33,6 +34,13 @@ const roleOptions = [
 ];
 
 const languageOptions = ["en", "de", "fr", "it"];
+const dateTimeFormatter = new Intl.DateTimeFormat("en-GB", {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
 
 type ExportFormat = "csv" | "json";
 
@@ -70,11 +78,17 @@ function getColumnId(column: TypeColumn): string {
 }
 
 function getColumnLabel(column: TypeColumn): string {
-  return typeof column.header === "string" ? column.header : getColumnId(column);
+  return typeof column.header === "string"
+    ? column.header
+    : getColumnId(column);
 }
 
 function extractCellValue(valueOrCellProps: unknown): unknown {
-  if (typeof valueOrCellProps === "object" && valueOrCellProps !== null && "value" in valueOrCellProps) {
+  if (
+    typeof valueOrCellProps === "object" &&
+    valueOrCellProps !== null &&
+    "value" in valueOrCellProps
+  ) {
     return (valueOrCellProps as { value?: unknown }).value;
   }
 
@@ -82,7 +96,11 @@ function extractCellValue(valueOrCellProps: unknown): unknown {
 }
 
 function extractRowData(valueOrCellProps: unknown): ExampleUser | null {
-  if (typeof valueOrCellProps === "object" && valueOrCellProps !== null && "data" in valueOrCellProps) {
+  if (
+    typeof valueOrCellProps === "object" &&
+    valueOrCellProps !== null &&
+    "data" in valueOrCellProps
+  ) {
     return (valueOrCellProps as { data?: ExampleUser }).data ?? null;
   }
 
@@ -95,13 +113,7 @@ function formatDateTime(value: unknown): string {
   const date = value instanceof Date ? value : new Date(String(value));
   if (Number.isNaN(date.getTime())) return String(value);
 
-  return new Intl.DateTimeFormat("en-GB", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
+  return dateTimeFormatter.format(date);
 }
 
 function formatBooleanPill(value: boolean) {
@@ -118,7 +130,10 @@ function formatBooleanPill(value: boolean) {
   );
 }
 
-function getUserFieldValue(row: ExampleUser, columnId: keyof ExampleUser): ExampleUser[keyof ExampleUser] {
+function getUserFieldValue(
+  row: ExampleUser,
+  columnId: keyof ExampleUser
+): ExampleUser[keyof ExampleUser] {
   return row[columnId];
 }
 
@@ -135,8 +150,12 @@ function createUsers(): ExampleUser[] {
       csrolename: role,
       csemail: `user.${id}@ikarus.demo`,
       failed_login_attempts: index % 5,
-      date_last_successful_login: new Date(Date.UTC(2026, 1, 10 + (index % 18), 8 + (index % 9), 15)).toISOString(),
-      date_pwdchanged: new Date(Date.UTC(2026, 0, 2 + (index % 24), 6 + (index % 7), 45)).toISOString(),
+      date_last_successful_login: new Date(
+        Date.UTC(2026, 1, 10 + (index % 18), 8 + (index % 9), 15)
+      ).toISOString(),
+      date_pwdchanged: new Date(
+        Date.UTC(2026, 0, 2 + (index % 24), 6 + (index % 7), 45)
+      ).toISOString(),
       lang: language,
       disabled,
       tfa_enabled: tfaEnabled,
@@ -165,9 +184,15 @@ function downloadTextFile(filename: string, content: string, mimeType: string) {
 }
 
 function orderColumns(columns: TypeColumns, order: string[]) {
-  const indexed = new Map(columns.map((column) => [getColumnId(column), column]));
-  const ordered = order.map((columnId) => indexed.get(columnId)).filter((column): column is TypeColumn => Boolean(column));
-  const remaining = columns.filter((column) => !order.includes(getColumnId(column)));
+  const indexed = new Map(
+    columns.map((column) => [getColumnId(column), column])
+  );
+  const ordered = order
+    .map((columnId) => indexed.get(columnId))
+    .filter((column): column is TypeColumn => Boolean(column));
+  const remaining = columns.filter(
+    (column) => !order.includes(getColumnId(column))
+  );
   return [...ordered, ...remaining];
 }
 
@@ -180,9 +205,14 @@ function UsersToolbar({
   onToggleFilters,
   onExport,
 }: UsersToolbarProps) {
-  const orderedColumns = useMemo(() => orderColumns(columns, order), [columns, order]);
+  const orderedColumns = useMemo(
+    () => orderColumns(columns, order),
+    [columns, order]
+  );
 
-  const visibleColumnNames = selectedColumns.filter((name) => name !== FILTER_RESERVED_COLNAME);
+  const visibleColumnNames = selectedColumns.filter(
+    (name) => name !== FILTER_RESERVED_COLNAME
+  );
   const visibleSet = new Set(visibleColumnNames);
 
   function toggleColumn(columnName: string) {
@@ -193,7 +223,9 @@ function UsersToolbar({
     }
 
     if (isVisible) {
-      onSelectedColumnsChange(visibleColumnNames.filter((name) => name !== columnName));
+      onSelectedColumnsChange(
+        visibleColumnNames.filter((name) => name !== columnName)
+      );
       return;
     }
 
@@ -205,12 +237,16 @@ function UsersToolbar({
       <div className="flex flex-col gap-1">
         <div className="text-sm font-medium">Visible columns</div>
         <div className="text-xs text-muted-foreground">
-          Toggle columns, export the current dataset shape, and show or hide the filter row.
+          Toggle columns, export the current dataset shape, and show or hide the
+          filter row.
         </div>
       </div>
 
       <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-        <ButtonGroup aria-label="Visible column toggles" className="flex max-w-full flex-wrap gap-2">
+        <ButtonGroup
+          aria-label="Visible column toggles"
+          className="flex max-w-full flex-wrap gap-2"
+        >
           {orderedColumns.map((column) => {
             const columnId = getColumnId(column);
             const isVisible = visibleSet.has(columnId);
@@ -222,9 +258,9 @@ function UsersToolbar({
                 variant={isVisible ? "secondary" : "outline"}
                 size="sm"
                 className="rounded-md"
+                aria-pressed={isVisible}
                 onClick={() => toggleColumn(columnId)}
               >
-                {isVisible ? null : <EyeOff className="size-3.5" />}
                 {getColumnLabel(column)}
               </Button>
             );
@@ -243,14 +279,27 @@ function UsersToolbar({
               <DropdownMenuLabel>Download example data</DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuGroup>
-                <DropdownMenuItem onSelect={() => onExport("csv")}>Export CSV</DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => onExport("json")}>Export JSON</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onExport("csv")}>
+                  Export CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onExport("json")}>
+                  Export JSON
+                </DropdownMenuItem>
               </DropdownMenuGroup>
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <Button type="button" variant={filtersActive ? "secondary" : "outline"} size="sm" onClick={onToggleFilters}>
-            {filtersActive ? <FilterX className="size-4" /> : <Filter className="size-4" />}
+          <Button
+            type="button"
+            variant={filtersActive ? "secondary" : "outline"}
+            size="sm"
+            onClick={onToggleFilters}
+          >
+            {filtersActive ? (
+              <FilterX className="size-4" />
+            ) : (
+              <Filter className="size-4" />
+            )}
             {filtersActive ? "Hide filters" : "Show filters"}
           </Button>
         </div>
@@ -272,14 +321,29 @@ export default function UsersGridExample({
       { name: "csuserid", operator: "eq", type: "string", value: "" },
       { name: "csrolename", operator: "eq", type: "select", value: null },
       { name: "csemail", operator: "contains", type: "string", value: "" },
-      { name: "failed_login_attempts", operator: "eq", type: "number", value: null },
-      { name: "date_last_successful_login", operator: "afterOrOn", type: "date", value: null },
-      { name: "date_pwdchanged", operator: "afterOrOn", type: "date", value: null },
+      {
+        name: "failed_login_attempts",
+        operator: "eq",
+        type: "number",
+        value: null,
+      },
+      {
+        name: "date_last_successful_login",
+        operator: "afterOrOn",
+        type: "date",
+        value: null,
+      },
+      {
+        name: "date_pwdchanged",
+        operator: "afterOrOn",
+        type: "date",
+        value: null,
+      },
       { name: "lang", operator: "eq", type: "select", value: null },
       { name: "disabled", operator: "eq", type: "select", value: null },
       { name: "tfa_enabled", operator: "eq", type: "select", value: null },
     ],
-    [],
+    []
   );
 
   const baseColumns = useMemo<TypeColumns>(
@@ -314,6 +378,7 @@ export default function UsersGridExample({
         header: "Failed logins",
         defaultWidth: 152,
         defaultHidden: true,
+        visible: false,
         type: "number",
         filterType: "number",
         filterEditor: NumberFilter,
@@ -322,6 +387,7 @@ export default function UsersGridExample({
         name: "date_last_successful_login",
         header: "Last login",
         defaultHidden: true,
+        visible: false,
         defaultWidth: 212,
         filterType: "date",
         filterEditor: DateFilter,
@@ -335,6 +401,7 @@ export default function UsersGridExample({
         name: "date_pwdchanged",
         header: "Password changed",
         defaultHidden: true,
+        visible: false,
         defaultWidth: 212,
         filterType: "date",
         filterEditor: DateFilter,
@@ -349,11 +416,15 @@ export default function UsersGridExample({
         header: "Language",
         defaultWidth: 132,
         defaultHidden: true,
+        visible: false,
         filterType: "select",
         filterEditor: SelectFilter,
         filterEditorProps: {
           placeholder: "All languages",
-          dataSource: languageOptions.map((language) => ({ id: language, label: language.toUpperCase() })),
+          dataSource: languageOptions.map((language) => ({
+            id: language,
+            label: language.toUpperCase(),
+          })),
         },
         render: (valueOrCellProps: unknown) =>
           String(extractCellValue(valueOrCellProps) ?? "").toUpperCase(),
@@ -431,12 +502,16 @@ export default function UsersGridExample({
         },
       },
     ],
-    [],
+    []
   );
 
-  const [columnOrder, setColumnOrder] = useState<string[]>(() => baseColumns.map(getColumnId));
+  const [columnOrder, setColumnOrder] = useState<string[]>(() =>
+    baseColumns.map(getColumnId)
+  );
   const [selectedColumns, setSelectedColumns] = useState<string[]>(() => [
-    ...baseColumns.filter((column) => column.defaultHidden !== true).map(getColumnId),
+    ...baseColumns
+      .filter((column) => column.defaultHidden !== true)
+      .map(getColumnId),
     FILTER_RESERVED_COLNAME,
   ]);
   const [filteredRows, setFilteredRows] = useState(rows.length);
@@ -444,22 +519,33 @@ export default function UsersGridExample({
   const filtersActive = selectedColumns.includes(FILTER_RESERVED_COLNAME);
   const visibleColumnNames = useMemo(
     () => selectedColumns.filter((name) => name !== FILTER_RESERVED_COLNAME),
-    [selectedColumns],
+    [selectedColumns]
   );
+  const gridApiRef = useRef<TypeComputedProps | null>(null);
 
-  const gridColumns = useMemo(
-    () => baseColumns.filter((column) => visibleColumnNames.includes(getColumnId(column))),
-    [baseColumns, visibleColumnNames],
-  );
-  const gridColumnOrder = useMemo(
-    () =>
-      orderColumns(baseColumns, columnOrder)
-        .map((column) => getColumnId(column))
-        .filter((columnId) => visibleColumnNames.includes(columnId)),
-    [baseColumns, columnOrder, visibleColumnNames],
+  const captureGridApi = useCallback(
+    (ref: { current: TypeComputedProps | null }) => {
+      gridApiRef.current = ref.current;
+    },
+    []
   );
 
   function handleSelectedColumnsChange(nextColumns: string[]) {
+    const currentVisible = new Set(visibleColumnNames);
+    const nextVisible = new Set(nextColumns);
+
+    // Visibility is presentation state. Keep the complete column model stable
+    // so toggling one button does not recreate TanStack definitions, rerun the
+    // local data pipeline, or remount every filter editor.
+    for (const column of baseColumns) {
+      const columnId = getColumnId(column);
+      const wasVisible = currentVisible.has(columnId);
+      const willBeVisible = nextVisible.has(columnId);
+      if (wasVisible !== willBeVisible) {
+        gridApiRef.current?.setColumnVisible?.(columnId, willBeVisible);
+      }
+    }
+
     const filtersMarker = filtersActive ? [FILTER_RESERVED_COLNAME] : [];
     setSelectedColumns([...nextColumns, ...filtersMarker]);
   }
@@ -468,16 +554,18 @@ export default function UsersGridExample({
     setSelectedColumns((current) =>
       current.includes(FILTER_RESERVED_COLNAME)
         ? current.filter((name) => name !== FILTER_RESERVED_COLNAME)
-        : [...current, FILTER_RESERVED_COLNAME],
+        : [...current, FILTER_RESERVED_COLNAME]
     );
     setFilteredRows(rows.length);
   }
 
   function handleExport(format: ExportFormat) {
-    const exportColumns = orderColumns(baseColumns, columnOrder).filter((column) => {
-      const columnId = getColumnId(column);
-      return selectedColumns.includes(columnId) && columnId !== "actions";
-    });
+    const exportColumns = orderColumns(baseColumns, columnOrder).filter(
+      (column) => {
+        const columnId = getColumnId(column);
+        return selectedColumns.includes(columnId) && columnId !== "actions";
+      }
+    );
 
     const exportedRows = rows.map((row) =>
       Object.fromEntries(
@@ -488,21 +576,34 @@ export default function UsersGridExample({
               ? row[columnId as "disabled" | "tfa_enabled"]
                 ? "Yes"
                 : "No"
-              : columnId === "date_last_successful_login" || columnId === "date_pwdchanged"
-                ? formatDateTime(row[columnId as "date_last_successful_login" | "date_pwdchanged"])
+              : columnId === "date_last_successful_login" ||
+                  columnId === "date_pwdchanged"
+                ? formatDateTime(
+                    row[
+                      columnId as
+                        | "date_last_successful_login"
+                        | "date_pwdchanged"
+                    ]
+                  )
                 : getUserFieldValue(row, columnId as keyof ExampleUser);
 
           return [getColumnLabel(column), value];
-        }),
-      ),
+        })
+      )
     );
 
     if (format === "json") {
-      downloadTextFile("users-grid.json", JSON.stringify(exportedRows, null, 2), "application/json;charset=utf-8");
+      downloadTextFile(
+        "users-grid.json",
+        JSON.stringify(exportedRows, null, 2),
+        "application/json;charset=utf-8"
+      );
       return;
     }
 
-    const header = exportColumns.map((column) => escapeCsv(getColumnLabel(column))).join(",");
+    const header = exportColumns
+      .map((column) => escapeCsv(getColumnLabel(column)))
+      .join(",");
     const body = exportedRows
       .map((row) =>
         exportColumns
@@ -510,11 +611,15 @@ export default function UsersGridExample({
             const key = getColumnLabel(column);
             return escapeCsv(row[key]);
           })
-          .join(","),
+          .join(",")
       )
       .join("\n");
 
-    downloadTextFile("users-grid.csv", `${header}\n${body}`, "text/csv;charset=utf-8");
+    downloadTextFile(
+      "users-grid.csv",
+      `${header}\n${body}`,
+      "text/csv;charset=utf-8"
+    );
   }
 
   return (
@@ -522,16 +627,19 @@ export default function UsersGridExample({
       <div className="space-y-1">
         <h2 className="text-lg font-semibold">Users-style example</h2>
         <p className="text-sm text-muted-foreground">
-          A fuller integration example with optional columns, export actions, row actions, and mixed string, select,
-          number, and date filters.
+          A fuller integration example with optional columns, export actions,
+          row actions, and mixed string, select, number, and date filters.
         </p>
       </div>
 
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>
-          Filtered users: <span className="font-mono">{filteredRows}</span> / {rows.length}
+          Filtered users: <span className="font-mono">{filteredRows}</span> /{" "}
+          {rows.length}
         </span>
-        <span>Reorder columns directly in the grid to update the toolbar order.</span>
+        <span>
+          Reorder columns directly in the grid to update the toolbar order.
+        </span>
       </div>
 
       <UsersToolbar
@@ -544,27 +652,29 @@ export default function UsersGridExample({
         onExport={handleExport}
       />
 
-      <ReactDataGrid
-        key={filtersActive ? "users-grid-filters-on" : "users-grid-filters-off"}
-        theme={theme}
-        idProperty="csuserid"
-        columns={gridColumns}
-        dataSource={rows}
-        columnOrder={gridColumnOrder}
-        enableColumnFilterContextMenu
-        enableColumnAutosize
-        skipHeaderOnAutoSize={false}
-        resizable={resizable}
-        enableFiltering={filtersActive}
-        defaultFilterValue={defaultFilterValue}
-        filteredRowsCount={setFilteredRows}
-        onColumnOrderChange={setColumnOrder}
-        virtualized
-        columnUserSelect
-        showCellBorders={showCellBorders}
-        i18n={i18n}
-        showColumnMenuTool={false}
-      />
+      <div className="h-[32rem] min-h-0" data-testid="users-grid-viewport">
+        <ReactDataGrid
+          theme={theme}
+          idProperty="csuserid"
+          columns={baseColumns}
+          dataSource={rows}
+          columnOrder={columnOrder}
+          enableColumnFilterContextMenu
+          enableColumnAutosize
+          skipHeaderOnAutoSize={false}
+          resizable={resizable}
+          enableFiltering={filtersActive}
+          defaultFilterValue={defaultFilterValue}
+          filteredRowsCount={setFilteredRows}
+          onColumnOrderChange={setColumnOrder}
+          virtualized
+          columnUserSelect
+          showCellBorders={showCellBorders}
+          i18n={i18n}
+          showColumnMenuTool={false}
+          handle={captureGridApi}
+        />
+      </div>
     </section>
   );
 }

--- a/examples/src/docs/CopyableCodeBlock.tsx
+++ b/examples/src/docs/CopyableCodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { Highlight, themes, type Language } from "prism-react-renderer";
 
@@ -92,29 +92,11 @@ export default function CopyableCodeBlock(props: CopyableCodeBlockProps) {
     }, 1500);
   };
 
-  const handleKeyDown = async (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "Enter" && event.key !== " ") {
-      return;
-    }
-
-    event.preventDefault();
-    await handleCopy();
-  };
-
   return (
     <div
-      role="button"
-      tabIndex={0}
-      aria-label={`Copy ${headerLabel} code block`}
       data-testid={`copy-code-block-${headerLabel.toLowerCase()}`}
-      onClick={() => {
-        void handleCopy();
-      }}
-      onKeyDown={(event) => {
-        void handleKeyDown(event);
-      }}
       className={[
-        "group cursor-copy overflow-hidden rounded-2xl border bg-card text-left text-card-foreground shadow-sm transition-colors hover:border-ring/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "group overflow-hidden rounded-2xl border bg-card text-left text-card-foreground shadow-sm transition-colors hover:border-ring/30",
         className,
       ]
         .filter(Boolean)

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -406,7 +406,9 @@ function SectionBody(props: { section: ReferenceSection }) {
           {section.title}
         </h2>
       </div>
-      {section.body}
+      <div className="min-w-0 space-y-4 [&_ol]:max-w-prose [&_p]:max-w-prose [&_ul]:max-w-prose">
+        {section.body}
+      </div>
       {section.rows ? <ReferenceTable rows={section.rows} /> : null}
     </section>
   );
@@ -1942,14 +1944,14 @@ const computedPropsRows: ReferenceRow[] = [
     type: "methods and fields",
     defaultValue: "implemented",
     description:
-      "Horizontal/vertical get, set, and increment methods; scrollToIndex/Id/Cell/Column; scrollToIndexIfNeeded; first-visible/rendered/fully-visible checks; getRenderRange; and scrollbar flags. duration/force options are accepted but not acted on.",
+      "Horizontal/vertical get, set, and increment methods; scrollToIndex/Id/Cell/Column; scrollToIndexIfNeeded; first-visible/rendered/fully-visible checks; getRenderRange; and scrollbar flags. scrollToIndex duration/force options are accepted but are not yet acted on.",
   },
   {
     name: "Virtual-list adapter",
     type: "getVirtualList()",
     defaultValue: "implemented subset",
     description:
-      "getVirtualList exposes getContainerNode/getScrollerNode/getScrollingElement, height/scroll/client-size reads, getRows/forEachRow/getRowAt, visible count/range, setRowIndex, scrollToIndex/smoothScrollTo, refresh/update, visibility/rendered-index checks, and max render count. Ranges include overscan and measured natural rows report their current sizes.",
+      "getVirtualList exposes getContainerNode/getScrollerNode/getScrollingElement, height/scroll/client-size reads, getRows/forEachRow/getRowAt, visible count/range, setRowIndex, scrollToIndex/smoothScrollTo, refresh/update, visibility/rendered-index checks, and max render count. Inovua's smoothScrollTo(value, config, callback) pixel contract is preserved, including vertical/horizontal orientation, duration, and completion value. Ranges include overscan and measured natural rows report zero-based offsets and their current sizes.",
   },
   {
     name: "Editing",
@@ -4889,6 +4891,37 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                 implementation.
               </li>
             </ul>
+          </div>
+        ),
+      },
+      {
+        id: "internal-engine-boundary",
+        title: "Internal engine boundary",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              The Inovua-facing contract remains the canonical public API.
+              Consumers configure the grid with the documented Inovua-shaped
+              props, columns, state, callbacks, and imperative methods; TanStack
+              types and state shapes are internal implementation details and do
+              not replace that migration surface.
+            </p>
+            <p>
+              Internally, responsibilities are deliberately split. TanStack
+              Table provides the column, header, controlled-state, and pixel
+              geometry engine. TanStack Virtual provides the row and column
+              render windows because Table is headless and does not perform
+              virtualization itself.
+            </p>
+            <p>
+              Compatibility adapters preserve behavior that cannot be delegated
+              directly to those engines: Inovua <code>flex</code> and{" "}
+              <code>defaultFlex</code> allocation, selection callback payloads,
+              complete filter metadata, local and remote data-source semantics,
+              and the editing lifecycle. This boundary lets the implementation
+              use TanStack without asking an existing Inovua application to
+              rewrite its business logic or adopt additional public props.
+            </p>
           </div>
         ),
       },

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -596,6 +596,13 @@ const reactDataGridPropSections: ReferenceSection[] = [
           "Turns header drag-resize handles on or off. Mouse, pen, and touch use the same pointer lifecycle. Controlled column.width stays authoritative; uncontrolled defaultWidth can retain a drag result.",
       },
       {
+        name: "liveColumnResize",
+        type: "boolean",
+        defaultValue: "false",
+        description:
+          "the-datagrid extension that updates header and body column geometry while the resize pointer moves. Pointer events are coalesced to animation frames, and onColumnResize remains a single completion callback. When false, the grid keeps the Inovua-compatible resize proxy until drop.",
+      },
+      {
         name: "onColumnResize",
         type: "(info, context) => void",
         defaultValue: "-",
@@ -1218,6 +1225,20 @@ function createInovuaStatusPage(): DocsPage {
               flex columns are reported with flex payloads in the same commit.
             </p>
             <p>
+              <strong className="text-foreground">
+                Live preview extension.
+              </strong>{" "}
+              Inovua Community uses a resize proxy and commits on release.
+              the-datagrid preserves that behavior by default and adds the
+              opt-in <code>liveColumnResize</code> prop. Live mode updates the
+              matching header/body column and table geometry at most once per
+              animation frame without rerendering the row model for every
+              pointer event. <code>onColumnResize</code> remains
+              completion-only, cancellation restores the original geometry, and
+              a controlled width returns to its prop value unless the consumer
+              applies the proposal.
+            </p>
+            <p>
               <strong className="text-foreground">Flex allocation.</strong>{" "}
               Inovua uses <code>flex</code> and <code>defaultFlex</code> to
               distribute remaining viewport width by weight: subject to min/max
@@ -1231,7 +1252,8 @@ function createInovuaStatusPage(): DocsPage {
             <p>
               <strong className="text-foreground">Verified behavior.</strong>{" "}
               Focused tests cover the resize payload, controlled-width
-              authority, proportional flex allocation, and natural-row
+              authority, live header/body geometry, burst coalescing and
+              cleanup, proportional flex allocation, and natural-row
               remeasurement after width changes.
             </p>
             <p>
@@ -3241,6 +3263,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
   enableColumnAutosize: true,
   skipHeaderOnAutoSize: false,
   resizable: true,
+  liveColumnResize: false,
   enableFiltering: true,
   filterTypes: DEFAULT_FILTER_TYPES,
   virtualized: true,
@@ -3381,7 +3404,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "mouse, pen, touch / double-click",
         defaultValue: "enabled",
         description:
-          "Enabled handles use pointer capture, clamp drag widths, and report completion through onColumnResize for mouse, pen, and touch. Cancel, blur, responsive changes, and unmount clean up the session. Controlled width/flex remain prop-owned; defaultWidth/defaultFlex are grid-owned starts. Double-click reruns one-column estimation, and natural rows remeasure after width changes.",
+          "Enabled handles use pointer capture, clamp drag widths, and report completion through onColumnResize for mouse, pen, and touch. liveColumnResize opts into animation-frame-coalesced header/body geometry during the gesture; the default keeps Inovua's resize proxy. Cancel, blur, responsive changes, and unmount clean up the session. Controlled width/flex remain prop-owned; defaultWidth/defaultFlex are grid-owned starts. Double-click reruns one-column estimation, and natural rows remeasure after width changes.",
       },
       {
         name: "Header column menu",

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -591,14 +591,14 @@ const reactDataGridPropSections: ReferenceSection[] = [
         type: "boolean",
         defaultValue: "true",
         description:
-          "Turns header drag-resize handles on or off. Controlled column.width stays authoritative; uncontrolled defaultWidth can retain a drag result.",
+          "Turns header drag-resize handles on or off. Mouse, pen, and touch use the same pointer lifecycle. Controlled column.width stays authoritative; uncontrolled defaultWidth can retain a drag result.",
       },
       {
         name: "onColumnResize",
         type: "(info, context) => void",
         defaultValue: "-",
         description:
-          "Reports resize proposals as { column, width, flex } plus { reservedViewportWidth }. Controlled consumers persist the proposed width by returning it through columns.",
+          "Reports mouse, pen, or touch resize proposals on gesture completion as { column, width, flex } plus { reservedViewportWidth }. Controlled consumers persist the proposed width by returning it through columns.",
       },
       {
         name: "enableColumnAutosize",
@@ -620,6 +620,20 @@ const reactDataGridPropSections: ReferenceSection[] = [
         defaultValue: "true",
         description:
           "Enables TanStack row virtualization with overscan of 10. Numeric and functional heights are deterministic; natural rows are measured and remeasured when content or column widths change.",
+      },
+      {
+        name: "virtualizeColumnsThreshold",
+        type: "number",
+        defaultValue: "15",
+        description:
+          "Enables horizontal column virtualization at an inclusive visible-column count. It applies only with a finite numeric rowHeight; functional and natural row heights keep every column mounted.",
+      },
+      {
+        name: "virtualizeColumns",
+        type: "boolean",
+        defaultValue: "inferred from threshold",
+        description:
+          "Explicitly overrides the column-count threshold in either direction. A non-numeric rowHeight still disables column virtualization so row measurement and horizontal geometry cannot split.",
       },
       {
         name: "allowMobileTransform",
@@ -647,14 +661,14 @@ const reactDataGridPropSections: ReferenceSection[] = [
         type: "number | ((rowIndex: number) => number) | null",
         defaultValue: "44",
         description:
-          "Sets one fixed height, computes a height per row, or enables content-driven measured height with null.",
+          "Sets one fixed height, computes a height per row, or enables content-driven measured height with null. A valid numeric height is authoritative and is not raised by minRowHeight or clamped by maxRowHeight.",
       },
       {
         name: "minRowHeight",
         type: "number",
         defaultValue: "20",
         description:
-          "Minimum row height and the initial estimate used before a natural row is measured.",
+          "Minimum and initial estimate for natural rows, and the lower clamp for function-valued heights. It does not override a valid fixed numeric rowHeight.",
       },
       {
         name: "maxRowHeight",
@@ -739,6 +753,13 @@ const reactDataGridPropSections: ReferenceSection[] = [
         type: "(filterValue: TypeFilterValue) => void",
         defaultValue: "-",
         description: "Receives the next filter state after user edits.",
+      },
+      {
+        name: "onColumnFilterValueChange",
+        type: "(event: TypeColumnFilterValueChangeArg) => void",
+        defaultValue: "-",
+        description:
+          "Runs before onFilterValueChange for editor, operator, and clear changes. The payload contains filterValue, columnId, and visible columnIndex; filter-cell gestures also include cellProps, while imperative API calls intentionally omit it.",
       },
       {
         name: "filterTypes",
@@ -860,6 +881,13 @@ const reactDataGridPropSections: ReferenceSection[] = [
     title: "Selection",
     rows: [
       {
+        name: "enableSelection",
+        type: "boolean",
+        defaultValue: "inferred",
+        description:
+          "Explicitly enables or disables selection. When omitted, selected, defaultSelected, or checkboxColumn enables it; onSelectionChange alone does not. false suppresses controlled visuals and makes row/checkbox/imperative selection actions no-ops.",
+      },
+      {
         name: "checkboxColumn",
         type: "boolean | TypeCheckboxColumn",
         defaultValue: "false",
@@ -884,13 +912,14 @@ const reactDataGridPropSections: ReferenceSection[] = [
         type: "(config: TypeOnSelectionChangeArg) => void",
         defaultValue: "-",
         description:
-          "Always emits selected and originalData; UI actions also include the relevant row(s) in data. unselected is optional and built-in toggles do not currently populate it. Direct React setter wiring is supported.",
+          "Observes enabled selection but does not enable it by itself. Emissions contain selected and originalData; UI actions also include the relevant row(s) in data. unselected is optional and built-in toggles do not currently populate it. Direct React setter wiring is supported.",
       },
       {
         name: "multiSelect",
         type: "boolean",
-        defaultValue: "checkboxColumn ? true : false",
-        description: "Enables multi-row selection semantics.",
+        defaultValue: "inferred",
+        description:
+          "Enables multi-row semantics. When omitted, object/boolean selected or defaultSelected values and an uncontrolled checkboxColumn infer true; otherwise it is false.",
       },
       {
         name: "checkboxOnlyRowSelect",
@@ -951,7 +980,7 @@ const reactDataGridPropSections: ReferenceSection[] = [
         type: "(info: TypeEditInfo) => void | Promise<unknown>",
         defaultValue: "-",
         description:
-          "Runs after the editor stops and reports the accepted value. Navigation waits for fulfillment and is suppressed on rejection; the application remains responsible for persisting data.",
+          "Runs after the editor stops and reports the accepted value. Active editing is anchored to the visible row/column coordinate, so a controlled row or column reorder updates payload identity without discarding the draft. Navigation waits for fulfillment and is suppressed on rejection; the application remains responsible for persisting data.",
       },
       {
         name: "onEditCancel",
@@ -979,6 +1008,13 @@ const reactDataGridPropSections: ReferenceSection[] = [
         defaultValue: "built-in fallbacks",
         description:
           "Overrides UI strings such as noRecords, clear, sort labels, and column menu text.",
+      },
+      {
+        name: "emptyText",
+        type: "ReactNode | (() => ReactNode)",
+        defaultValue: '"noRecords"',
+        description:
+          "Renders the empty view after local filtering or remote resolution and in transformed mobile lists. Strings resolve as i18n keys first; nodes and zero-argument functions are preserved. null, false, or an empty string suppresses the content, and loading always hides it.",
       },
       {
         name: "showColumnMenuTool",
@@ -1864,7 +1900,7 @@ const computedPropsRows: ReferenceRow[] = [
     type: "methods and fields",
     defaultValue: "implemented",
     description:
-      "get/setFilterValue, clearAllFilters, clear/get/setColumnFilter, isColumnFiltered, computedFilterValue, and computedFilterValueMap. Setters reset skip to zero.",
+      "get/setFilterValue, clearAllFilters, clear/get/setColumnFilter, isColumnFiltered, computedFilterValue/map, and computedOnColumnFilterValueChange. Column setters accept an optional operator, emit the per-column callback before aggregate state, omit filter-cell-only cellProps, and reset skip to zero.",
   },
   {
     name: "Columns and visibility",
@@ -1878,14 +1914,14 @@ const computedPropsRows: ReferenceRow[] = [
     type: "methods and refs",
     defaultValue: "implemented",
     description:
-      "getDOMNode, getMenuPortalContainer, getScrollingElement, getDOMNodeForRowIndex, getRows, getHeader, focus, blur, setEnableFiltering, setShowHeader, domRef, and bodyRef.",
+      "getDOMNode, getMenuPortalContainer, getScrollingElement, getDOMNodeForRowIndex, getRows, getHeader, focus, blur, setEnableFiltering, setShowHeader, computedShowZebraRows, setShowZebraRows, domRef, and bodyRef. The zebra setter accepts values or functional updates for uncontrolled state and does not override a controlled prop.",
   },
   {
     name: "Mode, border, and layout fields",
     type: "computed fields",
     defaultValue: "implemented readout",
     description:
-      "gridId, size/viewportSize, available/total column widths, column prefix sums/count, maxVisibleRows, border flags, loading/filter/header flags, pagination mode flags, scrollbars, and remoteSort. Non-array source flags also classify static Promises as remote even though their rows compose locally.",
+      "gridId, size/viewportSize, available/total column widths, column prefix sums/count, maxVisibleRows, virtualizeColumns, border flags, loading/filter/header flags, pagination mode flags, scrollbars, and remoteSort. Non-array source flags also classify static Promises as remote even though their rows compose locally.",
   },
   {
     name: "Row lookup",
@@ -1920,7 +1956,7 @@ const computedPropsRows: ReferenceRow[] = [
     type: "fields and methods",
     defaultValue: "implemented",
     description:
-      "computedEditable, computedEditStartEvent, computedIsEditing, isInEdit.current, getCurrentEditInfo, startEdit, tryStartEdit, completeEdit, cancelEdit, and currentEditCompletePromise reflect or control the active cell editor. Start methods return Promises and async completion is session-safe.",
+      "computedEditable, computedEditStartEvent, computedIsEditing, isInEdit.current, getCurrentEditInfo, startEdit, tryStartEdit, completeEdit, cancelEdit, and currentEditCompletePromise reflect or control the active cell editor. Start methods return Promises, async completion is session-safe, and active drafts resolve identity from their current visible coordinate after controlled row/column reorder.",
   },
   {
     name: "Localization and filter menu",
@@ -2689,6 +2725,107 @@ const checkboxRows: ReferenceRow[] = [
 
 const inovuaCompatibilityRows: CompatibilityRow[] = [
   {
+    id: "column-filter-change-callback",
+    feature: "Per-column filter change callback",
+    upstreamContract: (
+      <>
+        <code>onColumnFilterValueChange</code> runs before the aggregate filter
+        callback and reports the descriptor, column identity/index, and optional
+        filter-cell context.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        Editor, operator, clear, and imperative set/clear paths use the same
+        ordered callback. UI paths include <code>cellProps</code>; imperative
+        calls omit it.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Preserve callback ordering and payload identity across controlled,
+        uncontrolled, and imperative filter changes.
+      </>
+    ),
+    status: "compatible",
+  },
+  {
+    id: "selection-enablement",
+    feature: "Selection enablement and precedence",
+    upstreamContract: (
+      <>
+        Explicit <code>enableSelection</code> wins. Otherwise{" "}
+        <code>selected</code>, <code>defaultSelected</code>, or{" "}
+        <code>checkboxColumn</code> enables selection; a callback alone does
+        not.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        The same precedence controls row clicks, checkbox/header actions,
+        controlled visuals, and computed selection methods. Explicit false gates
+        every path.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Keep selection inference deterministic and prevent callbacks or
+        controlled maps from bypassing an explicit false value.
+      </>
+    ),
+    status: "compatible",
+  },
+  {
+    id: "column-virtualization",
+    feature: "Horizontal column virtualization",
+    upstreamContract: (
+      <>
+        A default inclusive threshold of 15 visible columns enables horizontal
+        virtualization for fixed numeric row heights;{" "}
+        <code>virtualizeColumns</code> overrides the threshold.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        Header, filter row, body, scrolling geometry, far-column filtering, and
+        edit metadata share one overscanned render range. Functional/natural row
+        heights and transformed mobile layout disable it.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Preserve total scroll width and header/body alignment while mounting
+        only the active horizontal range and keeping filter/edit APIs usable.
+      </>
+    ),
+    status: "compatible",
+  },
+  {
+    id: "empty-text",
+    feature: "Empty-state content",
+    upstreamContract: (
+      <>
+        <code>emptyText</code> defaults to the <code>noRecords</code> i18n key,
+        accepts content or a zero-argument function, and can be suppressed with
+        null-like values.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        Desktop and transformed-mobile views share that resolver. Empty content
+        appears after local filtering or remote completion and remains hidden
+        while loading.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Keep literal/key precedence, React-node interactivity, suppression, and
+        loading/remote timing consistent in both layouts.
+      </>
+    ),
+    status: "compatible",
+  },
+  {
     id: "natural-row-height",
     feature: "Natural and dynamic row height",
     upstreamContract: (
@@ -2702,7 +2839,8 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
     currentBehavior: (
       <>
         Number, function, and <code>null</code> are supported. Natural rows are
-        measured and honor <code>minRowHeight</code>/<code>maxRowHeight</code>.
+        measured and honor <code>minRowHeight</code>/<code>maxRowHeight</code>;
+        a valid fixed numeric height remains authoritative over those bounds.
       </>
     ),
     requiredOutcome: (
@@ -2751,9 +2889,11 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
     ),
     currentBehavior: (
       <>
-        Dragging emits on pointer release; autosize and computed resize emit
-        when committed. All paths use the original two-argument callback shape
-        with the resolved width/flex and reserved viewport width.
+        Mouse, pen, and touch dragging emit on pointer release; autosize and
+        computed resize emit when committed. Cancel, blur, responsive changes,
+        and unmount clean up capture/listeners. All paths use the original
+        two-argument callback shape with the resolved width/flex and reserved
+        viewport width.
       </>
     ),
     requiredOutcome: (
@@ -2827,7 +2967,10 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
     currentBehavior: (
       <>
         Built-in themes visibly stripe by default and{" "}
-        <code>showZebraRows=false</code> disables the per-grid alternation.
+        <code>showZebraRows=false</code> disables the per-grid alternation. The
+        computed <code>setShowZebraRows</code> method accepts both values and
+        functional updates for uncontrolled grids while controlled props remain
+        authoritative.
       </>
     ),
     requiredOutcome: (
@@ -2857,7 +3000,10 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
         controls, the Inovua-shaped custom-editor/cell arguments, imperative
         start/try/complete/cancel methods, ordered async callbacks, session-safe
         completion, cancellation, focus restoration, and keyboard navigation
-        without mutating consumer data.
+        without mutating consumer data. An active draft remains anchored to its
+        visible coordinate when controlled rows or columns reorder, and later
+        callbacks report the new occupant identity without synthetic lifecycle
+        events during reconciliation.
       </>
     ),
     requiredOutcome: (
@@ -3059,7 +3205,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "TypeScript",
         defaultValue: "main entry",
         description:
-          "CellProps, IColumn, SortDirection, TypeColumn, TypeColumns, TypeColumnEditorProps/Cell, TypeColumnResizeInfo/Context, TypeComputedColumn, TypeComputedColumnsMap, TypeComputedProps, TypeDataGridProps, TypeDataSourceArgs, TypeDataSource, TypeEditInfo, TypeStartEditArgs, TypeTryStartEditArgs, TypeCompleteEditArgs, TypeCancelEditArgs, TypeFilterOperator, TypeFilterType, TypeFilterTypes, TypeFilterValue, TypeGetColumnByParam, TypeI18n, TypeOnSelectionChangeArg, TypePaginationMode, TypeRowStyle/Args/Props, TypeShowCellBorders, TypeRowSelection, TypeSize, TypeSingleFilterValue, TypeSingleSortInfo, TypeSortInfo, TypeCheckboxColumn, and TypeCheckboxProps.",
+          "CellProps, TypeCellProps, IColumn, SortDirection, TypeColumn, TypeColumns, TypeColumnEditorProps/Cell, TypeColumnFilterValueChangeArg, TypeColumnResizeInfo/Context, TypeComputedColumn, TypeComputedColumnsMap, TypeComputedProps, TypeDataGridProps, TypeDataSourceArgs, TypeDataSource, TypeEditInfo, TypeStartEditArgs, TypeTryStartEditArgs, TypeCompleteEditArgs, TypeCancelEditArgs, TypeFilterOperator, TypeFilterType, TypeFilterTypes, TypeFilterValue, TypeGetColumnByParam, TypeI18n, TypeOnSelectionChangeArg, TypePaginationMode, TypeRowStyle/Args/Props, TypeShowCellBorders, TypeRowSelection, TypeSize, TypeSingleFilterValue, TypeSingleSortInfo, TypeSortInfo, TypeCheckboxColumn, and TypeCheckboxProps.",
       },
       {
         name: "@geovi/the-datagrid/search",
@@ -3096,6 +3242,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
   enableFiltering: true,
   filterTypes: DEFAULT_FILTER_TYPES,
   virtualized: true,
+  virtualizeColumnsThreshold: 15,
   allowMobileTransform: false,
   columnUserSelect: true,
   showCellBorders: true,
@@ -3104,6 +3251,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
   minRowHeight: 20,
   defaultShowZebraRows: true,
   editStartEvent: "dblclick",
+  emptyText: "noRecords",
   headerHeight: 40,
   filterRowHeight: 44,
 };`}
@@ -3228,10 +3376,10 @@ const implementedSurfaceSections: ReferenceSection[] = [
       },
       {
         name: "Resize interaction",
-        type: "drag / double-click",
+        type: "mouse, pen, touch / double-click",
         defaultValue: "enabled",
         description:
-          "Enabled handles clamp drag widths and report completion through onColumnResize. Controlled width/flex remain prop-owned; defaultWidth/defaultFlex are grid-owned starts. Double-click reruns one-column estimation, and natural rows remeasure after width changes.",
+          "Enabled handles use pointer capture, clamp drag widths, and report completion through onColumnResize for mouse, pen, and touch. Cancel, blur, responsive changes, and unmount clean up the session. Controlled width/flex remain prop-owned; defaultWidth/defaultFlex are grid-owned starts. Double-click reruns one-column estimation, and natural rows remeasure after width changes.",
       },
       {
         name: "Header column menu",
@@ -3245,7 +3393,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "props",
         defaultValue: "documented defaults",
         description:
-          "headerHeight, filterRowHeight, fixed/functional/natural rowHeight, min/max row bounds, rowStyle, showZebraRows, showCellBorders, columnUserSelect, root className, and inner-surface style are implemented. Inline styles are used for computed numeric layout.",
+          "headerHeight, filterRowHeight, fixed/functional/natural rowHeight, min/max row bounds, horizontal column virtualization, rowStyle, showZebraRows, showCellBorders, columnUserSelect, root className, and inner-surface style are implemented. Fixed numeric rowHeight remains authoritative over min/max; inline styles are used for computed numeric layout.",
       },
     ],
   },
@@ -3317,6 +3465,13 @@ const implementedSurfaceSections: ReferenceSection[] = [
             honor onSkipChange(0).
           </li>
           <li>
+            <code>onColumnFilterValueChange</code> runs before the aggregate
+            callback for editor, operator, and clear changes. It reports the
+            descriptor and column identity/index; UI gestures include
+            filter-cell <code>cellProps</code>, while computed API set/clear
+            calls omit that DOM-specific context.
+          </li>
+          <li>
             The filter-cell context menu switches operators. Object/function{" "}
             <code>filterEditorProps</code> and custom editors are supported as
             described in IColumn; resolved props spread last. Without a custom
@@ -3370,9 +3525,9 @@ const implementedSurfaceSections: ReferenceSection[] = [
       {
         name: "Selection behavior",
         type: "row-id map",
-        defaultValue: "depends on checkboxColumn",
+        defaultValue: "inferred unless explicitly enabled/disabled",
         description:
-          "Without checkboxColumn, onSelectionChange enables single row-click selection. With it, multiSelect/checkboxOnlyRowSelect default true. Interactive descendants are ignored and the emitted wrapper can pass back to selected.",
+          "enableSelection has explicit precedence. When omitted, selected, defaultSelected, or checkboxColumn enables selection; onSelectionChange alone does not. Explicit false suppresses controlled visuals and gates row, checkbox, header, and imperative actions. Interactive descendants are ignored and the emitted wrapper can pass back to selected.",
       },
       {
         name: "Selection ranges and payload",
@@ -3392,7 +3547,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "showZebraRows",
         defaultValue: "true",
         description:
-          "Built-in themes visibly alternate rows. false removes per-grid alternation while odd/even hooks remain available to themes.",
+          "Built-in themes visibly alternate rows. false removes per-grid alternation while odd/even hooks remain available to themes. The computed setShowZebraRows method supports boolean and functional updates for uncontrolled grids; controlled showZebraRows stays authoritative.",
       },
       {
         name: "Whole-row styling",
@@ -3413,7 +3568,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "default / editor / renderEditor",
         defaultValue: "text editor",
         description:
-          "Editors receive Inovua-shaped props/cell helpers and emit start/value/stop plus complete or cancel payloads. Enter/Shift+Enter traverse rows, Tab/Shift+Tab traverse editable cells, and Escape cancels. Async completion is session-safe and never mutates consumer data.",
+          "Editors receive Inovua-shaped props/cell helpers and emit start/value/stop plus complete or cancel payloads. Enter/Shift+Enter traverse rows, Tab/Shift+Tab traverse editable cells, and Escape cancels. Active drafts remain anchored to visible coordinates through controlled row/column reorder, with later payloads resolving the new occupant and no synthetic lifecycle events during reconciliation. Async completion is session-safe and never mutates consumer data.",
       },
       {
         name: "Imperative editing",
@@ -3434,6 +3589,13 @@ const implementedSurfaceSections: ReferenceSection[] = [
         defaultValue: "enabled",
         description:
           "Uses fixed or functional estimates, or measures natural rows with min/max bounds and overscan 10. Resize/content changes repair measured offsets. Disabling virtualization renders all desktop rows; header and filter rows remain intact.",
+      },
+      {
+        name: "Column virtualization",
+        type: "horizontal range",
+        defaultValue: "15 visible columns with numeric rowHeight",
+        description:
+          "The inclusive virtualizeColumnsThreshold mounts one overscanned horizontal range shared by header, filter row, and body while preserving total scroll geometry. virtualizeColumns overrides the threshold. Functional/natural row heights and transformed mobile layout keep columns unvirtualized; far columns remain filterable and editable after scrolling.",
       },
       {
         name: "Mobile transform",
@@ -4361,10 +4523,11 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
         body: (
           <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
             <li>
-              With checkboxColumn enabled, multiSelect and checkboxOnlyRowSelect
-              default to true; without it, both default false unless explicitly
-              enabled. Without a checkbox column, providing onSelectionChange
-              enables single-selection row clicks.
+              enableSelection has explicit precedence. When omitted, selected,
+              defaultSelected, or checkboxColumn enables selection;
+              onSelectionChange alone does not. With checkboxColumn enabled,
+              multiSelect and checkboxOnlyRowSelect default to true; without it,
+              both default false unless inferred or explicitly enabled.
             </li>
             <li>
               checkboxSelectEnableShiftKey enables contiguous range selection

--- a/examples/src/router.tsx
+++ b/examples/src/router.tsx
@@ -16,6 +16,7 @@ import ExamplesOverviewPage from "./ExamplesOverviewPage";
 import FilteredRowsCountCompatPage from "./FilteredRowsCountCompatPage";
 import InovuaParityCompatPage from "./InovuaParityCompatPage";
 import InovuaParityExamplePage from "./InovuaParityExamplePage";
+import InovuaPendingParityCompatPage from "./InovuaPendingParityCompatPage";
 import MemorySafetyCompatPage from "./MemorySafetyCompatPage";
 import MobileTransformExample from "./MobileTransformExample";
 import SearchDataSourceCompatPage from "./SearchDataSourceCompatPage";
@@ -315,6 +316,12 @@ const compatInovuaParityRoute = createRoute({
   component: InovuaParityFixturePage,
 });
 
+const compatInovuaPendingParityRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/inovua-pending-parity",
+  component: InovuaPendingParityCompatPage,
+});
+
 const compatSearchDataSourceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "compat/search-data-source",
@@ -328,6 +335,7 @@ const routeTree = rootRoute.addChildren([
   compatDefaultPropsRoute,
   compatFilteredRowsCountRoute,
   compatInovuaParityRoute,
+  compatInovuaPendingParityRoute,
   compatMemorySafetyRoute,
   compatSearchDataSourceRoute,
   examplesOverviewRoute,

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -1818,6 +1818,62 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const getEditStartArgsRef = React.useRef(getEditStartArgs);
   getEditStartArgsRef.current = getEditStartArgs;
 
+  // Inovua anchors an active edit session to its visible coordinates. If a
+  // controlled row or column model changes, preserve the session and draft
+  // while resolving identity and callback metadata from the new occupant.
+  // Model reconciliation itself must not emit edit lifecycle callbacks.
+  const reconcileEditingCellToCoordinate = React.useCallback(
+    (cell: GridEditingCell | null): GridEditingCell | null => {
+      if (!cell) return null;
+
+      const args = getEditStartArgsRef.current(cell.rowIndex, cell.columnIndex);
+      if (!args) return cell;
+
+      const targetChanged =
+        String(cell.rowId) !== String(args.rowId) ||
+        cell.columnId !== args.columnId;
+
+      return {
+        ...cell,
+        rowId: args.rowId,
+        rowIndex: args.rowIndex,
+        columnId: args.columnId,
+        columnIndex: args.columnIndex,
+        originalValue: targetChanged ? args.value : cell.originalValue,
+        data: args.data,
+        column: args.column,
+        cellProps: {
+          ...args.cellProps,
+          editValue: cell.value,
+          inEdit: true,
+        },
+      };
+    },
+    []
+  );
+
+  const getEditingCellAtCurrentCoordinate = React.useCallback(() => {
+    const current = editingCellRef.current;
+    const reconciled = reconcileEditingCellToCoordinate(current);
+
+    if (current && reconciled && current.sessionId === reconciled.sessionId) {
+      editingCellRef.current = reconciled;
+    }
+
+    return reconciled;
+  }, [reconcileEditingCellToCoordinate]);
+
+  const coordinateEditingCell = reconcileEditingCellToCoordinate(editingCell);
+
+  React.useLayoutEffect(() => {
+    if (
+      coordinateEditingCell &&
+      editingCellRef.current?.sessionId === coordinateEditingCell.sessionId
+    ) {
+      editingCellRef.current = coordinateEditingCell;
+    }
+  }, [coordinateEditingCell]);
+
   const resolveEditRowIndex = React.useCallback(
     (rowIndex?: number, rowId?: string | number): number => {
       if (rowIndex !== undefined) {
@@ -1878,7 +1934,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       const args = getEditStartArgsRef.current(rowIndex, columnIndex);
       if (!args) return null;
 
-      const liveEdit = editingCellRef.current;
+      const liveEdit = getEditingCellAtCurrentCoordinate();
       if (
         liveEdit?.rowIndex === rowIndex &&
         liveEdit.columnIndex === columnIndex
@@ -1912,7 +1968,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         cellProps: args.cellProps,
       };
     },
-    [editable]
+    [editable, getEditingCellAtCurrentCoordinate]
   );
 
   const navigateAfterEdit = React.useCallback(
@@ -1987,7 +2043,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   const handleEditValueChange = React.useCallback(
     (value: unknown) => {
-      const current = editingCellRef.current;
+      const current = getEditingCellAtCurrentCoordinate();
       if (!current || editEndingSessionRef.current != null) return;
 
       const next = {
@@ -2002,7 +2058,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
       setEditingCell(next);
       onEditValueChange?.(toEditInfo(next, { includeValue: true, value }));
     },
-    [onEditValueChange, setEditingCell, toEditInfo]
+    [
+      getEditingCellAtCurrentCoordinate,
+      onEditValueChange,
+      setEditingCell,
+      toEditInfo,
+    ]
   );
 
   const handleEditComplete = React.useCallback(
@@ -2011,7 +2072,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       value?: unknown,
       targetCell?: GridEditingCell
     ) => {
-      const current = editingCellRef.current;
+      const current = getEditingCellAtCurrentCoordinate();
       if (
         !current ||
         editEndingSessionRef.current === current.sessionId ||
@@ -2083,12 +2144,19 @@ function ReactDataGrid(props: TypeDataGridProps) {
         await navigateAfterEdit(completedCell, navigation);
       }
     },
-    [navigateAfterEdit, onEditComplete, onEditStop, setEditingCell, toEditInfo]
+    [
+      getEditingCellAtCurrentCoordinate,
+      navigateAfterEdit,
+      onEditComplete,
+      onEditStop,
+      setEditingCell,
+      toEditInfo,
+    ]
   );
 
   const handleEditStop = React.useCallback(
     async (navigation?: GridEditNavigation, value?: unknown) => {
-      const current = editingCellRef.current;
+      const current = getEditingCellAtCurrentCoordinate();
       editAttemptRef.current += 1;
       if (!current || editEndingSessionRef.current != null) return;
 
@@ -2115,13 +2183,19 @@ function ReactDataGrid(props: TypeDataGridProps) {
         surfaceRef.current?.focus();
       }
     },
-    [navigateAfterEdit, onEditStop, setEditingCell, toEditInfo]
+    [
+      getEditingCellAtCurrentCoordinate,
+      navigateAfterEdit,
+      onEditStop,
+      setEditingCell,
+      toEditInfo,
+    ]
   );
 
   const handleEditCancel = React.useCallback(
     (targetCell?: GridEditingCell) => {
       editAttemptRef.current += 1;
-      const current = editingCellRef.current;
+      const current = getEditingCellAtCurrentCoordinate();
       if (!current || editEndingSessionRef.current != null) return;
 
       const sessionId = current.sessionId;
@@ -2139,7 +2213,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
       }
       surfaceRef.current?.focus();
     },
-    [onEditCancel, onEditStop, setEditingCell, toEditInfo]
+    [
+      getEditingCellAtCurrentCoordinate,
+      onEditCancel,
+      onEditStop,
+      setEditingCell,
+      toEditInfo,
+    ]
   );
 
   const handleCrossTargetEditComplete = React.useCallback(
@@ -2265,7 +2345,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   const completeEditCompat = React.useCallback(
     (args?: TypeCompleteEditArgs): void => {
-      const current = editingCellRef.current;
+      const current = getEditingCellAtCurrentCoordinate();
       if (!current) return;
 
       let columnIndex = resolveEditColumnIndex(args?.columnId);
@@ -2305,7 +2385,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         );
         if (!target) return;
 
-        const liveEditBeforeFocus = editingCellRef.current;
+        const liveEditBeforeFocus = getEditingCellAtCurrentCoordinate();
         const targetsAnotherCell = Boolean(
           liveEditBeforeFocus &&
           (target.rowIndex !== liveEditBeforeFocus.rowIndex ||
@@ -2321,7 +2401,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
           surfaceRef.current?.focus();
         }
 
-        const liveEdit = editingCellRef.current;
+        const liveEdit = getEditingCellAtCurrentCoordinate();
         if (
           !liveEdit ||
           target.rowIndex !== liveEdit.rowIndex ||
@@ -2335,6 +2415,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     },
     [
       getRenderedEditingTarget,
+      getEditingCellAtCurrentCoordinate,
       handleCrossTargetEditComplete,
       handleEditComplete,
       resolveEditColumnIndex,
@@ -2346,7 +2427,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   const cancelEditCompat = React.useCallback(
     (args?: TypeCancelEditArgs): void => {
-      const current = editingCellRef.current;
+      const current = getEditingCellAtCurrentCoordinate();
       if (!current) return;
 
       // Inovua's 5.10.2 truthy column check makes numeric index 0 use the
@@ -2378,6 +2459,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     },
     [
       getRenderedEditingTarget,
+      getEditingCellAtCurrentCoordinate,
       handleCrossTargetEditCancel,
       handleEditCancel,
       resolveEditColumnIndex,
@@ -2386,9 +2468,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   const getCurrentEditInfoCompat =
     React.useCallback((): TypeEditInfo | null => {
-      const current = editingCellRef.current;
+      const current = getEditingCellAtCurrentCoordinate();
       return current ? toEditInfo(current, { includeValue: true }) : null;
-    }, [toEditInfo]);
+    }, [getEditingCellAtCurrentCoordinate, toEditInfo]);
 
   const virtualItems = virtualized ? rowVirtualizer.getVirtualItems() : [];
   const paddingTop =
@@ -4671,7 +4753,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                       getItemId: (data) => (data as any)?.[idProperty],
                     }}
                     showZebraRows={showZebraRows}
-                    editingCell={editingCell}
+                    editingCell={coordinateEditingCell}
                     cellNodesRef={editCellNodesRef}
                     editStartEvent={editStartEvent}
                     onCellEditStart={tryStartCellEdit}

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -2549,6 +2549,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const resizeSessionRef = React.useRef<{
     columnId: string;
     column: TypeColumn;
+    inputType: "mouse" | "pointer";
+    pointerId: number | null;
     startX: number;
     startWidth: number;
     nextWidth: number;
@@ -2844,17 +2846,36 @@ function ReactDataGrid(props: TypeDataGridProps) {
   );
 
   const stopColumnResize = React.useCallback(() => {
-    resizeCleanupRef.current?.();
+    const cleanup = resizeCleanupRef.current;
     resizeCleanupRef.current = null;
     resizeSessionRef.current = null;
+    cleanup?.();
     setResizeProxyLeft(null);
     setResizingColumnId(null);
   }, []);
 
   const startColumnResize = React.useCallback(
-    (event: React.MouseEvent<HTMLElement>, columnId: string) => {
+    (
+      event: React.MouseEvent<HTMLElement> | React.PointerEvent<HTMLElement>,
+      columnId: string
+    ) => {
       event.preventDefault();
       event.stopPropagation();
+
+      const isPointerEvent = "pointerId" in event;
+      const resizeHandle = event.currentTarget;
+      const pointerId = isPointerEvent ? event.pointerId : null;
+      if (
+        event.button !== 0 ||
+        (isPointerEvent && !event.isPrimary) ||
+        // A real mouse interaction emits pointerdown followed by mousedown.
+        // The pointer session owns that gesture, so the compatibility
+        // mousedown must not register a second set of listeners or commit it
+        // twice.
+        resizeSessionRef.current
+      ) {
+        return;
+      }
 
       const column = orderedColumns.find(
         (candidate) => getColumnId(candidate) === columnId
@@ -2903,6 +2924,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
       resizeSessionRef.current = {
         columnId,
         column,
+        inputType: isPointerEvent ? "pointer" : "mouse",
+        pointerId,
         startX: event.clientX,
         startWidth,
         nextWidth: startWidth,
@@ -2918,12 +2941,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
 
-      const handleMouseMove = (moveEvent: MouseEvent) => {
+      const updateResize = (clientX: number) => {
         const activeSession = resizeSessionRef.current;
         if (!activeSession) return;
 
         const nextWidth = clamp(
-          activeSession.startWidth + (moveEvent.clientX - activeSession.startX),
+          activeSession.startWidth + (clientX - activeSession.startX),
           activeSession.minWidth,
           activeSession.maxWidth
         );
@@ -2932,7 +2955,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         setResizeProxyLeft(activeSession.columnLeft + nextWidth);
       };
 
-      const handleMouseUp = () => {
+      const completeResize = () => {
         const completedSession = resizeSessionRef.current;
         if (
           completedSession &&
@@ -2951,21 +2974,112 @@ function ReactDataGrid(props: TypeDataGridProps) {
           });
         }
       };
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const activeSession = resizeSessionRef.current;
+        if (!activeSession || activeSession.inputType !== "mouse") return;
+        updateResize(moveEvent.clientX);
+      };
+      const handleMouseUp = (upEvent: MouseEvent) => {
+        const activeSession = resizeSessionRef.current;
+        if (
+          !activeSession ||
+          activeSession.inputType !== "mouse" ||
+          upEvent.button !== 0
+        ) {
+          return;
+        }
+        completeResize();
+      };
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const activeSession = resizeSessionRef.current;
+        if (
+          !activeSession ||
+          activeSession.inputType !== "pointer" ||
+          activeSession.pointerId !== moveEvent.pointerId
+        ) {
+          return;
+        }
+        moveEvent.preventDefault();
+        updateResize(moveEvent.clientX);
+      };
+      const handlePointerUp = (upEvent: PointerEvent) => {
+        const activeSession = resizeSessionRef.current;
+        if (
+          !activeSession ||
+          activeSession.inputType !== "pointer" ||
+          activeSession.pointerId !== upEvent.pointerId
+        ) {
+          return;
+        }
+        completeResize();
+      };
+      const handlePointerCancel = (cancelEvent: PointerEvent) => {
+        const activeSession = resizeSessionRef.current;
+        if (
+          !activeSession ||
+          activeSession.inputType !== "pointer" ||
+          activeSession.pointerId !== cancelEvent.pointerId
+        ) {
+          return;
+        }
+        stopColumnResize();
+      };
+      const handleLostPointerCapture = (lostEvent: PointerEvent) => {
+        const activeSession = resizeSessionRef.current;
+        if (
+          !activeSession ||
+          activeSession.inputType !== "pointer" ||
+          activeSession.pointerId !== lostEvent.pointerId
+        ) {
+          return;
+        }
+        stopColumnResize();
+      };
       const handleWindowBlur = () => {
         stopColumnResize();
       };
 
       resizeCleanupRef.current = () => {
+        if (pointerId != null && resizeHandle.hasPointerCapture(pointerId)) {
+          resizeHandle.releasePointerCapture(pointerId);
+        }
         headerCell.draggable = previousDraggable;
         document.body.style.cursor = previousCursor;
         document.body.style.userSelect = previousUserSelect;
         window.removeEventListener("mousemove", handleMouseMove);
         window.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", handlePointerUp);
+        window.removeEventListener("pointercancel", handlePointerCancel);
+        resizeHandle.removeEventListener(
+          "lostpointercapture",
+          handleLostPointerCapture
+        );
         window.removeEventListener("blur", handleWindowBlur);
       };
 
-      window.addEventListener("mousemove", handleMouseMove);
-      window.addEventListener("mouseup", handleMouseUp);
+      if (isPointerEvent) {
+        window.addEventListener("pointermove", handlePointerMove, {
+          passive: false,
+        });
+        window.addEventListener("pointerup", handlePointerUp);
+        window.addEventListener("pointercancel", handlePointerCancel);
+        resizeHandle.addEventListener(
+          "lostpointercapture",
+          handleLostPointerCapture
+        );
+        // Capturing keeps a touch/pen drag alive when the pointer leaves the
+        // narrow handle. Window listeners remain the fallback for browsers
+        // which reject capture for a synthetic pointer event.
+        try {
+          resizeHandle.setPointerCapture(event.pointerId);
+        } catch {
+          // The gesture can still be tracked by the window listeners.
+        }
+      } else {
+        window.addEventListener("mousemove", handleMouseMove);
+        window.addEventListener("mouseup", handleMouseUp);
+      }
       window.addEventListener("blur", handleWindowBlur);
       setResizingColumnId(columnId);
       setResizeProxyLeft(columnLeft + startWidth);
@@ -2981,7 +3095,10 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   React.useLayoutEffect(() => {
     return () => {
-      resizeCleanupRef.current?.();
+      const cleanup = resizeCleanupRef.current;
+      resizeCleanupRef.current = null;
+      resizeSessionRef.current = null;
+      cleanup?.();
     };
   }, []);
 

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -103,6 +103,7 @@ type ReactDataGridDefaultPropName =
   | "enableFiltering"
   | "filterTypes"
   | "virtualized"
+  | "virtualizeColumnsThreshold"
   | "allowMobileTransform"
   | "columnUserSelect"
   | "showCellBorders"
@@ -127,6 +128,7 @@ const REACT_DATA_GRID_DEFAULT_PROPS: ReactDataGridDefaultProps = {
   enableFiltering: true,
   filterTypes: DEFAULT_FILTER_TYPES,
   virtualized: true,
+  virtualizeColumnsThreshold: 15,
   allowMobileTransform: false,
   columnUserSelect: true,
   showCellBorders: true,
@@ -350,6 +352,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
     filteredRowsCount,
 
     virtualized = REACT_DATA_GRID_DEFAULT_PROPS.virtualized,
+    virtualizeColumnsThreshold = REACT_DATA_GRID_DEFAULT_PROPS.virtualizeColumnsThreshold,
+    virtualizeColumns,
     allowMobileTransform = REACT_DATA_GRID_DEFAULT_PROPS.allowMobileTransform,
     columnUserSelect = REACT_DATA_GRID_DEFAULT_PROPS.columnUserSelect,
     showCellBorders = REACT_DATA_GRID_DEFAULT_PROPS.showCellBorders,
@@ -1180,6 +1184,21 @@ function ReactDataGrid(props: TypeDataGridProps) {
     showColumnMenuTool,
   ]);
   const columnWidths = columnWidthAllocation.widths;
+  const normalizedVirtualizeColumnsThreshold =
+    typeof virtualizeColumnsThreshold === "number" &&
+    Number.isFinite(virtualizeColumnsThreshold)
+      ? Math.max(0, Math.floor(virtualizeColumnsThreshold))
+      : REACT_DATA_GRID_DEFAULT_PROPS.virtualizeColumnsThreshold;
+  const hasFixedNumericRowHeight =
+    typeof rowHeight === "number" && Number.isFinite(rowHeight);
+  const computedVirtualizeColumns = Boolean(
+    !mobileTransformActive &&
+    orderedColumns.length > 0 &&
+    hasFixedNumericRowHeight &&
+    (typeof virtualizeColumns === "boolean"
+      ? virtualizeColumns
+      : orderedColumns.length >= normalizedVirtualizeColumnsThreshold)
+  );
 
   /** ---------------- selection helpers ---------------- */
 
@@ -1496,6 +1515,22 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const headerScrollRef = React.useRef<HTMLDivElement | null>(null);
+  const [columnScrollLeft, setColumnScrollLeft] = React.useState(0);
+  React.useLayoutEffect(() => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+
+    const updateScrollLeft = () => {
+      const nextScrollLeft = Math.max(0, viewport.scrollLeft);
+      setColumnScrollLeft((current) =>
+        Object.is(current, nextScrollLeft) ? current : nextScrollLeft
+      );
+    };
+
+    updateScrollLeft();
+    viewport.addEventListener("scroll", updateScrollLeft, { passive: true });
+    return () => viewport.removeEventListener("scroll", updateScrollLeft);
+  }, [mobileTransformActive]);
   const rowModel = table.getRowModel().rows;
   const headerGroupCount = table.getHeaderGroups().length;
   const stickyHeaderOffset =
@@ -1735,6 +1770,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         editStartEvent,
         theme: themeName,
         totalDataCount: rows.length,
+        virtualizeColumns: computedVirtualizeColumns,
       });
 
       return {
@@ -1751,6 +1787,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     [
       columnWidths,
       computedMinRowHeight,
+      computedVirtualizeColumns,
       editStartEvent,
       editable,
       idProperty,
@@ -2403,6 +2440,93 @@ function ReactDataGrid(props: TypeDataGridProps) {
       }),
     [columnWidths, orderedColumns]
   );
+  const columnRenderRange = React.useMemo(() => {
+    const totalColumnCount = columnLayout.length;
+    if (!computedVirtualizeColumns || totalColumnCount === 0) {
+      return {
+        firstIndex: 0,
+        lastIndex: totalColumnCount - 1,
+        beforeWidth: 0,
+        afterWidth: 0,
+        columnRenderCount: totalColumnCount,
+      };
+    }
+
+    const viewportStart = Math.max(0, columnScrollLeft);
+    const viewportEnd = viewportStart + Math.max(1, columnViewportWidth || 1);
+    let runningWidth = 0;
+    let firstVisibleIndex = 0;
+    let lastVisibleIndex = totalColumnCount - 1;
+    let foundFirst = false;
+
+    for (const [index, column] of columnLayout.entries()) {
+      const columnStart = runningWidth;
+      const columnEnd = columnStart + column.width;
+
+      if (!foundFirst && columnEnd > viewportStart) {
+        firstVisibleIndex = index;
+        foundFirst = true;
+      }
+      if (columnStart < viewportEnd) {
+        lastVisibleIndex = index;
+      }
+      runningWidth = columnEnd;
+    }
+
+    // One column of horizontal overscan keeps resize handles, filter menus and
+    // keyboard-driven edit navigation stable at both viewport edges.
+    const firstIndex = Math.max(0, firstVisibleIndex - 1);
+    const lastIndex = Math.min(totalColumnCount - 1, lastVisibleIndex + 1);
+    const beforeWidth = columnLayout
+      .slice(0, firstIndex)
+      .reduce((sum, column) => sum + column.width, 0);
+    const renderedWidth = columnLayout
+      .slice(firstIndex, lastIndex + 1)
+      .reduce((sum, column) => sum + column.width, 0);
+
+    return {
+      firstIndex,
+      lastIndex,
+      beforeWidth,
+      afterWidth: Math.max(0, runningWidth - beforeWidth - renderedWidth),
+      columnRenderCount: lastIndex - firstIndex + 1,
+    };
+  }, [
+    columnLayout,
+    columnScrollLeft,
+    columnViewportWidth,
+    computedVirtualizeColumns,
+  ]);
+  const renderedColumnLayout = React.useMemo(() => {
+    if (!computedVirtualizeColumns) return columnLayout;
+
+    return [
+      ...(columnRenderRange.beforeWidth > 0
+        ? [
+            {
+              id: "__tdg_virtual_columns_before__",
+              width: columnRenderRange.beforeWidth,
+              minWidth: columnRenderRange.beforeWidth,
+              maxWidth: columnRenderRange.beforeWidth,
+            },
+          ]
+        : []),
+      ...columnLayout.slice(
+        columnRenderRange.firstIndex,
+        columnRenderRange.lastIndex + 1
+      ),
+      ...(columnRenderRange.afterWidth > 0
+        ? [
+            {
+              id: "__tdg_virtual_columns_after__",
+              width: columnRenderRange.afterWidth,
+              minWidth: columnRenderRange.afterWidth,
+              maxWidth: columnRenderRange.afterWidth,
+            },
+          ]
+        : []),
+    ];
+  }, [columnLayout, columnRenderRange, computedVirtualizeColumns]);
 
   const [resizeProxyLeft, setResizeProxyLeft] = React.useState<number | null>(
     null
@@ -2432,11 +2556,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
     const next: Record<string, number> = {};
 
-    for (const [index, column] of orderedColumns.entries()) {
-      const headerCell = headerCells[index];
-      if (!headerCell) continue;
-
-      const columnId = getColumnId(column);
+    for (const headerCell of headerCells) {
+      const columnId = headerCell.dataset.columnId;
+      if (!columnId) continue;
+      const column = orderedColumns.find(
+        (candidate) => getColumnId(candidate) === columnId
+      );
+      if (!column) continue;
       const { minWidth, maxWidth } = getColumnWidthBounds(column);
       next[columnId] = clamp(
         Math.round(headerCell.getBoundingClientRect().width),
@@ -3318,11 +3444,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const setScrollLeftCompat = React.useCallback((nextScrollLeft: number) => {
     if (!scrollRef.current) return;
     scrollRef.current.scrollLeft = nextScrollLeft;
+    setColumnScrollLeft(scrollRef.current.scrollLeft);
   }, []);
 
   const incrementScrollLeftCompat = React.useCallback((delta: number) => {
     if (!scrollRef.current) return;
     scrollRef.current.scrollLeft += delta;
+    setColumnScrollLeft(scrollRef.current.scrollLeft);
   }, []);
 
   const setScrollTopCompat = React.useCallback((nextScrollTop: number) => {
@@ -3385,31 +3513,30 @@ function ReactDataGrid(props: TypeDataGridProps) {
       const viewport = scrollRef.current;
       const column = visibleComputedColumns[index];
       if (!viewport || !column) return;
-
-      const headerCell = surfaceRef.current?.querySelector<HTMLElement>(
-        `[data-slot="grid-header-cell"][data-column-id="${getColumnId(column)}"]`
-      );
-      if (!headerCell) return;
-
-      const viewportRect = viewport.getBoundingClientRect();
-      const headerRect = headerCell.getBoundingClientRect();
+      const columnStart =
+        index === 0 ? 0 : (columnWidthPrefixSums[index - 1] ?? 0);
+      const columnEnd = columnWidthPrefixSums[index] ?? columnStart;
       const offset = config?.offset ?? 0;
+      let nextScrollLeft = viewport.scrollLeft;
 
       if (
         config?.direction === "left" ||
-        headerRect.left < viewportRect.left + offset
+        columnStart < viewport.scrollLeft + offset
       ) {
-        viewport.scrollLeft += headerRect.left - viewportRect.left - offset;
+        nextScrollLeft = columnStart - offset;
       } else if (
         config?.direction === "right" ||
-        headerRect.right > viewportRect.right - offset
+        columnEnd > viewport.scrollLeft + viewport.clientWidth - offset
       ) {
-        viewport.scrollLeft += headerRect.right - viewportRect.right + offset;
+        nextScrollLeft = columnEnd - viewport.clientWidth + offset;
       }
+
+      viewport.scrollLeft = Math.max(0, nextScrollLeft);
+      setColumnScrollLeft(viewport.scrollLeft);
 
       callback?.();
     },
-    [visibleComputedColumns]
+    [columnWidthPrefixSums, visibleComputedColumns]
   );
 
   const scrollToCellCompat = React.useCallback(
@@ -4045,7 +4172,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         setReservedViewportWidth(reservedViewportWidthRef.current);
       },
       reservedViewportWidth,
-      virtualizeColumns: false,
+      virtualizeColumns: computedVirtualizeColumns,
       computedShowHeaderBorderRight: showVerticalCellBorders,
       silentSetData: setRows,
       setOriginalData: setRows,
@@ -4086,6 +4213,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     columnsMap,
     commitColumnPixelResize,
     commitColumnResizeEntries,
+    computedVirtualizeColumns,
     count,
     dataSource,
     editable,
@@ -4247,7 +4375,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                         style={sharedTableStyle}
                       >
                         <colgroup>
-                          {columnLayout.map((column) => (
+                          {renderedColumnLayout.map((column) => (
                             <col
                               key={column.id}
                               style={{
@@ -4294,6 +4422,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           filterTypes={filterTypes}
                           openFilterMenuColId={openFilterMenuColId}
                           setOpenFilterMenuColId={setOpenFilterMenuColId}
+                          virtualizeColumns={computedVirtualizeColumns}
+                          columnRenderRange={columnRenderRange}
                         />
                       </table>
                     </div>
@@ -4304,7 +4434,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                   style={sharedTableStyle}
                 >
                   <colgroup>
-                    {columnLayout.map((column) => (
+                    {renderedColumnLayout.map((column) => (
                       <col
                         key={column.id}
                         style={{
@@ -4323,6 +4453,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
                     showHorizontalCellBorders={showHorizontalCellBorders}
                     showVerticalCellBorders={showVerticalCellBorders}
                     virtualized={virtualized}
+                    virtualizeColumns={computedVirtualizeColumns}
+                    columnRenderRange={columnRenderRange}
                     virtualItems={virtualItems}
                     paddingTop={paddingTop}
                     paddingBottom={paddingBottom}
@@ -4341,6 +4473,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
                       totalComputedWidth: tableMinWidth ?? 0,
                       remoteRowOffset: loadSkip,
                       columns: visibleComputedColumns,
+                      columnRenderCount: columnRenderRange.columnRenderCount,
+                      totalColumnCount: visibleComputedColumns.length,
+                      virtualizeColumns: computedVirtualizeColumns,
                       columnsMap,
                       dataSourceArray: rows,
                       theme: themeName,

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -110,6 +110,7 @@ type ReactDataGridDefaultPropName =
   | "enableColumnAutosize"
   | "skipHeaderOnAutoSize"
   | "resizable"
+  | "liveColumnResize"
   | "enableFiltering"
   | "filterTypes"
   | "virtualized"
@@ -136,6 +137,7 @@ const REACT_DATA_GRID_DEFAULT_PROPS: ReactDataGridDefaultProps = {
   enableColumnAutosize: true,
   skipHeaderOnAutoSize: false,
   resizable: true,
+  liveColumnResize: false,
   enableFiltering: true,
   filterTypes: DEFAULT_FILTER_TYPES,
   virtualized: true,
@@ -158,6 +160,94 @@ type ReactDataGridComponent = ((
 ) => React.ReactElement) & {
   defaultProps: ReactDataGridDefaultProps;
 };
+
+type LiveColumnResizePreview = {
+  baseColumnWidth: number;
+  columns: {
+    element: HTMLTableColElement;
+    inlineWidth: string;
+  }[];
+  tables: {
+    element: HTMLTableElement;
+    inlineWidth: string;
+    renderedWidth: number;
+  }[];
+};
+
+type ColumnResizeSession = {
+  columnId: string;
+  column: TypeColumn;
+  inputType: "mouse" | "pointer";
+  pointerId: number | null;
+  startX: number;
+  startWidth: number;
+  nextWidth: number;
+  columnLeft: number;
+  minWidth: number;
+  maxWidth: number;
+  liveColumnResize: boolean;
+  appliedPreviewWidth: number | null;
+  preview: LiveColumnResizePreview | null;
+};
+
+function captureLiveColumnResizePreview(
+  surface: HTMLElement,
+  columnId: string,
+  baseColumnWidth: number
+): LiveColumnResizePreview {
+  const columns = Array.from(
+    surface.querySelectorAll<HTMLTableColElement>("col[data-column-id]")
+  )
+    .filter((element) => element.dataset.columnId === columnId)
+    .map((element) => ({
+      element,
+      inlineWidth: element.style.width,
+    }));
+  const owningTables = new Set<HTMLTableElement>();
+
+  for (const { element } of columns) {
+    const table = element.closest("table");
+    if (table instanceof HTMLTableElement) owningTables.add(table);
+  }
+
+  return {
+    baseColumnWidth,
+    columns,
+    tables: Array.from(owningTables, (element) => ({
+      element,
+      inlineWidth: element.style.width,
+      renderedWidth: element.getBoundingClientRect().width,
+    })),
+  };
+}
+
+function applyLiveColumnResizePreview(
+  session: ColumnResizeSession,
+  nextWidth: number
+) {
+  if (!session.preview || session.appliedPreviewWidth === nextWidth) return;
+
+  const widthDelta = nextWidth - session.preview.baseColumnWidth;
+  for (const { element } of session.preview.columns) {
+    element.style.width = `${nextWidth}px`;
+  }
+  for (const { element, renderedWidth } of session.preview.tables) {
+    element.style.width = `${Math.max(1, renderedWidth + widthDelta)}px`;
+  }
+  session.appliedPreviewWidth = nextWidth;
+}
+
+function restoreLiveColumnResizePreview(session: ColumnResizeSession | null) {
+  if (!session?.preview || session.appliedPreviewWidth == null) return;
+
+  for (const { element, inlineWidth } of session.preview.columns) {
+    element.style.width = inlineWidth;
+  }
+  for (const { element, inlineWidth } of session.preview.tables) {
+    element.style.width = inlineWidth;
+  }
+  session.appliedPreviewWidth = null;
+}
 
 type InternalSearchController = {
   value: string;
@@ -358,6 +448,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     enableColumnAutosize = REACT_DATA_GRID_DEFAULT_PROPS.enableColumnAutosize,
     skipHeaderOnAutoSize = REACT_DATA_GRID_DEFAULT_PROPS.skipHeaderOnAutoSize,
     resizable = REACT_DATA_GRID_DEFAULT_PROPS.resizable,
+    liveColumnResize = REACT_DATA_GRID_DEFAULT_PROPS.liveColumnResize,
 
     enableFiltering = REACT_DATA_GRID_DEFAULT_PROPS.enableFiltering,
     onColumnFilterValueChange,
@@ -2811,21 +2902,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const resizeProxyElementRef = React.useRef<HTMLDivElement | null>(null);
   const resizeProxyFrameRef = React.useRef<number | null>(null);
   const resizeProxyNextLeftRef = React.useRef<number | null>(null);
+  const liveColumnResizeFrameRef = React.useRef<number | null>(null);
+  const liveColumnResizeNextWidthRef = React.useRef<number | null>(null);
   const [resizingColumnId, setResizingColumnId] = React.useState<string | null>(
     null
   );
-  const resizeSessionRef = React.useRef<{
-    columnId: string;
-    column: TypeColumn;
-    inputType: "mouse" | "pointer";
-    pointerId: number | null;
-    startX: number;
-    startWidth: number;
-    nextWidth: number;
-    columnLeft: number;
-    minWidth: number;
-    maxWidth: number;
-  } | null>(null);
+  const resizeSessionRef = React.useRef<ColumnResizeSession | null>(null);
   const resizeCleanupRef = React.useRef<(() => void) | null>(null);
 
   const cancelResizeProxyFrame = React.useCallback(() => {
@@ -2849,6 +2931,65 @@ function ReactDataGrid(props: TypeDataGridProps) {
       proxy.style.transform = `translate3d(${left}px, 0, 0)`;
     });
   }, []);
+
+  const cancelLiveColumnResizeFrame = React.useCallback(() => {
+    if (liveColumnResizeFrameRef.current != null) {
+      window.cancelAnimationFrame(liveColumnResizeFrameRef.current);
+      liveColumnResizeFrameRef.current = null;
+    }
+    liveColumnResizeNextWidthRef.current = null;
+  }, []);
+
+  const scheduleLiveColumnResizePreview = React.useCallback(
+    (nextWidth: number) => {
+      liveColumnResizeNextWidthRef.current = nextWidth;
+      if (liveColumnResizeFrameRef.current != null) return;
+
+      liveColumnResizeFrameRef.current = window.requestAnimationFrame(() => {
+        liveColumnResizeFrameRef.current = null;
+        const activeSession = resizeSessionRef.current;
+        const width = liveColumnResizeNextWidthRef.current;
+        liveColumnResizeNextWidthRef.current = null;
+        if (!activeSession?.liveColumnResize || width == null) return;
+
+        applyLiveColumnResizePreview(activeSession, width);
+      });
+    },
+    []
+  );
+
+  React.useLayoutEffect(() => {
+    const activeSession = resizeSessionRef.current;
+    const preview = activeSession?.preview;
+    if (!activeSession?.liveColumnResize || !preview) return;
+
+    const latestColumn = renderedColumnLayout.find(
+      (column) => column.id === activeSession.columnId
+    );
+    if (!latestColumn) return;
+
+    // React can receive a newer controlled width while a pointer gesture is
+    // still active. Keep that latest React-owned geometry as the cancellation
+    // baseline, then place the transient pointer preview back on top before
+    // paint. This prevents cleanup from restoring a stale drag-start width.
+    preview.baseColumnWidth = latestColumn.width;
+    for (const column of preview.columns) {
+      column.inlineWidth = `${latestColumn.width}px`;
+    }
+
+    const latestTableInlineWidth = tableMinWidth ? `${tableMinWidth}px` : "";
+    for (const table of preview.tables) {
+      table.inlineWidth = latestTableInlineWidth;
+      table.renderedWidth =
+        tableMinWidth ?? table.element.getBoundingClientRect().width;
+    }
+
+    const appliedPreviewWidth = activeSession.appliedPreviewWidth;
+    if (appliedPreviewWidth == null) return;
+
+    activeSession.appliedPreviewWidth = null;
+    applyLiveColumnResizePreview(activeSession, appliedPreviewWidth);
+  }, [renderedColumnLayout, tableMinWidth]);
 
   const captureRenderedColumnWidths = React.useCallback(() => {
     const headerCells = Array.from(
@@ -3150,14 +3291,17 @@ function ReactDataGrid(props: TypeDataGridProps) {
   );
 
   const stopColumnResize = React.useCallback(() => {
+    const session = resizeSessionRef.current;
     const cleanup = resizeCleanupRef.current;
     resizeCleanupRef.current = null;
     resizeSessionRef.current = null;
-    cleanup?.();
     cancelResizeProxyFrame();
+    cancelLiveColumnResizeFrame();
+    restoreLiveColumnResizePreview(session);
+    cleanup?.();
     setResizeProxyLeft(null);
     setResizingColumnId(null);
-  }, [cancelResizeProxyFrame]);
+  }, [cancelLiveColumnResizeFrame, cancelResizeProxyFrame]);
 
   const startColumnResize = React.useCallback(
     (
@@ -3223,6 +3367,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
           bodyViewport.scrollLeft <=
           1
       );
+      const preview = liveColumnResize
+        ? captureLiveColumnResizePreview(surfaceElement, columnId, startWidth)
+        : null;
 
       headerCell.draggable = false;
 
@@ -3237,6 +3384,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
         columnLeft,
         minWidth,
         maxWidth,
+        liveColumnResize,
+        appliedPreviewWidth: null,
+        preview,
       };
 
       resizeCleanupRef.current?.();
@@ -3257,15 +3407,26 @@ function ReactDataGrid(props: TypeDataGridProps) {
         );
 
         activeSession.nextWidth = nextWidth;
-        scheduleResizeProxyPosition(activeSession.columnLeft + nextWidth);
+        if (activeSession.liveColumnResize) {
+          scheduleLiveColumnResizePreview(nextWidth);
+        } else {
+          scheduleResizeProxyPosition(activeSession.columnLeft + nextWidth);
+        }
       };
 
       const completeResize = () => {
         const completedSession = resizeSessionRef.current;
-        if (
+        const shouldCommit = Boolean(
           completedSession &&
           completedSession.nextWidth !== completedSession.startWidth
-        ) {
+        );
+        if (completedSession && shouldCommit) {
+          // Settle the imperative preview before entering the existing commit
+          // path. React applies the grid-owned result in the same event turn;
+          // controlled widths therefore return to their prop value unless the
+          // consumer supplies the proposal back from `onColumnResize`.
+          cancelLiveColumnResizeFrame();
+          restoreLiveColumnResizePreview(completedSession);
           commitColumnPixelResize(
             completedSession.column,
             completedSession.nextWidth
@@ -3387,15 +3548,23 @@ function ReactDataGrid(props: TypeDataGridProps) {
       }
       window.addEventListener("blur", handleWindowBlur);
       setResizingColumnId(columnId);
-      const initialProxyLeft = columnLeft + startWidth;
       cancelResizeProxyFrame();
-      resizeProxyNextLeftRef.current = initialProxyLeft;
-      setResizeProxyLeft(initialProxyLeft);
+      cancelLiveColumnResizeFrame();
+      if (liveColumnResize) {
+        setResizeProxyLeft(null);
+      } else {
+        const initialProxyLeft = columnLeft + startWidth;
+        resizeProxyNextLeftRef.current = initialProxyLeft;
+        setResizeProxyLeft(initialProxyLeft);
+      }
     },
     [
+      cancelLiveColumnResizeFrame,
       cancelResizeProxyFrame,
       commitColumnPixelResize,
+      liveColumnResize,
       orderedColumns,
+      scheduleLiveColumnResizePreview,
       scheduleResizeProxyPosition,
       seedManualColumnWidthsFromDom,
       showColumnMenuTool,
@@ -3405,17 +3574,21 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   React.useLayoutEffect(() => {
     return () => {
+      const session = resizeSessionRef.current;
       const cleanup = resizeCleanupRef.current;
       resizeCleanupRef.current = null;
       resizeSessionRef.current = null;
-      cleanup?.();
       cancelResizeProxyFrame();
+      cancelLiveColumnResizeFrame();
+      restoreLiveColumnResizePreview(session);
+      cleanup?.();
     };
-  }, [cancelResizeProxyFrame]);
+  }, [cancelLiveColumnResizeFrame, cancelResizeProxyFrame]);
 
   React.useEffect(() => {
     if (!resizingColumnId) return;
 
+    const activeSession = resizeSessionRef.current;
     const resizingColumnExists = orderedColumns.some(
       (column) => getColumnId(column) === resizingColumnId
     );
@@ -3424,11 +3597,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
       mobileTransformActive ||
       !resizable ||
       !showHeader ||
-      !resizingColumnExists
+      !resizingColumnExists ||
+      activeSession?.liveColumnResize !== liveColumnResize
     ) {
       stopColumnResize();
     }
   }, [
+    liveColumnResize,
     mobileTransformActive,
     orderedColumns,
     resizable,
@@ -4835,7 +5010,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
             tabIndex={-1}
             style={style}
           >
-            {resizeProxyLeft != null ? (
+            {!liveColumnResize && resizeProxyLeft != null ? (
               <div
                 ref={resizeProxyElementRef}
                 className="InovuaReactDataGrid__resize-proxy"
@@ -4889,6 +5064,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           {renderedColumnLayout.map((column) => (
                             <col
                               key={column.id}
+                              data-column-id={column.id}
                               style={{
                                 width: column.width,
                                 minWidth: column.minWidth,
@@ -4949,6 +5125,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                     {renderedColumnLayout.map((column) => (
                       <col
                         key={column.id}
+                        data-column-id={column.id}
                         style={{
                           width: column.width,
                           minWidth: column.minWidth,

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -114,6 +114,7 @@ type ReactDataGridDefaultPropName =
   | "minRowHeight"
   | "defaultShowZebraRows"
   | "editStartEvent"
+  | "emptyText"
   | "headerHeight"
   | "filterRowHeight";
 
@@ -139,6 +140,7 @@ const REACT_DATA_GRID_DEFAULT_PROPS: ReactDataGridDefaultProps = {
   minRowHeight: 20,
   defaultShowZebraRows: true,
   editStartEvent: "dblclick",
+  emptyText: "noRecords",
   headerHeight: 40,
   filterRowHeight: 44,
 };

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -58,17 +58,25 @@ import {
   normalizeFilterValue,
   upsertFilterEntry,
 } from "../filters/utils";
+import { applyLocalSort, toggleSortInfo } from "../sorting/utils";
+
 import {
-  applyLocalSort,
-  toTanstackSorting,
-  toggleSortInfo,
-} from "../sorting/utils";
+  fromTanStackColumnFiltersState,
+  fromTanStackRowSelectionState,
+  fromTanStackSortingState,
+  hydrateTanStackRowSelection,
+  projectTanStackColumnOrder,
+  projectTanStackColumnSizing,
+  projectTanStackColumnVisibility,
+  toTanStackColumnFiltersState,
+  toTanStackRowSelectionState,
+  toTanStackSortingState,
+} from "./engine/tanstackAdapter";
 
 import {
   injectIntoOrder,
   isColumnVisible,
   isInteractiveClickTarget,
-  normalizeColumnOrder,
   stripFromOrder,
   toSelectionMap,
   unwrapSelectionState,
@@ -619,17 +627,11 @@ function ReactDataGrid(props: TypeDataGridProps) {
       return Object.fromEntries(nextEntries);
     });
   }, [allInputColumns]);
-  const columnVisibilityMap = React.useMemo(() => {
-    const next: Record<string, boolean> = {};
-
-    for (const column of allInputColumns) {
-      const columnId = getColumnId(column);
-      next[columnId] =
-        columnVisibilityState[columnId] ?? isColumnVisible(column);
-    }
-
-    return next;
-  }, [allInputColumns, columnVisibilityState]);
+  const columnVisibilityMap = React.useMemo(
+    () =>
+      projectTanStackColumnVisibility(allInputColumns, columnVisibilityState),
+    [allInputColumns, columnVisibilityState]
+  );
 
   const defaultColumnOrder = React.useMemo(() => {
     const base = inputColumns.map((c) => getColumnId(c));
@@ -665,13 +667,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
       props.onColumnOrderChange?.(userNext);
     },
   });
-  const availableColumnIds = React.useMemo(
-    () => allInputColumns.map((column) => getColumnId(column)),
-    [allInputColumns]
-  );
   const effectiveColumnOrder = React.useMemo(
-    () => normalizeColumnOrder(columnOrder, availableColumnIds),
-    [availableColumnIds, columnOrder]
+    () => projectTanStackColumnOrder(allInputColumns, columnOrder),
+    [allInputColumns, columnOrder]
   );
 
   const [sortInfo, setSortInfo] = useControllableState<TypeSortInfo>({
@@ -784,8 +782,16 @@ function ReactDataGrid(props: TypeDataGridProps) {
   }, [allInputColumns, columnVisibilityMap, effectiveColumnOrder]);
 
   const tanstackSorting = React.useMemo(
-    () => toTanstackSorting(sortInfo, orderedColumns),
-    [sortInfo, orderedColumns]
+    () => toTanStackSortingState(sortInfo, allInputColumns),
+    [allInputColumns, sortInfo]
+  );
+  const tanstackColumnFilters = React.useMemo(
+    () => toTanStackColumnFiltersState(filterValue, allInputColumns),
+    [allInputColumns, filterValue]
+  );
+  const tanstackRowSelection = React.useMemo(
+    () => toTanStackRowSelectionState(selected),
+    [selected]
   );
 
   /** ---------------- data loading ---------------- */
@@ -1206,6 +1212,10 @@ function ReactDataGrid(props: TypeDataGridProps) {
     showColumnMenuTool,
   ]);
   const columnWidths = columnWidthAllocation.widths;
+  const tanstackColumnSizing = React.useMemo(
+    () => projectTanStackColumnSizing(allInputColumns, columnWidths),
+    [allInputColumns, columnWidths]
+  );
   const normalizedVirtualizeColumnsThreshold =
     typeof virtualizeColumnsThreshold === "number" &&
     Number.isFinite(virtualizeColumnsThreshold)
@@ -1267,9 +1277,40 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   /** ---------------- columnDefs (TanStack) ---------------- */
 
+  // Keep the feature definitions stable. Selection is live compatibility
+  // state, so renderers read it through a ref instead of forcing TanStack to
+  // rebuild its complete column/header/cell memo graph for every selection or
+  // data update.
+  const selectionRuntimeRef = React.useRef({
+    rows,
+    selectedMap,
+    selectionEnabled,
+    multiSelect,
+    checkboxSelectEnableShiftKey,
+    getRowKey,
+    emitSelectionChange,
+  });
+  selectionRuntimeRef.current = {
+    rows,
+    selectedMap,
+    selectionEnabled,
+    multiSelect,
+    checkboxSelectEnableShiftKey,
+    getRowKey,
+    emitSelectionChange,
+  };
+
   const columnDefs = React.useMemo<ColumnDef<any, any>[]>(() => {
-    return orderedColumns.map((c) => {
+    return allInputColumns.map((c) => {
       const colId = getColumnId(c);
+      const { minWidth, maxWidth } = getColumnWidthBounds(c);
+      const configuredSize =
+        typeof c.width === "number" && Number.isFinite(c.width)
+          ? c.width
+          : typeof c.defaultWidth === "number" &&
+              Number.isFinite(c.defaultWidth)
+            ? c.defaultWidth
+            : undefined;
 
       if (checkboxEnabled && colId === checkboxColId) {
         const cfg =
@@ -1284,11 +1325,20 @@ function ReactDataGrid(props: TypeDataGridProps) {
           id: colId,
           accessorFn: () => null,
           enableSorting: false,
+          enableColumnFilter: false,
+          enableHiding: false,
+          enableResizing: false,
+          size: configuredSize,
+          minSize: minWidth,
+          maxSize: maxWidth,
 
           header: () => {
-            const pageRowIds = rows.map((r, idx) => getRowKey(r, idx));
+            const runtime = selectionRuntimeRef.current;
+            const pageRowIds = runtime.rows.map((r, idx) =>
+              runtime.getRowKey(r, idx)
+            );
             const selectedOnPage = pageRowIds.reduce(
-              (acc, id) => acc + (selectedMap[id] ? 1 : 0),
+              (acc, id) => acc + (runtime.selectedMap[id] ? 1 : 0),
               0
             );
             const allSelected =
@@ -1296,37 +1346,43 @@ function ReactDataGrid(props: TypeDataGridProps) {
             const someSelected = selectedOnPage > 0 && !allSelected;
 
             const onChange = (checked: boolean) => {
-              if (!selectionEnabled) return;
+              const current = selectionRuntimeRef.current;
+              if (!current.selectionEnabled) return;
 
-              if (!multiSelect) {
+              if (!current.multiSelect) {
                 const next: Record<string, any> = {};
-                if (checked && rows[0]) next[getRowKey(rows[0], 0)] = rows[0];
-                emitSelectionChange(next, { data: rows[0] });
+                if (checked && current.rows[0]) {
+                  next[current.getRowKey(current.rows[0], 0)] = current.rows[0];
+                }
+                current.emitSelectionChange(next, { data: current.rows[0] });
                 return;
               }
 
-              const next = { ...selectedMap };
+              const next = { ...current.selectedMap };
               if (checked) {
-                rows.forEach((r, idx) => {
-                  next[getRowKey(r, idx)] = r;
+                current.rows.forEach((r, idx) => {
+                  next[current.getRowKey(r, idx)] = r;
                 });
               } else {
-                rows.forEach((r, idx) => {
-                  delete next[getRowKey(r, idx)];
+                current.rows.forEach((r, idx) => {
+                  delete next[current.getRowKey(r, idx)];
                 });
               }
-              emitSelectionChange(next, { data: rows });
+              current.emitSelectionChange(next, { data: current.rows });
             };
 
             const checkboxProps: TypeCheckboxProps = {
               checked: allSelected,
               indeterminate: someSelected,
-              disabled: !selectionEnabled || rows.length === 0,
+              disabled: !runtime.selectionEnabled || runtime.rows.length === 0,
               onChange,
             };
 
             const node = renderCheckbox ? (
-              renderCheckbox(checkboxProps, { headerCell: true, data: rows })
+              renderCheckbox(checkboxProps, {
+                headerCell: true,
+                data: runtime.rows,
+              })
             ) : (
               <Checkbox
                 checked={
@@ -1358,22 +1414,24 @@ function ReactDataGrid(props: TypeDataGridProps) {
             const rowData = ctx.row.original;
             const rowIndex = ctx.row.index;
             const rowId = ctx.row.id;
+            const runtime = selectionRuntimeRef.current;
 
-            const isSelected = Boolean(selectedMap[rowId]);
+            const isSelected = Boolean(runtime.selectedMap[rowId]);
 
             const onChange = (checked: boolean) => {
-              if (!selectionEnabled) return;
+              const current = selectionRuntimeRef.current;
+              if (!current.selectionEnabled) return;
 
               const shiftKey =
-                checkboxSelectEnableShiftKey &&
+                current.checkboxSelectEnableShiftKey &&
                 lastPointerRef.current.shiftKey === true;
-              const next = { ...selectedMap };
+              const next = { ...current.selectedMap };
 
               const rowModel = ctx.table.getRowModel().rows;
 
               if (
                 shiftKey &&
-                multiSelect &&
+                current.multiSelect &&
                 lastSelectedIndexRef.current != null
               ) {
                 const from = Math.min(lastSelectedIndexRef.current, rowIndex);
@@ -1387,7 +1445,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                 }
               } else {
                 if (checked) {
-                  if (!multiSelect) {
+                  if (!current.multiSelect) {
                     Object.keys(next).forEach((k) => delete next[k]);
                   }
                   next[rowId] = rowData;
@@ -1397,12 +1455,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
               }
 
               lastSelectedIndexRef.current = rowIndex;
-              emitSelectionChange(next, { data: rowData });
+              current.emitSelectionChange(next, { data: rowData });
             };
 
             const checkboxProps: TypeCheckboxProps = {
               checked: isSelected,
-              disabled: !selectionEnabled,
+              disabled: !runtime.selectionEnabled,
               onChange,
             };
 
@@ -1443,6 +1501,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
         id: colId,
         accessorFn: (row) => (row as any)?.[colId],
         enableSorting: c.sortable ?? true,
+        enableColumnFilter: c.filterable ?? true,
+        enableHiding: c.hideable ?? true,
+        enableResizing: resizable && (c.resizable ?? true),
+        size: configuredSize,
+        minSize: minWidth,
+        maxSize: maxWidth,
 
         header: () =>
           (c as any).renderHeader?.({ column: c, columnId: colId }) ??
@@ -1511,48 +1575,129 @@ function ReactDataGrid(props: TypeDataGridProps) {
     checkboxColId,
     checkboxColumnProp,
     checkboxEnabled,
-    emitSelectionChange,
-    getRowKey,
-    multiSelect,
-    orderedColumns,
-    rows,
-    selectedMap,
-    selectionEnabled,
-    checkboxSelectEnableShiftKey,
+    allInputColumns,
+    resizable,
   ]);
 
   const table = useReactTable({
     data: rows,
     columns: columnDefs,
-    state: { sorting: tanstackSorting },
-    manualSorting: true,
-    getCoreRowModel: getCoreRowModel(),
-    getRowId: (row, index) => {
-      const v = (row as any)?.[idProperty];
-      return v == null ? String(index) : String(v);
+    state: {
+      sorting: tanstackSorting,
+      columnFilters: tanstackColumnFilters,
+      globalFilter: searchValue,
+      columnOrder: effectiveColumnOrder,
+      columnVisibility: columnVisibilityMap,
+      columnSizing: tanstackColumnSizing,
+      rowSelection: tanstackRowSelection,
     },
+    onSortingChange: (updater) => {
+      const nextSorting = resolveStateAction(updater, tanstackSorting);
+      setSkip(0);
+      setSortInfo(
+        fromTanStackSortingState(nextSorting, allInputColumns, sortInfo)
+      );
+    },
+    onColumnFiltersChange: (updater) => {
+      const nextColumnFilters = resolveStateAction(
+        updater,
+        tanstackColumnFilters
+      );
+      const nextFilterValue = fromTanStackColumnFiltersState(
+        nextColumnFilters,
+        allInputColumns,
+        filterValue
+      );
+
+      setSkip(0);
+      if (!filterControlled) setDraftFilterValue(nextFilterValue);
+      setFilterValue(nextFilterValue);
+    },
+    onColumnOrderChange: (updater) => {
+      setColumnOrder(resolveStateAction(updater, effectiveColumnOrder));
+    },
+    onColumnVisibilityChange: (updater) => {
+      const nextVisibility = resolveStateAction(updater, columnVisibilityMap);
+
+      // TanStack visibility is a complete controlled snapshot, while the
+      // compatibility layer stores sparse user overrides on top of live
+      // column.visible values. Persist only the IDs changed by this action so
+      // an unrelated column prop can still change on a later render.
+      setColumnVisibilityState((current) => {
+        const next = { ...current };
+        let changed = false;
+
+        for (const column of allInputColumns) {
+          const columnId = getColumnId(column);
+          const previousVisible = columnVisibilityMap[columnId] !== false;
+          const nextVisible = nextVisibility[columnId] !== false;
+          if (nextVisible === previousVisible) continue;
+
+          next[columnId] = nextVisible;
+          changed = true;
+        }
+
+        return changed ? next : current;
+      });
+    },
+    onRowSelectionChange: (updater) => {
+      if (!selectionEnabled) return;
+
+      const nextRowSelection = resolveStateAction(
+        updater,
+        tanstackRowSelection
+      );
+      const nextCompatibilitySelection = fromTanStackRowSelectionState(
+        nextRowSelection,
+        selected
+      );
+      const nextMap = {
+        ...toSelectionMap(nextCompatibilitySelection),
+        ...hydrateTanStackRowSelection(nextRowSelection, rows, getRowKey),
+      };
+
+      emitSelectionChange(nextMap);
+    },
+    manualSorting: true,
+    manualFiltering: true,
+    manualPagination: true,
+    enableRowSelection: selectionEnabled,
+    enableMultiRowSelection: multiSelect,
+    enableSortingRemoval: allowUnsort,
+    sortDescFirst: defaultSortDir === -1,
+    enableColumnResizing: resizable,
+    columnResizeMode: "onEnd",
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: getRowKey,
   });
 
   /** ---------------- virtualization ---------------- */
 
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const headerScrollRef = React.useRef<HTMLDivElement | null>(null);
-  const [columnScrollLeft, setColumnScrollLeft] = React.useState(0);
-  React.useLayoutEffect(() => {
-    const viewport = scrollRef.current;
-    if (!viewport) return;
-
-    const updateScrollLeft = () => {
-      const nextScrollLeft = Math.max(0, viewport.scrollLeft);
-      setColumnScrollLeft((current) =>
-        Object.is(current, nextScrollLeft) ? current : nextScrollLeft
+  const smoothScrollFrameIdsRef = React.useRef<Set<number>>(new Set());
+  React.useEffect(
+    () => () => {
+      smoothScrollFrameIdsRef.current.forEach((frameId) =>
+        window.cancelAnimationFrame(frameId)
       );
-    };
-
-    updateScrollLeft();
-    viewport.addEventListener("scroll", updateScrollLeft, { passive: true });
-    return () => viewport.removeEventListener("scroll", updateScrollLeft);
-  }, [mobileTransformActive]);
+      smoothScrollFrameIdsRef.current.clear();
+    },
+    []
+  );
+  const visibleTableColumns = table.getVisibleLeafColumns();
+  const visibleTableColumnsRef = React.useRef(visibleTableColumns);
+  visibleTableColumnsRef.current = visibleTableColumns;
+  const estimateVirtualColumnSize = React.useCallback(
+    (columnIndex: number) =>
+      visibleTableColumnsRef.current[columnIndex]?.getSize() ?? 0,
+    []
+  );
+  const getVirtualColumnKey = React.useCallback(
+    (columnIndex: number) =>
+      visibleTableColumnsRef.current[columnIndex]?.id ?? columnIndex,
+    []
+  );
   const rowModel = table.getRowModel().rows;
   const headerGroupCount = table.getHeaderGroups().length;
   const stickyHeaderOffset =
@@ -1590,10 +1735,28 @@ function ReactDataGrid(props: TypeDataGridProps) {
     estimateSize: (rowIndex) => resolveRowHeight(rowIndex),
     overscan: 10,
     scrollMargin: stickyHeaderOffset,
+    // Keep start-aligned imperative scrolling below the sticky header and
+    // filter rows instead of positioning the requested row underneath them.
+    scrollPaddingStart: stickyHeaderOffset,
     // Seed a usable range before the desktop viewport observer reports its
     // size, including when returning from the unmounted mobile branch.
     initialRect: { width: 0, height: initialRowHeight * 10 },
     enabled: virtualized && !mobileTransformActive,
+  });
+
+  // TanStack Table owns the ordered/visible column model and resolved pixel
+  // sizes. TanStack Virtual only decides which of those columns are mounted.
+  // Keeping horizontal scroll offset inside the virtualizer avoids rerendering
+  // the entire grid from a second, component-level scrollLeft state.
+  const columnVirtualizer = useVirtualizer({
+    horizontal: true,
+    count: visibleTableColumns.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: estimateVirtualColumnSize,
+    getItemKey: getVirtualColumnKey,
+    overscan: 1,
+    initialRect: { width: Math.max(0, columnViewportWidth), height: 0 },
+    enabled: computedVirtualizeColumns && !mobileTransformActive,
   });
 
   const columnWidthMeasurementKey = React.useMemo(
@@ -1607,8 +1770,43 @@ function ReactDataGrid(props: TypeDataGridProps) {
     [columnWidths, orderedColumns]
   );
   React.useLayoutEffect(() => {
+    if (!computedVirtualizeColumns || mobileTransformActive) return;
+
+    columnVirtualizer.measure();
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      const maxScrollLeft = Math.max(
+        0,
+        columnVirtualizer.getTotalSize() - viewport.clientWidth
+      );
+      if (viewport.scrollLeft > maxScrollLeft + 1) {
+        viewport.scrollLeft = maxScrollLeft;
+      }
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [
+    columnVirtualizer,
+    columnWidthMeasurementKey,
+    computedVirtualizeColumns,
+    mobileTransformActive,
+  ]);
+  React.useLayoutEffect(() => {
     if (virtualized && rowHeight == null && !mobileTransformActive) {
       rowVirtualizer.measure();
+
+      // `measure()` clears cached sizes for rows which are currently outside
+      // the viewport. Remeasure the mounted rows once after the resulting
+      // layout, rather than replacing every row ref on every grid render.
+      const frameId = window.requestAnimationFrame(() => {
+        scrollRef.current
+          ?.querySelectorAll<HTMLElement>('[data-slot="grid-row"][data-index]')
+          .forEach((element) => rowVirtualizer.measureElement(element));
+      });
+
+      return () => window.cancelAnimationFrame(frameId);
     }
   }, [
     columnWidthMeasurementKey,
@@ -1723,6 +1921,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         value: args.value,
         data: args.data,
         column: args.column,
+        initialCellHeight: args.initialCellHeight,
         cellProps: {
           ...args.cellProps,
           editValue: args.value,
@@ -1742,6 +1941,17 @@ function ReactDataGrid(props: TypeDataGridProps) {
       return true;
     },
     [editable, onEditStart, setEditingCell, toEditInfo]
+  );
+
+  // Inovua treats a UI activation on another cell as a direct coordinate
+  // replacement. The previous custom editor is not implicitly completed or
+  // cancelled; editors that want blur completion call their supplied
+  // `onComplete` handler. Keeping this path separate preserves the guarded
+  // behavior used by post-completion keyboard navigation.
+  const handleUiCellEditStart = React.useCallback(
+    (args: GridCellEditStartArgs) =>
+      tryStartCellEdit(args, { replaceActive: true }),
+    [tryStartCellEdit]
   );
 
   const getEditStartArgs = React.useCallback(
@@ -1796,6 +2006,10 @@ function ReactDataGrid(props: TypeDataGridProps) {
         data: row.original,
         column,
         cellProps,
+        initialCellHeight:
+          editCellNodesRef.current
+            .get(`${String(row.id)}\u0000${columnId}`)
+            ?.getBoundingClientRect().height ?? null,
       };
     },
     [
@@ -1844,6 +2058,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
         originalValue: targetChanged ? args.value : cell.originalValue,
         data: args.data,
         column: args.column,
+        initialCellHeight: targetChanged
+          ? args.initialCellHeight
+          : cell.initialCellHeight,
         cellProps: {
           ...args.cellProps,
           editValue: cell.value,
@@ -1968,6 +2185,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         data: args.data,
         column: args.column,
         cellProps: args.cellProps,
+        initialCellHeight: args.initialCellHeight,
       };
     },
     [editable, getEditingCellAtCurrentCoordinate]
@@ -2499,44 +2717,27 @@ function ReactDataGrid(props: TypeDataGridProps) {
     coerceUserSelect(columnUserSelect) === "none"
       ? "select-none"
       : "select-text";
-  const tableMinWidth = React.useMemo(() => {
-    if (orderedColumns.length === 0) return undefined;
-
-    return orderedColumns.reduce((sum, column) => {
-      const columnId = getColumnId(column);
-      const explicitWidth =
-        columnWidths[columnId] ??
-        column.width ??
-        column.defaultWidth ??
-        column.minWidth ??
-        120;
-      return sum + explicitWidth;
-    }, 0);
-  }, [columnWidths, orderedColumns]);
+  const tableMinWidth =
+    visibleTableColumns.length > 0 ? table.getTotalSize() : undefined;
   const sharedTableStyle = tableMinWidth
     ? { width: `${tableMinWidth}px` }
     : undefined;
   const columnLayout = React.useMemo(
     () =>
-      orderedColumns.map((column) => {
-        const columnId = getColumnId(column);
-        const explicitWidth =
-          columnWidths[columnId] ??
-          column.width ??
-          column.defaultWidth ??
-          column.minWidth ??
-          120;
-
+      visibleTableColumns.map((column) => {
+        const tableWidth = column.getSize();
         return {
-          id: columnId,
-          width: explicitWidth,
-          minWidth: column.minWidth,
-          maxWidth: column.maxWidth,
+          id: column.id,
+          width: Number.isFinite(tableWidth)
+            ? tableWidth
+            : (columnWidths[column.id] ?? 0),
+          minWidth: column.columnDef.minSize,
+          maxWidth: column.columnDef.maxSize,
         };
       }),
-    [columnWidths, orderedColumns]
+    [columnWidths, visibleTableColumns]
   );
-  const columnRenderRange = React.useMemo(() => {
+  const columnRenderRange = (() => {
     const totalColumnCount = columnLayout.length;
     if (!computedVirtualizeColumns || totalColumnCount === 0) {
       return {
@@ -2548,51 +2749,31 @@ function ReactDataGrid(props: TypeDataGridProps) {
       };
     }
 
-    const viewportStart = Math.max(0, columnScrollLeft);
-    const viewportEnd = viewportStart + Math.max(1, columnViewportWidth || 1);
-    let runningWidth = 0;
-    let firstVisibleIndex = 0;
-    let lastVisibleIndex = totalColumnCount - 1;
-    let foundFirst = false;
+    const virtualColumns = columnVirtualizer.getVirtualItems();
+    const firstColumn = virtualColumns[0];
+    const lastColumn = virtualColumns[virtualColumns.length - 1];
 
-    for (const [index, column] of columnLayout.entries()) {
-      const columnStart = runningWidth;
-      const columnEnd = columnStart + column.width;
-
-      if (!foundFirst && columnEnd > viewportStart) {
-        firstVisibleIndex = index;
-        foundFirst = true;
-      }
-      if (columnStart < viewportEnd) {
-        lastVisibleIndex = index;
-      }
-      runningWidth = columnEnd;
+    if (!firstColumn || !lastColumn) {
+      return {
+        firstIndex: 0,
+        lastIndex: totalColumnCount - 1,
+        beforeWidth: 0,
+        afterWidth: 0,
+        columnRenderCount: totalColumnCount,
+      };
     }
 
-    // One column of horizontal overscan keeps resize handles, filter menus and
-    // keyboard-driven edit navigation stable at both viewport edges.
-    const firstIndex = Math.max(0, firstVisibleIndex - 1);
-    const lastIndex = Math.min(totalColumnCount - 1, lastVisibleIndex + 1);
-    const beforeWidth = columnLayout
-      .slice(0, firstIndex)
-      .reduce((sum, column) => sum + column.width, 0);
-    const renderedWidth = columnLayout
-      .slice(firstIndex, lastIndex + 1)
-      .reduce((sum, column) => sum + column.width, 0);
-
     return {
-      firstIndex,
-      lastIndex,
-      beforeWidth,
-      afterWidth: Math.max(0, runningWidth - beforeWidth - renderedWidth),
-      columnRenderCount: lastIndex - firstIndex + 1,
+      firstIndex: firstColumn.index,
+      lastIndex: lastColumn.index,
+      beforeWidth: firstColumn.start,
+      afterWidth: Math.max(
+        0,
+        columnVirtualizer.getTotalSize() - lastColumn.end
+      ),
+      columnRenderCount: virtualColumns.length,
     };
-  }, [
-    columnLayout,
-    columnScrollLeft,
-    columnViewportWidth,
-    computedVirtualizeColumns,
-  ]);
+  })();
   const renderedColumnLayout = React.useMemo(() => {
     if (!computedVirtualizeColumns) return columnLayout;
 
@@ -2627,6 +2808,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const [resizeProxyLeft, setResizeProxyLeft] = React.useState<number | null>(
     null
   );
+  const resizeProxyElementRef = React.useRef<HTMLDivElement | null>(null);
+  const resizeProxyFrameRef = React.useRef<number | null>(null);
+  const resizeProxyNextLeftRef = React.useRef<number | null>(null);
   const [resizingColumnId, setResizingColumnId] = React.useState<string | null>(
     null
   );
@@ -2643,6 +2827,28 @@ function ReactDataGrid(props: TypeDataGridProps) {
     maxWidth: number;
   } | null>(null);
   const resizeCleanupRef = React.useRef<(() => void) | null>(null);
+
+  const cancelResizeProxyFrame = React.useCallback(() => {
+    if (resizeProxyFrameRef.current != null) {
+      window.cancelAnimationFrame(resizeProxyFrameRef.current);
+      resizeProxyFrameRef.current = null;
+    }
+    resizeProxyNextLeftRef.current = null;
+  }, []);
+
+  const scheduleResizeProxyPosition = React.useCallback((nextLeft: number) => {
+    resizeProxyNextLeftRef.current = nextLeft;
+    if (resizeProxyFrameRef.current != null) return;
+
+    resizeProxyFrameRef.current = window.requestAnimationFrame(() => {
+      resizeProxyFrameRef.current = null;
+      const proxy = resizeProxyElementRef.current;
+      const left = resizeProxyNextLeftRef.current;
+      if (!proxy || left == null) return;
+
+      proxy.style.transform = `translate3d(${left}px, 0, 0)`;
+    });
+  }, []);
 
   const captureRenderedColumnWidths = React.useCallback(() => {
     const headerCells = Array.from(
@@ -2883,6 +3089,20 @@ function ReactDataGrid(props: TypeDataGridProps) {
     ]
   );
 
+  const resizeColumnBy = React.useCallback(
+    (columnId: string, diff: number) => {
+      const column = orderedColumns.find(
+        (candidate) => getColumnId(candidate) === columnId
+      );
+      if (!column || !Number.isFinite(diff) || diff === 0) return;
+
+      const currentWidth =
+        columnWidths[columnId] ?? column.width ?? column.defaultWidth ?? 120;
+      commitColumnPixelResize(column, currentWidth + diff);
+    },
+    [columnWidths, commitColumnPixelResize, orderedColumns]
+  );
+
   const autosizeColumn = React.useCallback(
     (columnId: string) => {
       const column = orderedColumns.find(
@@ -2934,9 +3154,10 @@ function ReactDataGrid(props: TypeDataGridProps) {
     resizeCleanupRef.current = null;
     resizeSessionRef.current = null;
     cleanup?.();
+    cancelResizeProxyFrame();
     setResizeProxyLeft(null);
     setResizingColumnId(null);
-  }, []);
+  }, [cancelResizeProxyFrame]);
 
   const startColumnResize = React.useCallback(
     (
@@ -3036,7 +3257,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         );
 
         activeSession.nextWidth = nextWidth;
-        setResizeProxyLeft(activeSession.columnLeft + nextWidth);
+        scheduleResizeProxyPosition(activeSession.columnLeft + nextWidth);
       };
 
       const completeResize = () => {
@@ -3166,11 +3387,16 @@ function ReactDataGrid(props: TypeDataGridProps) {
       }
       window.addEventListener("blur", handleWindowBlur);
       setResizingColumnId(columnId);
-      setResizeProxyLeft(columnLeft + startWidth);
+      const initialProxyLeft = columnLeft + startWidth;
+      cancelResizeProxyFrame();
+      resizeProxyNextLeftRef.current = initialProxyLeft;
+      setResizeProxyLeft(initialProxyLeft);
     },
     [
+      cancelResizeProxyFrame,
       commitColumnPixelResize,
       orderedColumns,
+      scheduleResizeProxyPosition,
       seedManualColumnWidthsFromDom,
       showColumnMenuTool,
       stopColumnResize,
@@ -3183,8 +3409,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
       resizeCleanupRef.current = null;
       resizeSessionRef.current = null;
       cleanup?.();
+      cancelResizeProxyFrame();
     };
-  }, []);
+  }, [cancelResizeProxyFrame]);
 
   React.useEffect(() => {
     if (!resizingColumnId) return;
@@ -3251,7 +3478,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
     next.splice(from, 1);
     next.splice(to, 0, sourceId);
-    setColumnOrder(next);
+    table.setColumnOrder(next);
   }
 
   function onHeaderDragOver(e: React.DragEvent) {
@@ -3325,36 +3552,51 @@ function ReactDataGrid(props: TypeDataGridProps) {
       {}
     );
   }, [filterValue]);
+  const computedColumnLayoutMap = React.useMemo(
+    () =>
+      new Map(
+        columnLayout.map((column, visibleIndex) => [
+          column.id,
+          { ...column, visibleIndex },
+        ])
+      ),
+    [columnLayout]
+  );
   const allComputedColumns = React.useMemo<TypeComputedColumn[]>(() => {
     return allInputColumns.map((column, index) => {
       const columnId = getColumnId(column);
-      const computedVisibleIndex = orderedColumns.findIndex(
-        (candidate) => getColumnId(candidate) === columnId
-      );
+      const layout = computedColumnLayoutMap.get(columnId);
 
       return {
         ...column,
-        computedWidth: columnWidths[columnId],
-        computedVisibleIndex:
-          computedVisibleIndex >= 0 ? computedVisibleIndex : undefined,
+        computedWidth:
+          layout?.width ??
+          tanstackColumnSizing[columnId] ??
+          columnWidths[columnId],
+        computedVisibleIndex: layout?.visibleIndex,
         index,
       };
     });
-  }, [allInputColumns, columnWidths, orderedColumns]);
+  }, [
+    allInputColumns,
+    columnWidths,
+    computedColumnLayoutMap,
+    tanstackColumnSizing,
+  ]);
   const visibleComputedColumns = React.useMemo<TypeComputedColumn[]>(() => {
-    return orderedColumns.map((column, visibleIndex) => {
-      const columnId = getColumnId(column);
+    return columnLayout.map((layout, visibleIndex) => {
+      const columnId = layout.id;
       const computedColumn = allComputedColumns.find(
         (candidate) => getColumnId(candidate) === columnId
       );
 
       return {
-        ...(computedColumn ?? column),
-        computedWidth: columnWidths[columnId],
+        ...(computedColumn ?? { id: columnId }),
+        computedWidth: layout.width,
         computedVisibleIndex: visibleIndex,
       };
     });
-  }, [allComputedColumns, columnWidths, orderedColumns]);
+  }, [allComputedColumns, columnLayout]);
   const columnsMap = React.useMemo<TypeComputedColumnsMap>(() => {
     return Object.fromEntries(
       allComputedColumns.map((column) => [getColumnId(column), column])
@@ -3381,12 +3623,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
   }, [columnWidthAllocation.flexWeights]);
   const columnSizes = React.useMemo<Record<string, number>>(() => {
     return Object.fromEntries(
-      orderedColumns.map((column) => [
-        getColumnId(column),
-        Number(columnWidths[getColumnId(column)] ?? 0),
-      ])
+      columnLayout.map((column) => [column.id, Number(column.width)])
     );
-  }, [columnWidths, orderedColumns]);
+  }, [columnLayout]);
 
   const setLimitAndResetPage = React.useCallback(
     (next: number) => {
@@ -3435,9 +3674,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
       const internalNext = checkboxEnabled
         ? (injectIntoOrder(next, checkboxColId) ?? next)
         : next;
-      setColumnOrder(internalNext);
+      table.setColumnOrder(internalNext);
     },
-    [checkboxColId, checkboxEnabled, setColumnOrder]
+    [checkboxColId, checkboxEnabled, table]
   );
 
   const getColumnByCompat = React.useCallback(
@@ -3702,13 +3941,11 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const setScrollLeftCompat = React.useCallback((nextScrollLeft: number) => {
     if (!scrollRef.current) return;
     scrollRef.current.scrollLeft = nextScrollLeft;
-    setColumnScrollLeft(scrollRef.current.scrollLeft);
   }, []);
 
   const incrementScrollLeftCompat = React.useCallback((delta: number) => {
     if (!scrollRef.current) return;
     scrollRef.current.scrollLeft += delta;
-    setColumnScrollLeft(scrollRef.current.scrollLeft);
   }, []);
 
   const setScrollTopCompat = React.useCallback((nextScrollTop: number) => {
@@ -3790,7 +4027,6 @@ function ReactDataGrid(props: TypeDataGridProps) {
       }
 
       viewport.scrollLeft = Math.max(0, nextScrollLeft);
-      setColumnScrollLeft(viewport.scrollLeft);
 
       callback?.();
     },
@@ -3881,19 +4117,30 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
       return virtualRows.map((virtualRow) => {
         const row = rowModel[virtualRow.index];
+        const start = Math.max(
+          0,
+          virtualRow.start - (virtualized ? stickyHeaderOffset : 0)
+        );
+        const end = start + virtualRow.size;
 
         return {
           id: row?.id ?? virtualRow.index,
           index: virtualRow.index,
           rowIndex: virtualRow.index,
           data: row?.original,
-          top: virtualRow.start,
+          top: start,
           height: virtualRow.size,
-          start: virtualRow.start,
-          end: virtualRow.end,
+          start,
+          end,
         };
       });
-    }, [resolvedRowHeightLayout, rowModel, rowVirtualizer, virtualized]);
+    }, [
+      resolvedRowHeightLayout,
+      rowModel,
+      rowVirtualizer,
+      stickyHeaderOffset,
+      virtualized,
+    ]);
 
   const getTotalRowHeightCompat = React.useCallback(() => {
     return virtualized
@@ -3949,62 +4196,58 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   const smoothScrollToCompat = React.useCallback<
     TypeComputedVirtualList["smoothScrollTo"]
-  >(
-    (index, config, callback) => {
-      if (index < 0) return;
+  >((value, configOrCallback, callback) => {
+    const viewport = scrollRef.current;
+    if (!viewport || !Number.isFinite(value)) return;
 
-      const viewport = scrollRef.current;
-      if (!viewport) {
-        scrollToIndexCompat(index, config, callback);
-        return;
+    const config =
+      typeof configOrCallback === "function"
+        ? undefined
+        : (configOrCallback ?? undefined);
+    const resolvedCallback =
+      typeof configOrCallback === "function" ? configOrCallback : callback;
+    const horizontal = config?.orientation === "horizontal";
+    const duration = config?.duration ?? 100;
+    const initialValue = horizontal ? viewport.scrollLeft : viewport.scrollTop;
+    const writeValue = (nextValue: number) => {
+      if (horizontal) {
+        viewport.scrollLeft = nextValue;
+      } else {
+        viewport.scrollTop = nextValue;
       }
+    };
 
-      const maxIndex = Math.max(0, rowModel.length - 1);
-      const targetIndex = clamp(index, 0, maxIndex);
-      const alignEnd = config?.direction === "bottom" || config?.top === false;
-      const offset = config?.offset ?? 0;
+    if (!Number.isFinite(duration) || duration <= 0 || initialValue === value) {
+      writeValue(value);
+      resolvedCallback?.(value);
+      return;
+    }
 
-      if (virtualized) {
-        const offsetInfo = rowVirtualizer.getOffsetForIndex(
-          targetIndex,
-          alignEnd ? "end" : "start"
-        );
-
-        if (offsetInfo) {
-          viewport.scrollTo({
-            top: Math.max(0, offsetInfo[0] + offset),
-            behavior: "smooth",
-          });
-          callback?.();
-          return;
-        }
-
-        scrollToIndexCompat(targetIndex, config, callback);
-        return;
-      }
-
-      const targetRow = resolvedRowHeightLayout[targetIndex] ?? {
-        start: 0,
-        end: 0,
-      };
-      const top = alignEnd
-        ? targetRow.end - viewport.clientHeight + offset
-        : targetRow.start + offset;
-
-      viewport.scrollTo({
-        top: Math.max(0, top),
-        behavior: "smooth",
+    const scheduleFrame = (frameCallback: FrameRequestCallback) => {
+      let frameId = 0;
+      frameId = window.requestAnimationFrame((now) => {
+        smoothScrollFrameIdsRef.current.delete(frameId);
+        frameCallback(now);
       });
-      callback?.();
-    },
-    [
-      resolvedRowHeightLayout,
-      rowModel.length,
-      rowVirtualizer,
-      scrollToIndexCompat,
-      virtualized,
-    ]
-  );
+      smoothScrollFrameIdsRef.current.add(frameId);
+    };
+    const startedAt = window.performance.now();
+    const difference = value - initialValue;
+    const animate = (now: number) => {
+      const progress = Math.min(1, (now - startedAt) / duration);
+      writeValue(initialValue + difference * progress);
+
+      if (progress < 1) {
+        scheduleFrame(animate);
+        return;
+      }
+
+      writeValue(value);
+      resolvedCallback?.(value);
+    };
+
+    scheduleFrame(animate);
+  }, []);
 
   const refreshVirtualListLayoutCompat = React.useCallback(() => {
     if (virtualized) {
@@ -4060,9 +4303,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       },
       getRowAt: (index) => {
         const virtualRows = getVirtualListRowsCompat();
-        return (
-          virtualRows.find((row) => row.index === index) ?? virtualRows[index]
-        );
+        return virtualRows.find((row) => row.index === index);
       },
       getVisibleCount: getVirtualListVisibleCountCompat,
       getVisibleRange: getVirtualListRangeCompat,
@@ -4173,16 +4414,14 @@ function ReactDataGrid(props: TypeDataGridProps) {
       setColumnVisible: (column, visible) => {
         const columnId = getColumnIdCompat(column);
         if (!columnId) return;
+        if (!table.getColumn(columnId)) return;
 
+        // `hideable` constrains UI affordances, not the Inovua imperative API.
+        // Writing the sparse controlled override also avoids TanStack's
+        // `getCanHide()` gate for hideable:false columns.
         setColumnVisibilityState((current) => {
-          if (current[columnId] === visible) {
-            return current;
-          }
-
-          return {
-            ...current,
-            [columnId]: visible,
-          };
+          if (current[columnId] === visible) return current;
+          return { ...current, [columnId]: visible };
         });
       },
       gridId: gridIdRef.current,
@@ -4475,6 +4714,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     commitColumnPixelResize,
     commitColumnResizeEntries,
     computedVirtualizeColumns,
+    computedFilterValueMap,
     computedOnColumnFilterValueChangeCompat,
     count,
     dataSource,
@@ -4496,6 +4736,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
     getCurrentEditInfoCompat,
     i18n,
     idProperty,
+    incrementScrollLeftCompat,
+    incrementScrollTopCompat,
     isRowFullyVisibleCompat,
     isRowRenderedCompat,
     limit,
@@ -4525,6 +4767,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     setSelectedByIdCompat,
     setSelectedCompat,
     setShowZebraRows,
+    setSkip,
     setSortInfoAndResetPage,
     setScrollLeftCompat,
     setScrollTopCompat,
@@ -4536,6 +4779,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     sortInfo,
     stableApi,
     stableApiTarget,
+    table,
     startEditCompat,
     toggleColumnSortCompat,
     tryStartEditCompat,
@@ -4593,9 +4837,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
           >
             {resizeProxyLeft != null ? (
               <div
+                ref={resizeProxyElementRef}
                 className="InovuaReactDataGrid__resize-proxy"
                 aria-hidden="true"
-                style={{ left: `${resizeProxyLeft}px` }}
+                style={{
+                  transform: `translate3d(${resizeProxyLeft}px, 0, 0)`,
+                }}
               />
             ) : null}
             {mobileTransformActive ? (
@@ -4654,7 +4901,6 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           headerGroups={table.getHeaderGroups()}
                           headerHeight={headerHeight}
                           filterRowHeight={filterRowHeight}
-                          columnWidths={columnWidths}
                           sortInfo={sortInfo}
                           setSortInfo={setSortInfo}
                           setSkip={setSkip}
@@ -4673,6 +4919,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           onHeaderDrop={onHeaderDrop}
                           resizingColumnId={resizingColumnId}
                           onColumnResizeStart={startColumnResize}
+                          onColumnResizeBy={resizeColumnBy}
                           onColumnAutoResize={autosizeColumn}
                           enableFiltering={effectiveEnableFiltering}
                           enableColumnFilterContextMenu={
@@ -4758,7 +5005,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                     editingCell={coordinateEditingCell}
                     cellNodesRef={editCellNodesRef}
                     editStartEvent={editStartEvent}
-                    onCellEditStart={tryStartCellEdit}
+                    onCellEditStart={handleUiCellEditStart}
                     onEditValueChange={handleEditValueChange}
                     onEditComplete={handleEditComplete}
                     onEditStop={handleEditStop}

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -470,6 +470,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const checkboxColumnProp: TypeCheckboxColumn | undefined =
     props.checkboxColumn;
   const checkboxEnabled = Boolean(checkboxColumnProp);
+  const controlledSelected = props.selected !== undefined;
+  const selectionEnabled =
+    props.enableSelection !== undefined
+      ? Boolean(props.enableSelection)
+      : controlledSelected ||
+        props.defaultSelected !== undefined ||
+        checkboxEnabled;
 
   const checkboxColId = React.useMemo(() => {
     if (!checkboxEnabled) return "__checkbox__";
@@ -479,22 +486,30 @@ function ReactDataGrid(props: TypeDataGridProps) {
     return "__checkbox__";
   }, [checkboxEnabled, checkboxColumnProp]);
 
-  const multiSelect = (props as any).multiSelect ?? checkboxEnabled;
-  const checkboxOnlyRowSelect =
-    (props as any).checkboxOnlyRowSelect ?? checkboxEnabled;
+  const selectionValue = controlledSelected
+    ? props.selected
+    : props.defaultSelected;
+  const multiSelect = selectionEnabled
+    ? (props.multiSelect ??
+      ((typeof selectionValue === "object" && selectionValue !== null) ||
+        typeof selectionValue === "boolean" ||
+        (!controlledSelected && checkboxEnabled)))
+    : false;
+  const checkboxOnlyRowSelect = props.checkboxOnlyRowSelect ?? checkboxEnabled;
   const checkboxSelectEnableShiftKey =
-    (props as any).checkboxSelectEnableShiftKey ?? false;
+    props.checkboxSelectEnableShiftKey ?? false;
 
-  const controlledSelected = props.selected !== undefined;
   const [internalSelected, setInternalSelected] =
     React.useState<TypeRowSelection>(() => {
       if (props.defaultSelected !== undefined) return props.defaultSelected;
       return multiSelect ? {} : null;
     });
 
-  const selected: TypeRowSelection = controlledSelected
-    ? (props.selected as TypeRowSelection)
-    : internalSelected;
+  const selected: TypeRowSelection = selectionEnabled
+    ? controlledSelected
+      ? (props.selected as TypeRowSelection)
+      : internalSelected
+    : null;
   const selectedMap = React.useMemo(() => toSelectionMap(selected), [selected]);
 
   const lastSelectedIndexRef = React.useRef<number | null>(null);
@@ -507,6 +522,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
       nextMap: Record<string, any>,
       meta?: { data?: unknown; unselected?: TypeRowSelection }
     ) => {
+      if (!selectionEnabled) return;
+
       const nextSelected: TypeRowSelection = nextMap;
 
       if (!controlledSelected) setInternalSelected(nextSelected);
@@ -518,7 +535,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         originalData: dataSource,
       });
     },
-    [controlledSelected, dataSource, props]
+    [controlledSelected, dataSource, props, selectionEnabled]
   );
 
   /** ---------------- filter types ---------------- */
@@ -1166,8 +1183,6 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   /** ---------------- selection helpers ---------------- */
 
-  const selectionEnabled = checkboxEnabled || Boolean(props.onSelectionChange);
-
   const getRowKey = React.useCallback(
     (row: any, index: number) => {
       const v = row?.[idProperty];
@@ -1240,6 +1255,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
             const someSelected = selectedOnPage > 0 && !allSelected;
 
             const onChange = (checked: boolean) => {
+              if (!selectionEnabled) return;
+
               if (!multiSelect) {
                 const next: Record<string, any> = {};
                 if (checked && rows[0]) next[getRowKey(rows[0], 0)] = rows[0];
@@ -1263,7 +1280,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
             const checkboxProps: TypeCheckboxProps = {
               checked: allSelected,
               indeterminate: someSelected,
-              disabled: rows.length === 0,
+              disabled: !selectionEnabled || rows.length === 0,
               onChange,
             };
 
@@ -1344,7 +1361,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
             const checkboxProps: TypeCheckboxProps = {
               checked: isSelected,
-              disabled: false,
+              disabled: !selectionEnabled,
               onChange,
             };
 
@@ -3872,11 +3889,15 @@ function ReactDataGrid(props: TypeDataGridProps) {
         return rowId == null ? false : Boolean(selectedMap[String(rowId)]);
       },
       getSelectedCount: (selectionArg) =>
-        Object.keys(
-          toSelectionMap(
-            unwrapSelectionState(selectionArg ?? selected) as TypeRowSelection
-          )
-        ).length,
+        selectionEnabled
+          ? Object.keys(
+              toSelectionMap(
+                unwrapSelectionState(
+                  selectionArg ?? selected
+                ) as TypeRowSelection
+              )
+            ).length
+          : 0,
       computedSelectedCount: Object.keys(selectedMap).length,
       computedUnselectedCount: 0,
       setSelectedById: setSelectedByIdCompat,
@@ -4103,6 +4124,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     safeLimit,
     selected,
     selectedMap,
+    selectionEnabled,
     showZebraRows,
     setColumnFilterValueCompat,
     setColumnOrderCompat,

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -8,6 +8,7 @@ import type {
   TypeComputedColumn,
   TypeComputedColumnsMap,
   TypeComputedProps,
+  TypeColumnFilterValueChangeArg,
   TypeComputedVirtualList,
   TypeComputedVirtualListRow,
   TypeCompleteEditArgs,
@@ -348,6 +349,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     resizable = REACT_DATA_GRID_DEFAULT_PROPS.resizable,
 
     enableFiltering = REACT_DATA_GRID_DEFAULT_PROPS.enableFiltering,
+    onColumnFilterValueChange,
 
     filteredRowsCount,
 
@@ -3202,6 +3204,21 @@ function ReactDataGrid(props: TypeDataGridProps) {
     [filterControlled, setDraftFilterValue, setFilterValue, setSkip]
   );
 
+  const computedOnColumnFilterValueChangeCompat = React.useCallback(
+    (event: TypeColumnFilterValueChangeArg) => {
+      onColumnFilterValueChange?.(event);
+      setFilterValueAndResetPage(
+        upsertFilterEntry(filterValue, event.filterValue, { filterTypes })
+      );
+    },
+    [
+      filterTypes,
+      filterValue,
+      onColumnFilterValueChange,
+      setFilterValueAndResetPage,
+    ]
+  );
+
   const setColumnOrderCompat = React.useCallback(
     (next: string[]) => {
       const internalNext = checkboxEnabled
@@ -3325,7 +3342,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
   );
 
   const setColumnFilterValueCompat = React.useCallback(
-    (column: TypeGetColumnByParam, value: unknown) => {
+    (column: TypeGetColumnByParam, value: unknown, operator?: string) => {
       const resolved = getColumnByCompat(column, { initial: true });
       const columnId = resolved
         ? getColumnId(resolved)
@@ -3337,28 +3354,30 @@ function ReactDataGrid(props: TypeDataGridProps) {
         resolved as TypeColumn | undefined,
         existing
       );
-      const operator = resolveDefaultFilterOperator(filterType, existing);
-
-      setFilterValueAndResetPage(
-        upsertFilterEntry(
-          filterValue,
-          {
-            name: columnId,
-            type: filterType,
-            operator,
-            value,
-            active: undefined,
-          },
-          { filterTypes }
-        )
+      const nextOperator =
+        operator ?? resolveDefaultFilterOperator(filterType, existing);
+      const columnIndex = orderedColumns.findIndex(
+        (candidate) => getColumnId(candidate) === columnId
       );
+
+      computedOnColumnFilterValueChangeCompat({
+        columnId,
+        columnIndex,
+        filterValue: {
+          ...(existing ?? {}),
+          name: columnId,
+          type: filterType,
+          operator: nextOperator,
+          value,
+        },
+      });
     },
     [
-      filterTypes,
+      computedOnColumnFilterValueChangeCompat,
       filterValue,
       getColumnByCompat,
       getColumnIdCompat,
-      setFilterValueAndResetPage,
+      orderedColumns,
     ]
   );
 
@@ -3367,11 +3386,39 @@ function ReactDataGrid(props: TypeDataGridProps) {
       const columnId = getColumnIdCompat(column);
       if (!columnId) return;
 
-      setFilterValueAndResetPage(
-        clearFilter(filterValue, columnId, { filterTypes })
+      const existing = getFilterEntry(filterValue, columnId);
+      if (!existing) {
+        setFilterValueAndResetPage(
+          clearFilter(filterValue, columnId, { filterTypes })
+        );
+        return;
+      }
+
+      const next = clearFilter(filterValue, columnId, { filterTypes });
+      const clearedEntry = getFilterEntry(next, columnId);
+      if (!clearedEntry) return;
+
+      const columnIndex = orderedColumns.findIndex(
+        (candidate) => getColumnId(candidate) === columnId
       );
+
+      computedOnColumnFilterValueChangeCompat({
+        columnId,
+        columnIndex,
+        filterValue: {
+          ...existing,
+          value: clearedEntry.value,
+        },
+      });
     },
-    [filterTypes, filterValue, getColumnIdCompat, setFilterValueAndResetPage]
+    [
+      computedOnColumnFilterValueChangeCompat,
+      filterTypes,
+      filterValue,
+      getColumnIdCompat,
+      orderedColumns,
+      setFilterValueAndResetPage,
+    ]
   );
 
   const setSelectedCompat = React.useCallback(
@@ -3892,6 +3939,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
       clearColumnFilter: clearColumnFilterCompat,
       getColumnFilterValue: getColumnFilterValueCompat,
       setColumnFilterValue: setColumnFilterValueCompat,
+      computedOnColumnFilterValueChange:
+        computedOnColumnFilterValueChangeCompat,
       isColumnFiltered: (column) => {
         const entry = getColumnFilterValueCompat(column);
         return Boolean(entry && entry.active !== false);
@@ -4214,6 +4263,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     commitColumnPixelResize,
     commitColumnResizeEntries,
     computedVirtualizeColumns,
+    computedOnColumnFilterValueChangeCompat,
     count,
     dataSource,
     editable,
@@ -4419,6 +4469,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           draftFilterValue={draftFilterValue}
                           setFilterValue={setFilterValue}
                           setDraftFilterValue={setDraftFilterValue}
+                          onColumnFilterValueChange={onColumnFilterValueChange}
                           filterTypes={filterTypes}
                           openFilterMenuColId={openFilterMenuColId}
                           setOpenFilterMenuColId={setOpenFilterMenuColId}

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -385,9 +385,26 @@ function ReactDataGrid(props: TypeDataGridProps) {
     style,
   } = props;
 
-  const [uncontrolledShowZebraRows] = React.useState(
-    () =>
-      defaultShowZebraRows ?? REACT_DATA_GRID_DEFAULT_PROPS.defaultShowZebraRows
+  const [uncontrolledShowZebraRows, setUncontrolledShowZebraRows] =
+    React.useState(
+      () =>
+        defaultShowZebraRows ??
+        REACT_DATA_GRID_DEFAULT_PROPS.defaultShowZebraRows
+    );
+  const showZebraRowsControlled = controlledShowZebraRows !== undefined;
+  const showZebraRowsControlledRef = React.useRef(showZebraRowsControlled);
+  React.useLayoutEffect(() => {
+    showZebraRowsControlledRef.current = showZebraRowsControlled;
+  }, [showZebraRowsControlled]);
+  const setShowZebraRows = React.useCallback(
+    (nextValue: React.SetStateAction<boolean>) => {
+      if (showZebraRowsControlledRef.current) return;
+
+      setUncontrolledShowZebraRows((current) =>
+        resolveStateAction(nextValue, current)
+      );
+    },
+    []
   );
   const showZebraRows = controlledShowZebraRows ?? uncontrolledShowZebraRows;
 
@@ -4143,6 +4160,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       computedHasRowNavigation: false,
       computedShowHoverRows: true,
       computedShowZebraRows: showZebraRows,
+      setShowZebraRows,
       computedEditable: editable,
       computedEditStartEvent: editStartEvent,
       computedIsEditing: editingCell != null,
@@ -4305,6 +4323,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     setSelectedAtCompat,
     setSelectedByIdCompat,
     setSelectedCompat,
+    setShowZebraRows,
     setSortInfoAndResetPage,
     setScrollLeftCompat,
     setScrollTopCompat,

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -4394,6 +4394,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                 loading={loading}
                 selectedMap={selectedMap}
                 i18n={i18n}
+                emptyText={props.emptyText}
                 sortInfo={sortInfo}
                 defaultSortDirection={defaultSortDir}
                 searchEnabled={!searchConnected}
@@ -4512,6 +4513,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                     stickyHeaderOffset={stickyHeaderOffset}
                     loading={loading}
                     i18n={i18n}
+                    emptyText={props.emptyText}
                     selectedMap={selectedMap}
                     onRowClick={(id, data, e) => handleRowClick(id, data, e)}
                     rowHeight={rowHeight}

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -82,6 +82,7 @@ import {
   type GridEditNavigation,
 } from "./components/GridBody";
 import { buildEditCellProps } from "./utils/editing";
+import { resolveConfiguredRowHeight } from "./utils/rowHeight";
 import { GridPagination } from "./components/GridPagination";
 import { MobileGridList } from "./components/MobileGridList";
 import { allocateColumnWidths } from "./utils/columnSizing";
@@ -1553,21 +1554,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
       ? maxRowHeight
       : undefined;
   const resolveRowHeight = React.useCallback(
-    (rowIndex: number) => {
-      if (rowHeight == null) return computedMinRowHeight;
-
-      const requestedHeight =
-        typeof rowHeight === "function" ? rowHeight(rowIndex) : rowHeight;
-      const finiteHeight =
-        typeof requestedHeight === "number" && Number.isFinite(requestedHeight)
-          ? requestedHeight
-          : computedMinRowHeight;
-
-      return Math.min(
-        Math.max(finiteHeight, computedMinRowHeight),
-        computedMaxRowHeight ?? Number.POSITIVE_INFINITY
-      );
-    },
+    (rowIndex: number) =>
+      resolveConfiguredRowHeight({
+        rowHeight,
+        rowIndex,
+        minRowHeight: computedMinRowHeight,
+        maxRowHeight: computedMaxRowHeight,
+      }),
     [computedMaxRowHeight, computedMinRowHeight, rowHeight]
   );
   const initialRowHeight = resolveRowHeight(0);

--- a/src/grid/components/FilterCell.tsx
+++ b/src/grid/components/FilterCell.tsx
@@ -5,7 +5,9 @@ import { IconChevronDown } from "@tabler/icons-react";
 import { X } from "lucide-react";
 
 import type {
+  TypeCellProps,
   TypeColumn,
+  TypeColumnFilterValueChangeArg,
   TypeFilterTypes,
   TypeFilterValue,
   TypeI18n,
@@ -72,6 +74,7 @@ export type FilterCellProps = {
   draftFilterValue: TypeFilterValue;
   setFilterValue: (v: TypeFilterValue) => void;
   setDraftFilterValue: React.Dispatch<React.SetStateAction<TypeFilterValue>>;
+  onColumnFilterValueChange?: (event: TypeColumnFilterValueChangeArg) => void;
 
   setSkip: (n: number) => void;
 
@@ -167,6 +170,7 @@ export function FilterCell(props: FilterCellProps) {
     draftFilterValue,
     setFilterValue,
     setDraftFilterValue,
+    onColumnFilterValueChange,
     setSkip,
     filterTypes,
     showHorizontalCellBorders,
@@ -212,6 +216,18 @@ export function FilterCell(props: FilterCellProps) {
 
   const operatorMenuEnabled = enableColumnFilterContextMenu && filterable;
   const filterCellPadding = normalizeFilterCellPadding(col?.filterCellPadding);
+  const filterCellContext = React.useMemo<TypeCellProps>(
+    () => ({
+      rowIndex: -1,
+      columnIndex,
+      computedVisibleIndex: columnIndex,
+      id: colId,
+      name: colId,
+      columnId: colId,
+      column: col,
+    }),
+    [col, colId, columnIndex]
+  );
 
   // Resolve filterEditorProps (supports function form)
   const filterEditorPropsAny = (col as any)?.filterEditorProps;
@@ -230,15 +246,44 @@ export function FilterCell(props: FilterCellProps) {
     }
   }
 
+  function emitColumnFilterValueChange(nextEntry: TypeSingleFilterValue) {
+    onColumnFilterValueChange?.({
+      filterValue: nextEntry,
+      columnId: colId,
+      columnIndex,
+      cellProps: filterCellContext,
+    });
+  }
+
   const onClear = () => {
-    applyFilterNow(clearFilter(filterValue, colId, { filterTypes }));
+    const next = clearFilter(currentFilter, colId, { filterTypes });
+    const clearedEntry = getFilterEntry(next, colId);
+
+    if (entry && clearedEntry) {
+      emitColumnFilterValueChange({
+        ...entry,
+        value: clearedEntry.value,
+        active: entry.active,
+      });
+    }
+
+    applyFilterNow(next);
   };
 
   const onSelectOperator = (nextOp: string) => {
-    const next = setFilterOperator(filterValue, colId, nextOp, {
+    const next = setFilterOperator(currentFilter, colId, nextOp, {
       filterTypes,
       type: filterTypeName,
     });
+    const nextEntry = getFilterEntry(next, colId);
+
+    if (nextEntry) {
+      emitColumnFilterValueChange({
+        ...nextEntry,
+        active: entry?.active,
+      });
+    }
+
     applyFilterNow(next);
   };
 
@@ -253,6 +298,7 @@ export function FilterCell(props: FilterCellProps) {
       active: undefined,
     };
 
+    emitColumnFilterValueChange(nextEntry);
     setSkip(0);
     if (filterControlled) {
       setFilterValue(
@@ -292,13 +338,15 @@ export function FilterCell(props: FilterCellProps) {
           ? "border-r last:border-r-0 [border-right-color:var(--tdg-filter-border-color)]"
           : ""
       )}
-      style={{
-        width,
-        minWidth: col?.minWidth,
-        maxWidth: col?.maxWidth,
-        height: filterRowHeight,
-        "--tdg-filter-cell-padding": filterCellPadding,
-      } as React.CSSProperties}
+      style={
+        {
+          width,
+          minWidth: col?.minWidth,
+          maxWidth: col?.maxWidth,
+          height: filterRowHeight,
+          "--tdg-filter-cell-padding": filterCellPadding,
+        } as React.CSSProperties
+      }
       onContextMenu={(e) => {
         if (!operatorMenuEnabled) return;
         e.preventDefault();

--- a/src/grid/components/FilterCell.tsx
+++ b/src/grid/components/FilterCell.tsx
@@ -495,7 +495,7 @@ export function FilterCell(props: FilterCellProps) {
               type="button"
               variant="ghost"
               size="icon"
-              className="InovuaReactDataGrid__column-header__filter-clear size-6 shrink-0 rounded-none border-0 bg-transparent p-0 text-[var(--tdg-filter-tool-color)] shadow-none hover:bg-transparent hover:text-[var(--tdg-filter-tool-hover-color)] focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="InovuaReactDataGrid__column-header__filter-clear size-6 shrink-0 rounded-none border-0 bg-transparent p-0 text-[var(--tdg-filter-tool-color)] shadow-none hover:bg-transparent hover:text-[var(--tdg-filter-tool-hover-color)]"
               aria-label={clearLabel}
               title={clearLabel}
               onMouseDown={(event) => event.stopPropagation()}

--- a/src/grid/components/GridBody.tsx
+++ b/src/grid/components/GridBody.tsx
@@ -138,6 +138,14 @@ export type GridBodyProps = {
   showVerticalCellBorders: boolean;
 
   virtualized: boolean;
+  virtualizeColumns: boolean;
+  columnRenderRange: {
+    firstIndex: number;
+    lastIndex: number;
+    beforeWidth: number;
+    afterWidth: number;
+    columnRenderCount: number;
+  };
   virtualItems: any[];
   paddingTop: number;
   paddingBottom: number;
@@ -159,6 +167,9 @@ export type GridBodyProps = {
     totalComputedWidth: number;
     remoteRowOffset: number;
     columns: TypeComputedColumn[];
+    columnRenderCount: number;
+    totalColumnCount: number;
+    virtualizeColumns: boolean;
     columnsMap: TypeComputedColumnsMap;
     dataSourceArray: any[];
     theme: string;
@@ -196,6 +207,8 @@ export function GridBody(props: GridBodyProps) {
     showHorizontalCellBorders,
     showVerticalCellBorders,
     virtualized,
+    virtualizeColumns,
+    columnRenderRange,
     virtualItems,
     paddingTop,
     paddingBottom,
@@ -221,6 +234,11 @@ export function GridBody(props: GridBodyProps) {
     onEditCancel,
   } = props;
   const [hoveredCellId, setHoveredCellId] = React.useState<string | null>(null);
+  const renderedTableColumnCount = virtualizeColumns
+    ? columnRenderRange.columnRenderCount +
+      (columnRenderRange.beforeWidth > 0 ? 1 : 0) +
+      (columnRenderRange.afterWidth > 0 ? 1 : 0)
+    : orderedColumns.length;
 
   function getRowThemeClasses(
     rowIndex: number,
@@ -318,8 +336,8 @@ export function GridBody(props: GridBodyProps) {
               lastNonEmpty: rowIndex === rowModel.length - 1,
               columns: rowStyleMetadata.columns,
               columnsMap: rowStyleMetadata.columnsMap,
-              columnRenderCount: rowStyleMetadata.columns.length,
-              totalColumnCount: rowStyleMetadata.columns.length,
+              columnRenderCount: rowStyleMetadata.columnRenderCount,
+              totalColumnCount: rowStyleMetadata.totalColumnCount,
               firstUnlockedIndex: rowStyleMetadata.columns.length > 0 ? 0 : -1,
               lastUnlockedIndex: rowStyleMetadata.columns.length - 1,
               firstLockedStartIndex: -1,
@@ -363,7 +381,7 @@ export function GridBody(props: GridBodyProps) {
                     editColumnId: editingCell.columnId,
                   }
                 : {}),
-              virtualizeColumns: false,
+              virtualizeColumns: rowStyleMetadata.virtualizeColumns,
               theme: rowStyleMetadata.theme,
               getItemId: rowStyleMetadata.getItemId,
             },
@@ -428,6 +446,7 @@ export function GridBody(props: GridBodyProps) {
       editStartEvent,
       theme: rowStyleMetadata.theme,
       totalDataCount: rowStyleMetadata.dataSourceArray.length,
+      virtualizeColumns,
     });
 
     const toNavigation = (
@@ -578,129 +597,169 @@ export function GridBody(props: GridBodyProps) {
         ? { maxHeight: Math.max(0, contentHeightLimit - 16) }
         : undefined;
 
-    return row.getVisibleCells().map((cell: any, cellIndex: number) => {
-      const columnId = cell.column.id;
-      const column = (cell.column.columnDef as any)?.meta?.__column as
-        | TypeColumn
-        | undefined;
-      const width = columnWidths[columnId];
-      const align = column?.textAlign;
-      const isLastCell = cellIndex === row.getVisibleCells().length - 1;
-      const editor = column
-        ? renderEditor(row, rowIndex, cellIndex, column, columnId)
-        : null;
+    const allCells = row.getVisibleCells();
+    const renderedCells = virtualizeColumns
+      ? allCells.slice(
+          columnRenderRange.firstIndex,
+          columnRenderRange.lastIndex + 1
+        )
+      : allCells;
 
-      const startEdit = () => {
-        if (!column) return;
-        const value = cell.getValue();
-        const rowId = getCompatRowId(row, rowStyleMetadata.getItemId);
-        const cellProps = buildEditCellProps({
-          value,
-          data: row.original,
-          rowIndex,
-          remoteRowIndex: rowStyleMetadata.remoteRowOffset + rowIndex,
-          rowId,
-          rowSelected: Boolean(selectedMap[String(row.id)]),
-          selection: rowStyleMetadata.selection,
-          multiSelect: rowStyleMetadata.multiSelect,
-          naturalRowHeight: rowHeight == null,
-          resolvedRowHeight: getResolvedRowHeight(rowIndex) ?? minRowHeight,
-          minRowHeight,
-          column,
-          columnId,
-          columnIndex: cellIndex,
-          columnCount: orderedColumns.length,
-          computedWidth: width,
-          editable: rowStyleMetadata.editable,
-          editStartEvent,
-          theme: rowStyleMetadata.theme,
-          totalDataCount: rowStyleMetadata.dataSourceArray.length,
-        });
+    return (
+      <>
+        {columnRenderRange.beforeWidth > 0 && virtualizeColumns ? (
+          <TableCell
+            aria-hidden="true"
+            className="pointer-events-none !p-0"
+            style={{
+              width: columnRenderRange.beforeWidth,
+              minWidth: columnRenderRange.beforeWidth,
+              maxWidth: columnRenderRange.beforeWidth,
+            }}
+          />
+        ) : null}
+        {renderedCells.map((cell: any, renderedIndex: number) => {
+          const cellIndex = virtualizeColumns
+            ? columnRenderRange.firstIndex + renderedIndex
+            : renderedIndex;
+          const columnId = cell.column.id;
+          const column = (cell.column.columnDef as any)?.meta?.__column as
+            | TypeColumn
+            | undefined;
+          const width = columnWidths[columnId];
+          const align = column?.textAlign;
+          const isLastCell = cellIndex === allCells.length - 1;
+          const editor = column
+            ? renderEditor(row, rowIndex, cellIndex, column, columnId)
+            : null;
 
-        onCellEditStart({
-          rowId,
-          rowIndex,
-          columnId,
-          columnIndex: cellIndex,
-          value,
-          data: row.original,
-          column,
-          cellProps,
-        });
-      };
-      const normalizedStartEvent = editStartEvent.toLowerCase();
+          const startEdit = () => {
+            if (!column) return;
+            const value = cell.getValue();
+            const rowId = getCompatRowId(row, rowStyleMetadata.getItemId);
+            const cellProps = buildEditCellProps({
+              value,
+              data: row.original,
+              rowIndex,
+              remoteRowIndex: rowStyleMetadata.remoteRowOffset + rowIndex,
+              rowId,
+              rowSelected: Boolean(selectedMap[String(row.id)]),
+              selection: rowStyleMetadata.selection,
+              multiSelect: rowStyleMetadata.multiSelect,
+              naturalRowHeight: rowHeight == null,
+              resolvedRowHeight: getResolvedRowHeight(rowIndex) ?? minRowHeight,
+              minRowHeight,
+              column,
+              columnId,
+              columnIndex: cellIndex,
+              columnCount: orderedColumns.length,
+              computedWidth: width,
+              editable: rowStyleMetadata.editable,
+              editStartEvent,
+              theme: rowStyleMetadata.theme,
+              totalDataCount: rowStyleMetadata.dataSourceArray.length,
+              virtualizeColumns,
+            });
 
-      return (
-        <TableCell
-          ref={(node) => {
-            const key = `${String(row.id)}\u0000${columnId}`;
-            if (node) cellNodesRef.current.set(key, node);
-            else cellNodesRef.current.delete(key);
-          }}
-          key={cell.id}
-          data-column-id={columnId}
-          data-column-index={cellIndex}
-          data-editing={editor ? "true" : "false"}
-          className={cn(
-            userSelectClass,
-            "InovuaReactDataGrid__cell",
-            "InovuaReactDataGrid__cell--direction-ltr",
-            showHorizontalCellBorders
-              ? "InovuaReactDataGrid__cell--show-border-bottom"
-              : "",
-            showVerticalCellBorders
-              ? "InovuaReactDataGrid__cell--show-border-right"
-              : "",
-            isLastCell ? "InovuaReactDataGrid__cell--last" : "",
-            hoveredCellId === cell.id ? "InovuaReactDataGrid__cell--over" : "",
-            showHorizontalCellBorders
-              ? "border-b [border-bottom-color:var(--tdg-cell-border-color)]"
-              : "",
-            showVerticalCellBorders
-              ? "border-r last:border-r-0 [border-right-color:var(--tdg-cell-border-color)]"
-              : "",
-            align === "right" || align === "end" ? "text-right" : "",
-            column?.className
-          )}
-          style={{
-            width,
-            minWidth: column?.minWidth,
-            maxWidth: column?.maxWidth,
-            ...(typeof column?.style === "object" && column?.style
-              ? column.style
-              : {}),
-          }}
-          onClick={() => {
-            if (
-              normalizedStartEvent === "click" ||
-              normalizedStartEvent === "onclick"
-            ) {
-              startEdit();
-            }
-          }}
-          onDoubleClick={() => {
-            if (
-              normalizedStartEvent === "dblclick" ||
-              normalizedStartEvent === "doubleclick" ||
-              normalizedStartEvent === "ondoubleclick"
-            ) {
-              startEdit();
-            }
-          }}
-          onMouseEnter={() => setHoveredCellId(cell.id)}
-          onMouseLeave={() => {
-            setHoveredCellId((current) =>
-              current === cell.id ? null : current
-            );
-          }}
-        >
-          <div className="tdg-cell-content" style={contentStyle}>
-            {editor ??
-              flexRender(cell.column.columnDef.cell, cell.getContext())}
-          </div>
-        </TableCell>
-      );
-    });
+            onCellEditStart({
+              rowId,
+              rowIndex,
+              columnId,
+              columnIndex: cellIndex,
+              value,
+              data: row.original,
+              column,
+              cellProps,
+            });
+          };
+          const normalizedStartEvent = editStartEvent.toLowerCase();
+
+          return (
+            <TableCell
+              ref={(node) => {
+                const key = `${String(row.id)}\u0000${columnId}`;
+                if (node) cellNodesRef.current.set(key, node);
+                else cellNodesRef.current.delete(key);
+              }}
+              key={cell.id}
+              data-column-id={columnId}
+              data-column-index={cellIndex}
+              data-editing={editor ? "true" : "false"}
+              className={cn(
+                userSelectClass,
+                "InovuaReactDataGrid__cell",
+                "InovuaReactDataGrid__cell--direction-ltr",
+                showHorizontalCellBorders
+                  ? "InovuaReactDataGrid__cell--show-border-bottom"
+                  : "",
+                showVerticalCellBorders
+                  ? "InovuaReactDataGrid__cell--show-border-right"
+                  : "",
+                isLastCell ? "InovuaReactDataGrid__cell--last" : "",
+                hoveredCellId === cell.id
+                  ? "InovuaReactDataGrid__cell--over"
+                  : "",
+                showHorizontalCellBorders
+                  ? "border-b [border-bottom-color:var(--tdg-cell-border-color)]"
+                  : "",
+                showVerticalCellBorders
+                  ? "border-r last:border-r-0 [border-right-color:var(--tdg-cell-border-color)]"
+                  : "",
+                align === "right" || align === "end" ? "text-right" : "",
+                column?.className
+              )}
+              style={{
+                width,
+                minWidth: column?.minWidth,
+                maxWidth: column?.maxWidth,
+                ...(typeof column?.style === "object" && column?.style
+                  ? column.style
+                  : {}),
+              }}
+              onClick={() => {
+                if (
+                  normalizedStartEvent === "click" ||
+                  normalizedStartEvent === "onclick"
+                ) {
+                  startEdit();
+                }
+              }}
+              onDoubleClick={() => {
+                if (
+                  normalizedStartEvent === "dblclick" ||
+                  normalizedStartEvent === "doubleclick" ||
+                  normalizedStartEvent === "ondoubleclick"
+                ) {
+                  startEdit();
+                }
+              }}
+              onMouseEnter={() => setHoveredCellId(cell.id)}
+              onMouseLeave={() => {
+                setHoveredCellId((current) =>
+                  current === cell.id ? null : current
+                );
+              }}
+            >
+              <div className="tdg-cell-content" style={contentStyle}>
+                {editor ??
+                  flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </div>
+            </TableCell>
+          );
+        })}
+        {columnRenderRange.afterWidth > 0 && virtualizeColumns ? (
+          <TableCell
+            aria-hidden="true"
+            className="pointer-events-none !p-0"
+            style={{
+              width: columnRenderRange.afterWidth,
+              minWidth: columnRenderRange.afterWidth,
+              maxWidth: columnRenderRange.afterWidth,
+            }}
+          />
+        ) : null}
+      </>
+    );
   }
 
   if (loading && rowModel.length === 0) {
@@ -709,14 +768,14 @@ export function GridBody(props: GridBodyProps) {
         {stickyHeaderOffset > 0 ? (
           <TableRow aria-hidden="true">
             <TableCell
-              colSpan={orderedColumns.length}
+              colSpan={renderedTableColumnCount}
               style={{ height: stickyHeaderOffset }}
             />
           </TableRow>
         ) : null}
         <TableRow>
           <TableCell
-            colSpan={orderedColumns.length}
+            colSpan={renderedTableColumnCount}
             className={cn(
               "h-24 text-center",
               showHorizontalCellBorders
@@ -737,14 +796,14 @@ export function GridBody(props: GridBodyProps) {
         {stickyHeaderOffset > 0 ? (
           <TableRow aria-hidden="true">
             <TableCell
-              colSpan={orderedColumns.length}
+              colSpan={renderedTableColumnCount}
               style={{ height: stickyHeaderOffset }}
             />
           </TableRow>
         ) : null}
         <TableRow>
           <TableCell
-            colSpan={orderedColumns.length}
+            colSpan={renderedTableColumnCount}
             className={cn(
               "h-24 text-center",
               showHorizontalCellBorders
@@ -766,7 +825,7 @@ export function GridBody(props: GridBodyProps) {
           {paddingTop > 0 && (
             <TableRow>
               <TableCell
-                colSpan={orderedColumns.length}
+                colSpan={renderedTableColumnCount}
                 style={{ height: paddingTop }}
               />
             </TableRow>
@@ -808,7 +867,7 @@ export function GridBody(props: GridBodyProps) {
           {paddingBottom > 0 && (
             <TableRow>
               <TableCell
-                colSpan={orderedColumns.length}
+                colSpan={renderedTableColumnCount}
                 style={{ height: paddingBottom }}
               />
             </TableRow>
@@ -819,7 +878,7 @@ export function GridBody(props: GridBodyProps) {
           {stickyHeaderOffset > 0 ? (
             <TableRow aria-hidden="true">
               <TableCell
-                colSpan={orderedColumns.length}
+                colSpan={renderedTableColumnCount}
                 style={{ height: stickyHeaderOffset }}
               />
             </TableRow>

--- a/src/grid/components/GridBody.tsx
+++ b/src/grid/components/GridBody.tsx
@@ -19,6 +19,7 @@ import type {
 import { cn } from "../../lib/utils";
 import { buildEditCellProps } from "../utils/editing";
 import { resolveEmptyText } from "../utils/emptyText";
+import { resolveConfiguredRowHeight } from "../utils/rowHeight";
 
 import { Input } from "../../components/ui/input";
 import { TableBody, TableCell, TableRow } from "../../components/ui/table";
@@ -280,17 +281,12 @@ export function GridBody(props: GridBodyProps) {
   function getResolvedRowHeight(rowIndex: number): number | null {
     if (rowHeight == null) return null;
 
-    const requestedHeight =
-      typeof rowHeight === "function" ? rowHeight(rowIndex) : rowHeight;
-    const finiteHeight = Number.isFinite(requestedHeight)
-      ? requestedHeight
-      : minRowHeight;
-    const upperBound =
-      typeof maxRowHeight === "number" && Number.isFinite(maxRowHeight)
-        ? Math.max(minRowHeight, maxRowHeight)
-        : Number.POSITIVE_INFINITY;
-
-    return Math.min(Math.max(finiteHeight, minRowHeight), upperBound);
+    return resolveConfiguredRowHeight({
+      rowHeight,
+      rowIndex,
+      minRowHeight,
+      maxRowHeight,
+    });
   }
 
   function getRowStyle(
@@ -312,7 +308,9 @@ export function GridBody(props: GridBodyProps) {
       width: rowStyleMetadata.totalComputedWidth,
       minWidth: rowStyleMetadata.totalComputedWidth,
       direction: "ltr",
-      ...(typeof maxRowHeight === "number" && Number.isFinite(maxRowHeight)
+      ...(typeof rowHeight !== "number" &&
+      typeof maxRowHeight === "number" &&
+      Number.isFinite(maxRowHeight)
         ? { maxHeight: maxRowHeight }
         : {}),
       ...getRowThemeStyle(rowIsSelected),

--- a/src/grid/components/GridBody.tsx
+++ b/src/grid/components/GridBody.tsx
@@ -10,14 +10,15 @@ import type {
   TypeColumnEditorProps,
   TypeComputedColumn,
   TypeComputedColumnsMap,
+  TypeDataGridProps,
   TypeI18n,
   TypeRowSelection,
   TypeRowStyle,
   TypeShowCellBorders,
 } from "../../types";
 import { cn } from "../../lib/utils";
-import { t } from "../../utils/helpers";
 import { buildEditCellProps } from "../utils/editing";
+import { resolveEmptyText } from "../utils/emptyText";
 
 import { Input } from "../../components/ui/input";
 import { TableBody, TableCell, TableRow } from "../../components/ui/table";
@@ -153,6 +154,7 @@ export type GridBodyProps = {
 
   loading: boolean;
   i18n?: TypeI18n;
+  emptyText: TypeDataGridProps["emptyText"];
 
   selectedMap: Record<string, any>;
   onRowClick?: (rowId: string, rowData: any, e: React.MouseEvent) => void;
@@ -215,6 +217,7 @@ export function GridBody(props: GridBodyProps) {
     stickyHeaderOffset,
     loading,
     i18n,
+    emptyText,
     selectedMap,
     onRowClick,
     rowHeight,
@@ -791,6 +794,8 @@ export function GridBody(props: GridBodyProps) {
   }
 
   if (rowModel.length === 0) {
+    const emptyContent = resolveEmptyText(emptyText, i18n);
+
     return (
       <TableBody>
         {stickyHeaderOffset > 0 ? (
@@ -801,19 +806,21 @@ export function GridBody(props: GridBodyProps) {
             />
           </TableRow>
         ) : null}
-        <TableRow>
-          <TableCell
-            colSpan={renderedTableColumnCount}
-            className={cn(
-              "h-24 text-center",
-              showHorizontalCellBorders
-                ? "border-b [border-bottom-color:var(--tdg-cell-border-color)]"
-                : ""
-            )}
-          >
-            {t(i18n, "noRecords", "No records")}
-          </TableCell>
-        </TableRow>
+        {emptyContent == null ? null : (
+          <TableRow>
+            <TableCell
+              colSpan={renderedTableColumnCount}
+              className={cn(
+                "h-24 text-center",
+                showHorizontalCellBorders
+                  ? "border-b [border-bottom-color:var(--tdg-cell-border-color)]"
+                  : ""
+              )}
+            >
+              {emptyContent}
+            </TableCell>
+          </TableRow>
+        )}
       </TableBody>
     );
   }

--- a/src/grid/components/GridBody.tsx
+++ b/src/grid/components/GridBody.tsx
@@ -21,7 +21,6 @@ import { buildEditCellProps } from "../utils/editing";
 import { resolveEmptyText } from "../utils/emptyText";
 import { resolveConfiguredRowHeight } from "../utils/rowHeight";
 
-import { Input } from "../../components/ui/input";
 import { TableBody, TableCell, TableRow } from "../../components/ui/table";
 
 export type GridEditingCell = {
@@ -35,6 +34,7 @@ export type GridEditingCell = {
   data: any;
   column: TypeColumn;
   cellProps: CellProps;
+  initialCellHeight: number | null;
 };
 
 export type GridCellEditStartArgs = {
@@ -46,6 +46,7 @@ export type GridCellEditStartArgs = {
   data: any;
   column: TypeColumn;
   cellProps: CellProps;
+  initialCellHeight: number | null;
 };
 
 export type GridEditNavigation = {
@@ -91,10 +92,11 @@ function DefaultCellEditor(props: {
   }, []);
 
   return (
-    <Input
+    <input
       ref={inputRef}
       aria-label={props.ariaLabel}
-      className="tdg-cell-editor h-8 min-w-0 rounded-md px-2 py-1 text-sm"
+      className="tdg-cell-editor InovuaReactDataGrid__cell__editor InovuaReactDataGrid__cell__editor--text"
+      data-slot="cell-editor"
       value={props.value == null ? "" : String(props.value)}
       onChange={(event) => props.onChange(event.target.value)}
       onBlur={() => props.onComplete()}
@@ -129,6 +131,52 @@ function DefaultCellEditor(props: {
       }}
     />
   );
+}
+
+const SEAMLESS_CELL_EDITOR_SELECTOR =
+  '.tdg-cell-editor[data-slot="cell-editor"], .InovuaReactDataGrid__cell__editor';
+
+function CellEditorSurfaceSync(props: {
+  cellKey: string;
+  cellNodesRef: React.MutableRefObject<Map<string, HTMLTableCellElement>>;
+}) {
+  React.useLayoutEffect(() => {
+    const cell = props.cellNodesRef.current.get(props.cellKey);
+    const content = cell
+      ? Array.from(cell.children).find(
+          (child): child is HTMLElement =>
+            child instanceof HTMLElement &&
+            child.classList.contains("tdg-cell-content")
+        )
+      : undefined;
+    if (!cell || !content) return;
+
+    const syncSurface = () => {
+      if (content.querySelector(SEAMLESS_CELL_EDITOR_SELECTOR)) {
+        cell.dataset.editorSurface = "seamless";
+      } else if (cell.dataset.editorSurface === "seamless") {
+        delete cell.dataset.editorSurface;
+      }
+    };
+
+    syncSurface();
+    const observer = new MutationObserver(syncSurface);
+    observer.observe(content, {
+      attributes: true,
+      attributeFilter: ["class", "data-slot"],
+      childList: true,
+      subtree: true,
+    });
+
+    return () => {
+      observer.disconnect();
+      if (cell.dataset.editorSurface === "seamless") {
+        delete cell.dataset.editorSurface;
+      }
+    };
+  }, [props.cellKey, props.cellNodesRef]);
+
+  return null;
 }
 
 export type GridBodyProps = {
@@ -238,6 +286,12 @@ export function GridBody(props: GridBodyProps) {
     onEditCancel,
   } = props;
   const [hoveredCellId, setHoveredCellId] = React.useState<string | null>(null);
+  const measureNaturalRow = React.useCallback(
+    (element: HTMLTableRowElement | null) => {
+      measureElement?.(element);
+    },
+    [measureElement]
+  );
   const renderedTableColumnCount = virtualizeColumns
     ? columnRenderRange.columnRenderCount +
       (columnRenderRange.beforeWidth > 0 ? 1 : 0) +
@@ -495,6 +549,7 @@ export function GridBody(props: GridBodyProps) {
             data: row.original,
             column,
             cellProps,
+            initialCellHeight: editingCell.initialCellHeight,
           });
           if (!started) return errBack?.(false);
           return nextValue;
@@ -588,7 +643,11 @@ export function GridBody(props: GridBodyProps) {
     );
   }
 
-  function renderCells(row: any, rowIndex: number): React.ReactNode {
+  function renderCells(
+    row: any,
+    rowIndex: number,
+    virtualRowHeight?: number
+  ): React.ReactNode {
     const resolvedRowHeight = getResolvedRowHeight(rowIndex);
     const contentHeightLimit =
       rowHeight == null ? maxRowHeight : resolvedRowHeight;
@@ -627,17 +686,26 @@ export function GridBody(props: GridBodyProps) {
           const column = (cell.column.columnDef as any)?.meta?.__column as
             | TypeColumn
             | undefined;
-          const width = columnWidths[columnId];
+          const width = cell.column.getSize();
+          const cellKey = `${String(row.id)}\u0000${columnId}`;
           const align = column?.textAlign;
           const isLastCell = cellIndex === allCells.length - 1;
+          const rowId = getCompatRowId(row, rowStyleMetadata.getItemId);
+          const isEditingThisCell = Boolean(
+            editingCell &&
+            String(editingCell.rowId) === String(rowId) &&
+            editingCell.columnId === columnId
+          );
           const editor = column
             ? renderEditor(row, rowIndex, cellIndex, column, columnId)
             : null;
 
           const startEdit = () => {
-            if (!column) return;
+            // The editor's own click/double-click events can bubble through
+            // the cell. Inovua only starts when this cell is not already in
+            // edit, so repeated activation must be idempotent.
+            if (!column || isEditingThisCell) return;
             const value = cell.getValue();
-            const rowId = getCompatRowId(row, rowStyleMetadata.getItemId);
             const cellProps = buildEditCellProps({
               value,
               data: row.original,
@@ -671,6 +739,9 @@ export function GridBody(props: GridBodyProps) {
               data: row.original,
               column,
               cellProps,
+              initialCellHeight:
+                cellNodesRef.current.get(cellKey)?.getBoundingClientRect()
+                  .height ?? null,
             });
           };
           const normalizedStartEvent = editStartEvent.toLowerCase();
@@ -678,14 +749,13 @@ export function GridBody(props: GridBodyProps) {
           return (
             <TableCell
               ref={(node) => {
-                const key = `${String(row.id)}\u0000${columnId}`;
-                if (node) cellNodesRef.current.set(key, node);
-                else cellNodesRef.current.delete(key);
+                if (node) cellNodesRef.current.set(cellKey, node);
+                else cellNodesRef.current.delete(cellKey);
               }}
               key={cell.id}
               data-column-id={columnId}
               data-column-index={cellIndex}
-              data-editing={editor ? "true" : "false"}
+              data-editing={isEditingThisCell ? "true" : "false"}
               className={cn(
                 userSelectClass,
                 "InovuaReactDataGrid__cell",
@@ -716,6 +786,12 @@ export function GridBody(props: GridBodyProps) {
                 ...(typeof column?.style === "object" && column?.style
                   ? column.style
                   : {}),
+                ...(isEditingThisCell && rowHeight == null
+                  ? {
+                      height:
+                        editingCell?.initialCellHeight ?? virtualRowHeight,
+                    }
+                  : {}),
               }}
               onClick={() => {
                 if (
@@ -742,8 +818,17 @@ export function GridBody(props: GridBodyProps) {
               }}
             >
               <div className="tdg-cell-content" style={contentStyle}>
-                {editor ??
-                  flexRender(cell.column.columnDef.cell, cell.getContext())}
+                {editor != null ? (
+                  <>
+                    <CellEditorSurfaceSync
+                      cellKey={cellKey}
+                      cellNodesRef={cellNodesRef}
+                    />
+                    {editor}
+                  </>
+                ) : (
+                  flexRender(cell.column.columnDef.cell, cell.getContext())
+                )}
               </div>
             </TableCell>
           );
@@ -842,11 +927,7 @@ export function GridBody(props: GridBodyProps) {
 
             return (
               <TableRow
-                ref={
-                  rowHeight == null
-                    ? (element) => measureElement?.(element)
-                    : undefined
-                }
+                ref={rowHeight == null ? measureNaturalRow : undefined}
                 key={row.id}
                 className={cn(
                   getRowThemeClasses(vi.index, rowIsSelected),
@@ -864,7 +945,7 @@ export function GridBody(props: GridBodyProps) {
                 style={getRowStyle(row, vi.index, rowIsSelected, vi.size)}
                 onClick={(e) => onRowClick?.(row.id, row.original, e)}
               >
-                {renderCells(row, vi.index)}
+                {renderCells(row, vi.index, vi.size)}
               </TableRow>
             );
           })}

--- a/src/grid/components/GridHeader.tsx
+++ b/src/grid/components/GridHeader.tsx
@@ -19,7 +19,6 @@ export type GridHeaderProps = {
 
   headerHeight: number;
   filterRowHeight: number;
-  columnWidths: Record<string, number>;
 
   // sorting
   sortInfo: TypeSortInfo;
@@ -46,6 +45,7 @@ export type GridHeaderProps = {
     event: React.MouseEvent<HTMLElement> | React.PointerEvent<HTMLElement>,
     columnId: string
   ) => void;
+  onColumnResizeBy: (columnId: string, diff: number) => void;
   onColumnAutoResize: (columnId: string) => void;
 
   // filtering
@@ -92,7 +92,6 @@ export function GridHeader(props: GridHeaderProps) {
     headerGroups,
     headerHeight,
     filterRowHeight,
-    columnWidths,
     sortInfo,
     setSortInfo,
     setSkip,
@@ -111,6 +110,7 @@ export function GridHeader(props: GridHeaderProps) {
     onHeaderDrop,
     resizingColumnId,
     onColumnResizeStart,
+    onColumnResizeBy,
     onColumnAutoResize,
     enableFiltering,
     enableColumnFilterContextMenu,
@@ -154,7 +154,7 @@ export function GridHeader(props: GridHeaderProps) {
               const col: TypeColumn | undefined = colDef?.meta?.__column;
               const colId = h.column.id;
 
-              const width = columnWidths[colId];
+              const width = h.getSize();
 
               const canDrag =
                 allowColumnReorder &&
@@ -190,6 +190,7 @@ export function GridHeader(props: GridHeaderProps) {
                   canResize={canResize}
                   isResizing={resizingColumnId === colId}
                   onResizeStart={onColumnResizeStart}
+                  onResizeBy={onColumnResizeBy}
                   onAutoResize={onColumnAutoResize}
                 />
               );
@@ -226,7 +227,7 @@ export function GridHeader(props: GridHeaderProps) {
                 const col: TypeColumn | undefined = colDef?.meta?.__column;
                 const colId = h.column.id;
 
-                const width = columnWidths[colId];
+                const width = h.getSize();
 
                 return (
                   <FilterCell

--- a/src/grid/components/GridHeader.tsx
+++ b/src/grid/components/GridHeader.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import type {
   TypeColumn,
+  TypeColumnFilterValueChangeArg,
   TypeFilterTypes,
   TypeFilterValue,
   TypeI18n,
@@ -55,6 +56,7 @@ export type GridHeaderProps = {
   draftFilterValue: TypeFilterValue;
   setFilterValue: (v: TypeFilterValue) => void;
   setDraftFilterValue: React.Dispatch<React.SetStateAction<TypeFilterValue>>;
+  onColumnFilterValueChange?: (event: TypeColumnFilterValueChangeArg) => void;
   filterTypes: TypeFilterTypes;
 
   openFilterMenuColId: string | null;
@@ -117,6 +119,7 @@ export function GridHeader(props: GridHeaderProps) {
     draftFilterValue,
     setFilterValue,
     setDraftFilterValue,
+    onColumnFilterValueChange,
     filterTypes,
     openFilterMenuColId,
     setOpenFilterMenuColId,
@@ -246,6 +249,7 @@ export function GridHeader(props: GridHeaderProps) {
                     draftFilterValue={draftFilterValue}
                     setFilterValue={setFilterValue}
                     setDraftFilterValue={setDraftFilterValue}
+                    onColumnFilterValueChange={onColumnFilterValueChange}
                     setSkip={setSkip}
                     filterTypes={filterTypes}
                     i18n={i18n}

--- a/src/grid/components/GridHeader.tsx
+++ b/src/grid/components/GridHeader.tsx
@@ -9,7 +9,7 @@ import type {
   TypeSortInfo,
 } from "../../types";
 
-import { TableHeader, TableRow } from "../../components/ui/table";
+import { TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { HeaderCell } from "./HeaderCell";
 import { FilterCell } from "./FilterCell";
 
@@ -59,7 +59,31 @@ export type GridHeaderProps = {
 
   openFilterMenuColId: string | null;
   setOpenFilterMenuColId: (id: string | null) => void;
+
+  virtualizeColumns: boolean;
+  columnRenderRange: {
+    firstIndex: number;
+    lastIndex: number;
+    beforeWidth: number;
+    afterWidth: number;
+  };
 };
+
+function ColumnSpacerHeader(props: { width: number }) {
+  if (props.width <= 0) return null;
+
+  return (
+    <TableHead
+      aria-hidden="true"
+      className="pointer-events-none !p-0"
+      style={{
+        width: props.width,
+        minWidth: props.width,
+        maxWidth: props.width,
+      }}
+    />
+  );
+}
 
 export function GridHeader(props: GridHeaderProps) {
   const {
@@ -96,6 +120,8 @@ export function GridHeader(props: GridHeaderProps) {
     filterTypes,
     openFilterMenuColId,
     setOpenFilterMenuColId,
+    virtualizeColumns,
+    columnRenderRange,
   } = props;
 
   return (
@@ -107,51 +133,67 @@ export function GridHeader(props: GridHeaderProps) {
           className="tdg-header-row InovuaReactDataGrid__header-row bg-[var(--tdg-header-bg)]"
           style={{ height: headerHeight }}
         >
-          {hg.headers.map((h: any, columnIndex: number) => {
-            const colDef = h.column.columnDef as any;
-            const col: TypeColumn | undefined = colDef?.meta?.__column;
-            const colId = h.column.id;
+          <ColumnSpacerHeader
+            width={virtualizeColumns ? columnRenderRange.beforeWidth : 0}
+          />
+          {hg.headers
+            .slice(
+              virtualizeColumns ? columnRenderRange.firstIndex : 0,
+              virtualizeColumns
+                ? columnRenderRange.lastIndex + 1
+                : hg.headers.length
+            )
+            .map((h: any, renderedIndex: number) => {
+              const columnIndex = virtualizeColumns
+                ? columnRenderRange.firstIndex + renderedIndex
+                : renderedIndex;
+              const colDef = h.column.columnDef as any;
+              const col: TypeColumn | undefined = colDef?.meta?.__column;
+              const colId = h.column.id;
 
-            const width = columnWidths[colId];
+              const width = columnWidths[colId];
 
-            const canDrag =
-              allowColumnReorder &&
-              (!checkboxEnabled || colId !== checkboxColId) &&
-              (col?.draggable ?? true);
-            const canResize =
-              allowColumnResize &&
-              (!checkboxEnabled || colId !== checkboxColId) &&
-              (col?.resizable ?? true);
+              const canDrag =
+                allowColumnReorder &&
+                (!checkboxEnabled || colId !== checkboxColId) &&
+                (col?.draggable ?? true);
+              const canResize =
+                allowColumnResize &&
+                (!checkboxEnabled || colId !== checkboxColId) &&
+                (col?.resizable ?? true);
 
-            return (
-              <HeaderCell
-                key={h.id}
-                header={h}
-                col={col}
-                colId={colId}
-                columnIndex={columnIndex}
-                width={width}
-                headerHeight={headerHeight}
-                sortInfo={sortInfo}
-                setSortInfo={setSortInfo}
-                setSkip={setSkip}
-                allowUnsort={allowUnsort}
-                defaultSortDir={defaultSortDir}
-                showColumnMenuTool={showColumnMenuTool}
-                showHorizontalCellBorders={showHorizontalCellBorders}
-                showVerticalCellBorders={showVerticalCellBorders}
-                i18n={i18n}
-                canDrag={Boolean(canDrag)}
-                onDragStart={onHeaderDragStart}
-                onDragOver={onHeaderDragOver}
-                onDrop={onHeaderDrop}
-                canResize={canResize}
-                isResizing={resizingColumnId === colId}
-                onResizeStart={onColumnResizeStart}
-                onAutoResize={onColumnAutoResize}
-              />
-            );
-          })}
+              return (
+                <HeaderCell
+                  key={h.id}
+                  header={h}
+                  col={col}
+                  colId={colId}
+                  columnIndex={columnIndex}
+                  width={width}
+                  headerHeight={headerHeight}
+                  sortInfo={sortInfo}
+                  setSortInfo={setSortInfo}
+                  setSkip={setSkip}
+                  allowUnsort={allowUnsort}
+                  defaultSortDir={defaultSortDir}
+                  showColumnMenuTool={showColumnMenuTool}
+                  showHorizontalCellBorders={showHorizontalCellBorders}
+                  showVerticalCellBorders={showVerticalCellBorders}
+                  i18n={i18n}
+                  canDrag={Boolean(canDrag)}
+                  onDragStart={onHeaderDragStart}
+                  onDragOver={onHeaderDragOver}
+                  onDrop={onHeaderDrop}
+                  canResize={canResize}
+                  isResizing={resizingColumnId === colId}
+                  onResizeStart={onColumnResizeStart}
+                  onAutoResize={onColumnAutoResize}
+                />
+              );
+            })}
+          <ColumnSpacerHeader
+            width={virtualizeColumns ? columnRenderRange.afterWidth : 0}
+          />
         </TableRow>
       ))}
 
@@ -163,42 +205,60 @@ export function GridHeader(props: GridHeaderProps) {
             className="tdg-filter-row InovuaReactDataGrid__filter-row bg-[var(--tdg-filter-bg)]"
             style={{ height: filterRowHeight }}
           >
-            {hg.headers.map((h: any, columnIndex: number) => {
-              const colDef = h.column.columnDef as any;
-              const col: TypeColumn | undefined = colDef?.meta?.__column;
-              const colId = h.column.id;
+            <ColumnSpacerHeader
+              width={virtualizeColumns ? columnRenderRange.beforeWidth : 0}
+            />
+            {hg.headers
+              .slice(
+                virtualizeColumns ? columnRenderRange.firstIndex : 0,
+                virtualizeColumns
+                  ? columnRenderRange.lastIndex + 1
+                  : hg.headers.length
+              )
+              .map((h: any, renderedIndex: number) => {
+                const columnIndex = virtualizeColumns
+                  ? columnRenderRange.firstIndex + renderedIndex
+                  : renderedIndex;
+                const colDef = h.column.columnDef as any;
+                const col: TypeColumn | undefined = colDef?.meta?.__column;
+                const colId = h.column.id;
 
-              const width = columnWidths[colId];
+                const width = columnWidths[colId];
 
-              return (
-                <FilterCell
-                  key={`${h.id}-filter`}
-                  header={h}
-                  col={col}
-                  colId={colId}
-                  columnIndex={columnIndex}
-                  width={width}
-                  headerHeight={headerHeight}
-                  filterRowHeight={filterRowHeight}
-                  enableFiltering={enableFiltering}
-                  enableColumnFilterContextMenu={enableColumnFilterContextMenu}
-                  checkboxEnabled={checkboxEnabled}
-                  checkboxColId={checkboxColId}
-                  filterControlled={filterControlled}
-                  filterValue={filterValue}
-                  draftFilterValue={draftFilterValue}
-                  setFilterValue={setFilterValue}
-                  setDraftFilterValue={setDraftFilterValue}
-                  setSkip={setSkip}
-                  filterTypes={filterTypes}
-                  i18n={i18n}
-                  showHorizontalCellBorders={showHorizontalCellBorders}
-                  showVerticalCellBorders={showVerticalCellBorders}
-                  openFilterMenuColId={openFilterMenuColId}
-                  setOpenFilterMenuColId={setOpenFilterMenuColId}
-                />
-              );
-            })}
+                return (
+                  <FilterCell
+                    key={`${h.id}-filter`}
+                    header={h}
+                    col={col}
+                    colId={colId}
+                    columnIndex={columnIndex}
+                    width={width}
+                    headerHeight={headerHeight}
+                    filterRowHeight={filterRowHeight}
+                    enableFiltering={enableFiltering}
+                    enableColumnFilterContextMenu={
+                      enableColumnFilterContextMenu
+                    }
+                    checkboxEnabled={checkboxEnabled}
+                    checkboxColId={checkboxColId}
+                    filterControlled={filterControlled}
+                    filterValue={filterValue}
+                    draftFilterValue={draftFilterValue}
+                    setFilterValue={setFilterValue}
+                    setDraftFilterValue={setDraftFilterValue}
+                    setSkip={setSkip}
+                    filterTypes={filterTypes}
+                    i18n={i18n}
+                    showHorizontalCellBorders={showHorizontalCellBorders}
+                    showVerticalCellBorders={showVerticalCellBorders}
+                    openFilterMenuColId={openFilterMenuColId}
+                    setOpenFilterMenuColId={setOpenFilterMenuColId}
+                  />
+                );
+              })}
+            <ColumnSpacerHeader
+              width={virtualizeColumns ? columnRenderRange.afterWidth : 0}
+            />
           </TableRow>
         ))}
     </TableHeader>

--- a/src/grid/components/GridHeader.tsx
+++ b/src/grid/components/GridHeader.tsx
@@ -43,7 +43,7 @@ export type GridHeaderProps = {
   onHeaderDrop: (e: React.DragEvent, targetId: string) => void;
   resizingColumnId: string | null;
   onColumnResizeStart: (
-    event: React.MouseEvent<HTMLElement>,
+    event: React.MouseEvent<HTMLElement> | React.PointerEvent<HTMLElement>,
     columnId: string
   ) => void;
   onColumnAutoResize: (columnId: string) => void;

--- a/src/grid/components/HeaderCell.tsx
+++ b/src/grid/components/HeaderCell.tsx
@@ -111,7 +111,7 @@ export type HeaderCellProps = {
   canResize: boolean;
   isResizing: boolean;
   onResizeStart: (
-    event: React.MouseEvent<HTMLElement>,
+    event: React.MouseEvent<HTMLElement> | React.PointerEvent<HTMLElement>,
     columnId: string
   ) => void;
   onAutoResize: (columnId: string) => void;
@@ -325,6 +325,11 @@ export function HeaderCell(props: HeaderCellProps) {
               event.preventDefault();
               event.stopPropagation();
             }}
+            onPointerDown={(event) => onResizeStart(event, colId)}
+            // Pointer events are the primary path for mouse, pen and touch.
+            // Keep a mouse-only fallback for environments/tests which dispatch
+            // legacy mouse events directly; the grid ignores it while the
+            // corresponding pointer session is already active.
             onMouseDown={(event) => onResizeStart(event, colId)}
             onDoubleClick={(event) => {
               event.preventDefault();

--- a/src/grid/components/HeaderCell.tsx
+++ b/src/grid/components/HeaderCell.tsx
@@ -114,6 +114,7 @@ export type HeaderCellProps = {
     event: React.MouseEvent<HTMLElement> | React.PointerEvent<HTMLElement>,
     columnId: string
   ) => void;
+  onResizeBy: (columnId: string, diff: number) => void;
   onAutoResize: (columnId: string) => void;
 };
 
@@ -141,6 +142,7 @@ export function HeaderCell(props: HeaderCellProps) {
     canResize,
     isResizing,
     onResizeStart,
+    onResizeBy,
     onAutoResize,
   } = props;
 
@@ -271,7 +273,7 @@ export function HeaderCell(props: HeaderCellProps) {
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="InovuaReactDataGrid__column-header__menu-tool size-7 shrink-0 rounded-none border-0 bg-transparent shadow-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+                  className="InovuaReactDataGrid__column-header__menu-tool size-7 shrink-0 rounded-none border-0 bg-transparent shadow-none hover:bg-transparent"
                   aria-label="Column menu"
                 >
                   <IconDotsVertical className="size-4" />
@@ -312,11 +314,12 @@ export function HeaderCell(props: HeaderCellProps) {
           <button
             type="button"
             aria-label={`Resize ${typeof col?.header === "string" ? col.header : colId}`}
+            aria-keyshortcuts="ArrowLeft ArrowRight"
             data-slot="column-resizer"
             data-resizing={isResizing ? "true" : "false"}
             className="tdg-column-resizer InovuaReactDataGrid__column-header__resize-handle"
             draggable={false}
-            tabIndex={-1}
+            tabIndex={0}
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
@@ -331,6 +334,16 @@ export function HeaderCell(props: HeaderCellProps) {
             // legacy mouse events directly; the grid ignores it while the
             // corresponding pointer session is already active.
             onMouseDown={(event) => onResizeStart(event, colId)}
+            onKeyDown={(event) => {
+              if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+                return;
+              }
+
+              event.preventDefault();
+              event.stopPropagation();
+              const direction = event.key === "ArrowRight" ? 1 : -1;
+              onResizeBy(colId, direction * (event.shiftKey ? 40 : 10));
+            }}
             onDoubleClick={(event) => {
               event.preventDefault();
               event.stopPropagation();

--- a/src/grid/components/MobileGridList.tsx
+++ b/src/grid/components/MobileGridList.tsx
@@ -92,6 +92,7 @@ export function MobileGridList({
   );
   const deferredQuery = React.useDeferredValue(committedQuery);
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
+  const sortButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const searchIndexCache = React.useRef<{
     columns: TypeColumn[];
     index: DataGridSearchIndex<Row<Record<string, unknown>>>;
@@ -293,18 +294,23 @@ export function MobileGridList({
     setSortPanelOpen((open) => !open);
   };
 
+  const closeSortPanel = React.useCallback(() => {
+    setSortPanelOpen(false);
+    requestAnimationFrame(() => sortButtonRef.current?.focus());
+  }, []);
+
   const applyMobileSort = () => {
     if (!draftSortColumn) return;
     onSortInfoChange({
       name: getColumnSortName(draftSortColumn),
       dir: draftSortDirection,
     });
-    setSortPanelOpen(false);
+    closeSortPanel();
   };
 
   const clearMobileSort = () => {
     onSortInfoChange(null);
-    setSortPanelOpen(false);
+    closeSortPanel();
   };
   const virtualizer = useVirtualizer({
     count: filteredRows.length,
@@ -326,6 +332,19 @@ export function MobileGridList({
     <div
       className="tdg-mobile flex min-h-0 flex-1 flex-col bg-muted/30"
       data-slot="mobile-grid-list"
+      onKeyDown={(event) => {
+        if (
+          event.key !== "Escape" ||
+          event.defaultPrevented ||
+          !sortPanelOpen
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        closeSortPanel();
+      }}
     >
       <div className="shrink-0 border-b bg-background p-3 [border-color:var(--tdg-grid-border-color)]">
         <div className="flex items-center gap-2">
@@ -340,6 +359,7 @@ export function MobileGridList({
           )}
           {sortableColumns.length ? (
             <Button
+              ref={sortButtonRef}
               type="button"
               variant={sortPanelOpen ? "secondary" : "outline"}
               size="icon"

--- a/src/grid/components/MobileGridList.tsx
+++ b/src/grid/components/MobileGridList.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from "../../lib/utils";
 import { getColumnId, getColumnSortName } from "../../utils/column";
 import { t } from "../../utils/helpers";
+import { resolveEmptyText } from "../utils/emptyText";
 import {
   DataGridSearchBar,
   type DataGridSearchBarChange,
@@ -42,6 +43,7 @@ type MobileGridListProps = {
   loading: boolean;
   selectedMap: Record<string, unknown>;
   i18n: TypeDataGridProps["i18n"];
+  emptyText: TypeDataGridProps["emptyText"];
   sortInfo: TypeSortInfo;
   defaultSortDirection: 1 | -1;
   searchEnabled?: boolean;
@@ -72,6 +74,7 @@ export function MobileGridList({
   loading,
   selectedMap,
   i18n,
+  emptyText,
   sortInfo,
   defaultSortDirection,
   searchEnabled = true,
@@ -314,6 +317,11 @@ export function MobileGridList({
     virtualizer.scrollToOffset(0);
   }, [deferredQuery, virtualizer]);
 
+  const emptyContent =
+    !loading && filteredRows.length === 0
+      ? resolveEmptyText(emptyText, i18n)
+      : null;
+
   return (
     <div
       className="tdg-mobile flex min-h-0 flex-1 flex-col bg-muted/30"
@@ -501,9 +509,11 @@ export function MobileGridList({
             Loading...
           </div>
         ) : filteredRows.length === 0 ? (
-          <div className="p-6 text-center text-sm text-muted-foreground">
-            {t(i18n, "noRecords", "No records")}
-          </div>
+          emptyContent == null ? null : (
+            <div className="p-6 text-center text-sm text-muted-foreground">
+              {emptyContent}
+            </div>
+          )
         ) : (
           <div
             className="relative w-full"

--- a/src/grid/engine/tanstackAdapter.ts
+++ b/src/grid/engine/tanstackAdapter.ts
@@ -1,0 +1,427 @@
+import type {
+  ColumnFiltersState,
+  ColumnOrderState,
+  ColumnSizingState,
+  RowSelectionState,
+  SortingState,
+  VisibilityState,
+} from "@tanstack/react-table";
+
+import type {
+  TypeColumn,
+  TypeFilterValue,
+  TypeRowSelection,
+  TypeSingleFilterValue,
+  TypeSingleSortInfo,
+  TypeSortInfo,
+} from "../../types";
+
+type RuntimeColumn = TypeColumn & {
+  id?: unknown;
+  name?: unknown;
+  sortName?: unknown;
+  filterName?: unknown;
+};
+
+type SelectionMap = Record<string, unknown>;
+
+const hasOwn = (value: object, key: PropertyKey): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * TanStack stores every state identifier as a string. Nullish identifiers are
+ * absent, while other falsy identifiers (`0`, `false`, and `""`) remain
+ * distinct and must not be discarded by truthiness checks.
+ */
+function toStateKey(value: unknown): string | null {
+  return value === null || value === undefined ? null : String(value);
+}
+
+function getColumnId(column: TypeColumn): string {
+  const runtimeColumn = column as RuntimeColumn;
+  const id = toStateKey(runtimeColumn.id ?? runtimeColumn.name);
+
+  if (id === null || id.length === 0) {
+    throw new Error("the-datagrid: column must have `id` or `name`.");
+  }
+
+  return id;
+}
+
+function getColumnSortName(column: TypeColumn): string {
+  const runtimeColumn = column as RuntimeColumn;
+  return String(
+    runtimeColumn.sortName ?? runtimeColumn.name ?? runtimeColumn.id ?? ""
+  );
+}
+
+function getColumnFilterAliases(column: TypeColumn): string[] {
+  const runtimeColumn = column as RuntimeColumn;
+  const aliases = [
+    getColumnId(column),
+    toStateKey(runtimeColumn.name),
+    toStateKey(runtimeColumn.filterName),
+  ];
+
+  return Array.from(
+    new Set(aliases.filter((alias): alias is string => alias !== null))
+  );
+}
+
+function buildColumnLookups(columns: readonly TypeColumn[]) {
+  const sortNameToId = new Map<string, string>();
+  const filterNameToId = new Map<string, string>();
+  const idToSortName = new Map<string, string>();
+  const columnIds: string[] = [];
+
+  for (const column of columns) {
+    const id = getColumnId(column);
+    const sortName = getColumnSortName(column);
+
+    if (!columnIds.includes(id)) columnIds.push(id);
+    if (!idToSortName.has(id)) idToSortName.set(id, sortName || id);
+    if (!sortNameToId.has(id)) sortNameToId.set(id, id);
+    if (sortName && !sortNameToId.has(sortName)) {
+      sortNameToId.set(sortName, id);
+    }
+
+    for (const alias of getColumnFilterAliases(column)) {
+      if (!filterNameToId.has(alias)) filterNameToId.set(alias, id);
+    }
+  }
+
+  return { columnIds, filterNameToId, idToSortName, sortNameToId };
+}
+
+function sortInfoList(sortInfo: TypeSortInfo): TypeSingleSortInfo[] {
+  if (!sortInfo) return [];
+  return Array.isArray(sortInfo) ? sortInfo : [sortInfo];
+}
+
+/** Project the compatibility sorting model into controlled TanStack state. */
+export function toTanStackSortingState(
+  sortInfo: TypeSortInfo,
+  columns: readonly TypeColumn[]
+): SortingState {
+  const { sortNameToId } = buildColumnLookups(columns);
+  const result: SortingState = [];
+  const seen = new Set<string>();
+
+  for (const item of sortInfoList(sortInfo)) {
+    if (item.dir !== 1 && item.dir !== -1) continue;
+
+    const sourceName = toStateKey(item.name);
+    if (sourceName === null || sourceName.length === 0) continue;
+
+    const id = sortNameToId.get(sourceName) ?? sourceName;
+    if (seen.has(id)) continue;
+
+    seen.add(id);
+    result.push({ id, desc: item.dir === -1 });
+  }
+
+  return result;
+}
+
+/**
+ * Restore TanStack sorting to the Inovua-shaped model. Existing entries are
+ * used as templates so compatibility metadata (`type`, `fn`, `columnName`,
+ * and custom fields) survives a controlled state update.
+ */
+export function fromTanStackSortingState(
+  sorting: readonly SortingState[number][],
+  columns: readonly TypeColumn[],
+  current: TypeSortInfo = null
+): TypeSortInfo {
+  const { idToSortName, sortNameToId } = buildColumnLookups(columns);
+  const currentList = sortInfoList(current);
+  const currentById = new Map<string, TypeSingleSortInfo>();
+
+  for (const item of currentList) {
+    const name = toStateKey(item.name);
+    if (name === null) continue;
+    const id = sortNameToId.get(name) ?? name;
+    if (!currentById.has(id)) currentById.set(id, item);
+  }
+
+  const next: TypeSingleSortInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const item of sorting) {
+    const id = toStateKey(item.id);
+    if (id === null || id.length === 0 || seen.has(id)) continue;
+    seen.add(id);
+
+    next.push({
+      ...(currentById.get(id) ?? {}),
+      name: idToSortName.get(id) ?? id,
+      dir: item.desc ? -1 : 1,
+    });
+  }
+
+  if (next.length === 0) return null;
+  if (next.length > 1 || Array.isArray(current)) return next;
+  return next[0]!;
+}
+
+function isCompleteFilterEntry(value: unknown): value is TypeSingleFilterValue {
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    typeof value.type === "string" &&
+    typeof value.operator === "string" &&
+    hasOwn(value, "value")
+  );
+}
+
+/**
+ * Store the complete compatibility filter entry as the TanStack filter value.
+ * Keeping more than just `entry.value` prevents operator/type/active metadata
+ * from being lost when TanStack calls a controlled state updater.
+ */
+export function toTanStackColumnFiltersState(
+  filterValue: TypeFilterValue,
+  columns: readonly TypeColumn[]
+): ColumnFiltersState {
+  if (!filterValue) return [];
+
+  const { filterNameToId } = buildColumnLookups(columns);
+  const result: ColumnFiltersState = [];
+  const seen = new Set<string>();
+
+  for (const entry of filterValue) {
+    const name = toStateKey(entry.name);
+    if (name === null) continue;
+
+    const id = filterNameToId.get(name) ?? name;
+    if (seen.has(id)) continue;
+
+    seen.add(id);
+    result.push({ id, value: { ...entry } });
+  }
+
+  return result;
+}
+
+/**
+ * Restore complete filter entries from TanStack state. A raw TanStack value is
+ * accepted only when a current compatibility entry can provide its required
+ * type/operator metadata; otherwise the malformed entry is ignored.
+ */
+export function fromTanStackColumnFiltersState(
+  columnFilters: readonly ColumnFiltersState[number][],
+  columns: readonly TypeColumn[],
+  current: TypeFilterValue = null
+): TypeFilterValue {
+  const { filterNameToId } = buildColumnLookups(columns);
+  const currentById = new Map<string, TypeSingleFilterValue>();
+
+  for (const entry of current ?? []) {
+    const name = toStateKey(entry.name);
+    if (name === null) continue;
+    const id = filterNameToId.get(name) ?? name;
+    if (!currentById.has(id)) currentById.set(id, entry);
+  }
+
+  const next: TypeSingleFilterValue[] = [];
+  const seen = new Set<string>();
+
+  for (const columnFilter of columnFilters) {
+    const id = toStateKey(columnFilter.id);
+    if (id === null || seen.has(id)) continue;
+
+    let entry: TypeSingleFilterValue | undefined;
+    if (isCompleteFilterEntry(columnFilter.value)) {
+      const valueName = toStateKey(columnFilter.value.name);
+      const valueId =
+        valueName === null
+          ? null
+          : (filterNameToId.get(valueName) ?? valueName);
+
+      entry = {
+        ...columnFilter.value,
+        name:
+          valueId === id
+            ? columnFilter.value.name
+            : (currentById.get(id)?.name ?? id),
+      };
+    } else {
+      const existing = currentById.get(id);
+      if (existing) entry = { ...existing, value: columnFilter.value };
+    }
+
+    if (!entry) continue;
+    seen.add(id);
+    next.push(entry);
+  }
+
+  return next.length > 0 ? next : null;
+}
+
+function unwrapSelection(selection: TypeRowSelection): TypeRowSelection {
+  if (
+    isRecord(selection) &&
+    hasOwn(selection, "selected") &&
+    (hasOwn(selection, "data") ||
+      hasOwn(selection, "unselected") ||
+      hasOwn(selection, "originalData"))
+  ) {
+    return selection.selected as TypeRowSelection;
+  }
+
+  return selection;
+}
+
+function selectionMap(selection: TypeRowSelection): SelectionMap {
+  const normalized = unwrapSelection(selection);
+
+  if (normalized === null) return {};
+  if (isRecord(normalized)) return normalized;
+
+  const key = toStateKey(normalized);
+  return key === null ? {} : { [key]: true };
+}
+
+/** Project an Inovua selection value into TanStack's ID/boolean map. */
+export function toTanStackRowSelectionState(
+  selection: TypeRowSelection
+): RowSelectionState {
+  const result: RowSelectionState = {};
+
+  for (const [id, selected] of Object.entries(selectionMap(selection))) {
+    if (selected) result[id] = true;
+  }
+
+  return result;
+}
+
+/**
+ * Restore an ID map without requiring row data. When available, values from
+ * the current compatibility selection are retained instead of being replaced
+ * by `true`.
+ */
+export function fromTanStackRowSelectionState(
+  rowSelection: Readonly<RowSelectionState>,
+  current: TypeRowSelection = null
+): TypeRowSelection {
+  const currentMap = selectionMap(current);
+  const result: SelectionMap = {};
+
+  for (const [id, selected] of Object.entries(rowSelection)) {
+    if (!selected) continue;
+    result[id] =
+      hasOwn(currentMap, id) && currentMap[id] ? currentMap[id] : true;
+  }
+
+  return result;
+}
+
+/**
+ * Hydrate selected IDs with objects from the latest row model. Stale selected
+ * IDs are intentionally dropped, and duplicate row IDs keep the first row to
+ * match TanStack's requirement that row IDs are unique.
+ */
+export function hydrateTanStackRowSelection<TRow>(
+  rowSelection: Readonly<RowSelectionState>,
+  rows: readonly TRow[],
+  getRowId: (row: TRow, index: number) => unknown
+): Record<string, TRow> {
+  const result: Record<string, TRow> = {};
+
+  rows.forEach((row, index) => {
+    const id = toStateKey(getRowId(row, index));
+    if (id === null || !rowSelection[id] || hasOwn(result, id)) return;
+    result[id] = row;
+  });
+
+  return result;
+}
+
+/** Build complete, controlled visibility state for the current columns. */
+export function projectTanStackColumnVisibility(
+  columns: readonly TypeColumn[],
+  overrides: Readonly<Record<string, boolean | undefined>> = {}
+): VisibilityState {
+  const result: VisibilityState = {};
+
+  for (const column of columns) {
+    const id = getColumnId(column);
+    if (hasOwn(result, id)) continue;
+
+    if (hasOwn(overrides, id) && typeof overrides[id] === "boolean") {
+      result[id] = overrides[id]!;
+    } else if (typeof column.visible === "boolean") {
+      result[id] = column.visible;
+    } else {
+      result[id] = true;
+    }
+  }
+
+  return result;
+}
+
+/** Filter/dedupe a requested order, then append every still-available column. */
+export function projectTanStackColumnOrder(
+  columns: readonly TypeColumn[],
+  requestedOrder?: readonly unknown[] | null
+): ColumnOrderState {
+  const { columnIds } = buildColumnLookups(columns);
+  const available = new Set(columnIds);
+  const result: ColumnOrderState = [];
+  const seen = new Set<string>();
+
+  for (const rawId of requestedOrder ?? []) {
+    const id = toStateKey(rawId);
+    if (id === null || !available.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+
+  for (const id of columnIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+
+  return result;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+/**
+ * Project resolved grid widths into TanStack sizing state. Explicit computed
+ * widths win, while column min/max constraints remain authoritative.
+ */
+export function projectTanStackColumnSizing(
+  columns: readonly TypeColumn[],
+  computedWidths: Readonly<Record<string, number | undefined>> = {}
+): ColumnSizingState {
+  const result: ColumnSizingState = {};
+
+  for (const column of columns) {
+    const id = getColumnId(column);
+    if (hasOwn(result, id)) continue;
+
+    let size = finiteNumber(computedWidths[id]);
+    size ??= finiteNumber(column.width);
+    size ??= finiteNumber(column.defaultWidth);
+    if (size === undefined) continue;
+
+    const min = finiteNumber(column.minWidth);
+    const max = finiteNumber(column.maxWidth);
+
+    if (max !== undefined) size = Math.min(size, max);
+    if (min !== undefined) size = Math.max(size, min);
+    result[id] = size;
+  }
+
+  return result;
+}

--- a/src/grid/utils/editing.ts
+++ b/src/grid/utils/editing.ts
@@ -23,6 +23,7 @@ export type TypeBuildEditCellPropsArgs = {
   editStartEvent: string;
   theme: string;
   totalDataCount: number;
+  virtualizeColumns: boolean;
 };
 
 /**
@@ -53,6 +54,7 @@ export function buildEditCellProps({
   editStartEvent,
   theme,
   totalDataCount,
+  virtualizeColumns,
 }: TypeBuildEditCellPropsArgs): CellProps {
   const configuredCellProps =
     column.cellProps && typeof column.cellProps === "object"
@@ -103,7 +105,7 @@ export function buildEditCellProps({
     rtl: false,
     nativeScroll: true,
     editorProps: column.editorProps,
-    virtualizeColumns: false,
+    virtualizeColumns,
     cellProps: {
       ...configuredCellProps,
       column,

--- a/src/grid/utils/emptyText.ts
+++ b/src/grid/utils/emptyText.ts
@@ -1,0 +1,28 @@
+import type * as React from "react";
+
+import type { TypeDataGridProps } from "../../types";
+import { t } from "../../utils/helpers";
+
+const DEFAULT_EMPTY_TEXT_KEY = "noRecords";
+const DEFAULT_EMPTY_TEXT = "No records";
+
+export function resolveEmptyText(
+  emptyText: TypeDataGridProps["emptyText"],
+  i18n: TypeDataGridProps["i18n"]
+): React.ReactNode {
+  const candidate =
+    emptyText === undefined ? DEFAULT_EMPTY_TEXT_KEY : emptyText;
+  const localized =
+    typeof candidate === "string"
+      ? t(
+          i18n,
+          candidate,
+          candidate === DEFAULT_EMPTY_TEXT_KEY ? DEFAULT_EMPTY_TEXT : candidate
+        )
+      : candidate;
+  const content = typeof localized === "function" ? localized() : localized;
+
+  return content == null || content === false || content === ""
+    ? null
+    : content;
+}

--- a/src/grid/utils/gridUtils.ts
+++ b/src/grid/utils/gridUtils.ts
@@ -35,16 +35,24 @@ export function stripFromOrder(order: string[], id: string): string[] {
   return order.filter((x) => x !== id);
 }
 
-export function injectIntoOrder(order: string[] | undefined, id: string): string[] | undefined {
+export function injectIntoOrder(
+  order: string[] | undefined,
+  id: string
+): string[] | undefined {
   if (!order) return order;
   if (order.includes(id)) return order;
   return [id, ...order];
 }
 
-export function normalizeColumnOrder(order: string[] | undefined, availableIds: string[]): string[] {
+export function normalizeColumnOrder(
+  order: string[] | undefined,
+  availableIds: string[]
+): string[] {
   if (availableIds.length === 0) return [];
 
-  const normalized = Array.isArray(order) ? order.filter((id) => availableIds.includes(id)) : [];
+  const normalized = Array.isArray(order)
+    ? order.filter((id) => availableIds.includes(id))
+    : [];
 
   for (const id of availableIds) {
     if (!normalized.includes(id)) normalized.push(id);
@@ -65,7 +73,7 @@ export function isInteractiveClickTarget(target: HTMLElement | null): boolean {
       "[role='button']",
       "[data-rdg-stop-selection]",
       "[data-no-row-select]",
-    ].join(","),
+    ].join(",")
   );
   return Boolean(el);
 }
@@ -78,7 +86,8 @@ export function isColumnVisible(c: TypeColumn): boolean {
 }
 
 export function normalizeEditorOutput(next: unknown): unknown {
-  if (next && typeof next === "object" && "value" in (next as any)) return (next as any).value;
+  if (next && typeof next === "object" && "value" in (next as any))
+    return (next as any).value;
   return next;
 }
 
@@ -87,7 +96,9 @@ export function humanizeOperatorName(name: string): string {
     .replace(/[_-]+/g, " ")
     .replace(/([a-z])([A-Z])/g, "$1 $2")
     .trim();
-  return spaced.length ? spaced.charAt(0).toUpperCase() + spaced.slice(1) : name;
+  return spaced.length
+    ? spaced.charAt(0).toUpperCase() + spaced.slice(1)
+    : name;
 }
 
 export function isEmptyLikeUI(v: unknown): boolean {

--- a/src/grid/utils/rowHeight.ts
+++ b/src/grid/utils/rowHeight.ts
@@ -1,0 +1,44 @@
+type TypeConfiguredRowHeight = number | ((rowIndex: number) => number) | null;
+
+type ResolveConfiguredRowHeightArgs = {
+  rowHeight: TypeConfiguredRowHeight;
+  rowIndex: number;
+  minRowHeight: number;
+  maxRowHeight?: number;
+};
+
+/**
+ * Resolve the layout height for a row without applying natural DOM
+ * measurement. Inovua treats a valid fixed rowHeight as the authoritative
+ * layout size; min/max bounds are for natural and function-valued heights.
+ */
+export function resolveConfiguredRowHeight({
+  rowHeight,
+  rowIndex,
+  minRowHeight,
+  maxRowHeight,
+}: ResolveConfiguredRowHeightArgs): number {
+  if (typeof rowHeight === "number") {
+    return Number.isFinite(rowHeight) && rowHeight > 0
+      ? rowHeight
+      : minRowHeight;
+  }
+
+  if (rowHeight == null) return minRowHeight;
+
+  const requestedHeight = rowHeight(rowIndex);
+  const finiteHeight =
+    typeof requestedHeight === "number" &&
+    Number.isFinite(requestedHeight) &&
+    requestedHeight > 0
+      ? requestedHeight
+      : minRowHeight;
+  const upperBound =
+    typeof maxRowHeight === "number" &&
+    Number.isFinite(maxRowHeight) &&
+    maxRowHeight >= minRowHeight
+      ? maxRowHeight
+      : Number.POSITIVE_INFINITY;
+
+  return Math.min(Math.max(finiteHeight, minRowHeight), upperBound);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,8 @@ export type {
   IColumn,
   SortDirection,
   TypeColumn,
+  TypeCellProps,
+  TypeColumnFilterValueChangeArg,
   TypeColumns,
   TypeComputedColumn,
   TypeComputedColumnsMap,

--- a/src/runtime.css
+++ b/src/runtime.css
@@ -580,11 +580,6 @@
   min-width: 100% !important;
 }
 
-/* Leave the final, centered resize handle clear of the viewport scrollbar. */
-.tdg-root .tdg-body-viewport {
-  padding-inline-end: 1.125rem !important;
-}
-
 .tdg-root .tdg-header-viewport {
   overflow: visible !important;
 }
@@ -751,10 +746,10 @@
   appearance: none !important;
   position: absolute !important;
   top: 0 !important;
-  right: calc(-0.4375rem - 0.5rem) !important;
+  right: calc(-0.75rem - 0.5rem) !important;
   z-index: 10 !important;
   display: flex !important;
-  width: 0.875rem !important;
+  width: 1.5rem !important;
   height: 100% !important;
   align-items: center !important;
   justify-content: center !important;
@@ -785,13 +780,32 @@
   background: var(--tdg-column-header-resizer-constrained-color) !important;
 }
 
+.tdg-root .tdg-column-resizer:is(:hover, :focus-visible)::before {
+  opacity: 1 !important;
+}
+
+/*
+ * Keep the trailing resize target inside the table boundary. A centered
+ * target on the final edge contributes its outer half to scrollWidth and can
+ * manufacture an otherwise-useless horizontal scroll range.
+ */
+.tdg-root .tdg-header-row > .tdg-header-cell:last-child .tdg-column-resizer {
+  right: -0.5rem !important;
+}
+
+.tdg-root .tdg-column-resizer:focus-visible {
+  outline: none !important;
+}
+
 .tdg-root .InovuaReactDataGrid__resize-proxy {
   position: absolute !important;
   top: 0 !important;
   bottom: 0 !important;
+  left: 0 !important;
   z-index: 20 !important;
   width: 1px !important;
   pointer-events: none !important;
+  will-change: transform !important;
   background: var(--tdg-column-header-resizer-constrained-color) !important;
 }
 
@@ -802,6 +816,7 @@
 }
 
 .tdg-root .InovuaReactDataGrid__cell {
+  box-sizing: border-box !important;
   padding: 0.5rem !important;
   position: relative !important;
 }
@@ -951,6 +966,11 @@
   text-decoration: none !important;
   vertical-align: middle !important;
   user-select: none !important;
+}
+
+.tdg-button:focus-visible {
+  box-shadow: inset 0 0 0 2px
+    var(--tdg-color-ring, var(--ring, oklch(0.708 0 0))) !important;
 }
 
 .tdg-button[data-size="default"] {
@@ -1264,6 +1284,90 @@
   font: inherit !important;
   color: inherit !important;
   line-height: inherit !important;
+}
+
+/*
+ * Inovua editors are full-cell overlays. Keep that compatibility positioning
+ * separate from the native-input reset below so wrapper editors retain their
+ * own internal flex layout and controls.
+ */
+.tdg-root .InovuaReactDataGrid__cell__editor.InovuaReactDataGrid__cell__editor {
+  box-sizing: border-box !important;
+  position: absolute !important;
+  inset: 0 !important;
+  z-index: 1 !important;
+  width: 100% !important;
+  height: 100% !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  margin: 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+}
+
+/*
+ * Only marked/Inovua-shaped editors take over the cell surface. Unmarked
+ * custom editors keep the ordinary padded content layout. The cell height is
+ * frozen internally for natural rows while this overlay is mounted.
+ */
+.tdg-root
+  .InovuaReactDataGrid__cell[data-editing="true"][data-editor-surface="seamless"] {
+  background: var(--tdg-field-active-bg) !important;
+  box-shadow: inset 0 -2px 0 var(--tdg-color-primary) !important;
+}
+
+.tdg-root
+  .InovuaReactDataGrid__cell[data-editing="true"][data-editor-surface="seamless"]
+  > .tdg-cell-content {
+  position: static !important;
+  overflow: visible !important;
+}
+
+/*
+ * The explicit marker opts a native text input into the seamless treatment.
+ * Its padding replaces the cell padding; it does not add a second text inset.
+ */
+.tdg-root .tdg-cell-editor[data-slot="cell-editor"] {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  box-sizing: border-box !important;
+  position: absolute !important;
+  inset: 0 !important;
+  z-index: 1 !important;
+  display: block !important;
+  width: 100% !important;
+  height: 100% !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  margin: 0 !important;
+  padding: 0.5rem !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  outline: 0 !important;
+  outline-offset: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: inherit !important;
+  caret-color: var(--tdg-color-primary, currentColor) !important;
+  font: inherit !important;
+  letter-spacing: inherit !important;
+  line-height: inherit !important;
+  text-align: inherit !important;
+}
+
+.tdg-root .tdg-cell-editor[data-slot="cell-editor"]:is(:focus, :focus-visible) {
+  border: 0 !important;
+  outline: 0 !important;
+  box-shadow: none !important;
+}
+
+@media (forced-colors: active) {
+  .tdg-root
+    .InovuaReactDataGrid__cell[data-editing="true"][data-editor-surface="seamless"] {
+    outline: 1px solid CanvasText !important;
+    outline-offset: -1px !important;
+  }
 }
 
 .tdg-root

--- a/src/types.ts
+++ b/src/types.ts
@@ -517,6 +517,19 @@ export type TypeScrollToIndex = (
   callback?: (...args: unknown[]) => void
 ) => void;
 
+export type TypeSmoothScrollConfig = {
+  orientation?: "horizontal" | "vertical";
+  duration?: number;
+};
+
+export type TypeSmoothScrollCallback = (value: number) => void;
+
+export type TypeSmoothScrollTo = (
+  value: number,
+  configOrCallback?: TypeSmoothScrollConfig | TypeSmoothScrollCallback | null,
+  callback?: TypeSmoothScrollCallback
+) => void;
+
 export type TypeComputedVirtualList = {
   props: Record<string, unknown>;
   context: Record<string, unknown>;
@@ -549,7 +562,7 @@ export type TypeComputedVirtualList = {
   getVisibleRange: () => TypeComputedVirtualListRange;
   setRowIndex: (index: number) => void;
   scrollToIndex: TypeScrollToIndex;
-  smoothScrollTo: TypeScrollToIndex;
+  smoothScrollTo: TypeSmoothScrollTo;
   refreshLayout: () => void;
   updateVisibleCount: () => number;
   isRowRendered: (rowIndex: number) => boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,45 @@ export type TypeSingleFilterValue = {
 
 export type TypeFilterValue = TypeSingleFilterValue[] | null;
 
+/**
+ * Filter-header cell context supplied by `onColumnFilterValueChange`.
+ *
+ * Inovua types this payload as `TypeCellProps`. Header filter cells do not
+ * represent a data row, so `rowIndex` is reported as `-1` by our runtime while
+ * the column aliases identify the filter that initiated the change.
+ */
+export type TypeCellProps = {
+  rowIndex: number;
+  columnIndex: number;
+  computedVisibleIndex?: number;
+  data?: any;
+  name?: string;
+  header?:
+    | React.ReactNode
+    | string
+    | ((
+        cellProps: TypeCellProps,
+        context: {
+          cellProps: TypeCellProps;
+          column: TypeComputedColumn;
+          contextMenu: any;
+        }
+      ) => React.ReactNode);
+  groupProps?: any;
+  cellSelectable?: boolean;
+  id?: string | number;
+  columnId?: string;
+  column?: TypeComputedColumn | TypeColumn;
+  [key: string]: any;
+};
+
+export type TypeColumnFilterValueChangeArg = {
+  filterValue: TypeSingleFilterValue;
+  columnId: string;
+  columnIndex: number;
+  cellProps?: TypeCellProps;
+};
+
 export type TypeFilterOperator = {
   name: string;
   fn: (args: {
@@ -566,7 +605,14 @@ export type TypeComputedProps = {
   getColumnFilterValue?: (
     column: TypeGetColumnByParam
   ) => TypeSingleFilterValue | undefined;
-  setColumnFilterValue?: (column: TypeGetColumnByParam, value: unknown) => void;
+  setColumnFilterValue?: (
+    column: TypeGetColumnByParam,
+    value: unknown,
+    operator?: string
+  ) => void;
+  computedOnColumnFilterValueChange?: (
+    columnFilterValue: TypeColumnFilterValueChangeArg
+  ) => void;
   isColumnFiltered?: (column: TypeGetColumnByParam) => boolean;
 
   computedEditable?: boolean;
@@ -798,6 +844,9 @@ export type TypeDataGridProps = {
   filterValue?: TypeFilterValue;
   defaultFilterValue?: TypeFilterValue;
   onFilterValueChange?: (filterValue: TypeFilterValue) => void;
+  onColumnFilterValueChange?: (
+    columnFilterValue: TypeColumnFilterValueChangeArg
+  ) => void;
 
   filterTypes?: TypeFilterTypes;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -863,6 +863,12 @@ export type TypeDataGridProps = {
    */
   checkboxColumn?: TypeCheckboxColumn;
 
+  /**
+   * Explicitly enables or disables row selection. When omitted, selection is
+   * inferred from `selected`, `defaultSelected`, or `checkboxColumn`.
+   */
+  enableSelection?: boolean;
+
   selected?: TypeRowSelection;
   defaultSelected?: TypeRowSelection;
   onSelectionChange?: (config: TypeOnSelectionChangeArg) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -676,6 +676,9 @@ export type TypeComputedProps = {
   computedShowHeader?: boolean;
   setShowHeader?: (value: React.SetStateAction<boolean>) => void;
 
+  computedShowZebraRows: boolean;
+  setShowZebraRows: (value: React.SetStateAction<boolean>) => void;
+
   showHorizontalCellBorders?: boolean;
   showVerticalCellBorders?: boolean;
   computedShowCellBorders?: TypeShowCellBorders;

--- a/src/types.ts
+++ b/src/types.ts
@@ -896,6 +896,15 @@ export type TypeDataGridProps = {
 
   i18n?: TypeI18n;
 
+  /**
+   * Content rendered when the current data view has no rows.
+   *
+   * String values are resolved as i18n keys before falling back to the
+   * supplied string. A function is invoked when the empty state is rendered;
+   * `null`, `false`, and an empty string suppress the empty-state content.
+   */
+  emptyText?: React.ReactNode | (() => React.ReactNode);
+
   showColumnMenuTool?: boolean;
 
   rowHeight?: number | ((rowIndex: number) => number) | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -851,6 +851,15 @@ export type TypeDataGridProps = {
   reorderColumns?: boolean;
   resizable?: boolean;
 
+  /**
+   * When enabled, the rendered column follows the pointer while its resize
+   * handle is dragged. The default deferred mode keeps the lightweight resize
+   * proxy and applies the proposed width when the gesture completes.
+   *
+   * `onColumnResize` remains a completion callback in both modes.
+   */
+  liveColumnResize?: boolean;
+
   enableColumnFilterContextMenu?: boolean;
 
   enableColumnAutosize?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,7 +310,7 @@ export type TypeRowStyleProps = Record<string, unknown> & {
   editValue?: unknown;
   editColumnIndex?: number;
   editColumnId?: string;
-  virtualizeColumns: false;
+  virtualizeColumns: boolean;
   theme: string;
   getItemId: (data: any) => unknown;
 };
@@ -819,6 +819,21 @@ export type TypeDataGridProps = {
   pageSizes?: number[];
 
   virtualized?: boolean;
+
+  /**
+   * Enables horizontal column virtualization when the grid has at least this
+   * many visible columns. The boundary is inclusive and defaults to `15`.
+   * Column virtualization requires a fixed numeric `rowHeight`.
+   */
+  virtualizeColumnsThreshold?: number;
+
+  /**
+   * Explicitly enables or disables horizontal column virtualization,
+   * overriding `virtualizeColumnsThreshold`. A function-valued or natural
+   * `rowHeight` still disables column virtualization because those layouts
+   * cannot safely share a fixed horizontal render window.
+   */
+  virtualizeColumns?: boolean;
 
   /** Transform the grid into a responsive virtual list at widths up to 1024px. */
   allowMobileTransform?: boolean;

--- a/tests/engine/tanstack-adapter.test.ts
+++ b/tests/engine/tanstack-adapter.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  TypeColumn,
+  TypeFilterValue,
+  TypeSortInfo,
+} from "../../src/types";
+import {
+  fromTanStackColumnFiltersState,
+  fromTanStackRowSelectionState,
+  fromTanStackSortingState,
+  hydrateTanStackRowSelection,
+  projectTanStackColumnOrder,
+  projectTanStackColumnSizing,
+  projectTanStackColumnVisibility,
+  toTanStackColumnFiltersState,
+  toTanStackRowSelectionState,
+  toTanStackSortingState,
+} from "../../src/grid/engine/tanstackAdapter";
+
+const columns = [
+  { id: 0, name: "rank", sortName: "rankSort", minWidth: 20 },
+  { id: false, name: "enabled", sortName: "enabledSort", maxWidth: 100 },
+  { id: "display", name: "fullName", filterName: "nameFilter" },
+] as unknown as TypeColumn[];
+
+test("sorting projects sort names to column IDs without dropping falsy IDs", () => {
+  const sortInfo = [
+    { name: "rankSort", dir: 1 as const },
+    { name: "enabledSort", dir: -1 as const },
+    { name: "ignored", dir: 0 as const },
+    { name: "rankSort", dir: -1 as const },
+  ];
+
+  assert.deepEqual(toTanStackSortingState(sortInfo, columns), [
+    { id: "0", desc: false },
+    { id: "false", desc: true },
+  ]);
+});
+
+test("sorting restores sort names, metadata, unknown IDs, and controlled shape", () => {
+  const compare = () => 0;
+  const current = [
+    {
+      name: "rankSort",
+      dir: 1 as const,
+      type: "number",
+      fn: compare,
+      columnName: "rank",
+    },
+  ] satisfies TypeSortInfo;
+
+  const result = fromTanStackSortingState(
+    [
+      { id: "0", desc: true },
+      { id: "external", desc: false },
+      { id: "0", desc: false },
+    ],
+    columns,
+    current
+  );
+
+  assert.deepEqual(result, [
+    {
+      name: "rankSort",
+      dir: -1,
+      type: "number",
+      fn: compare,
+      columnName: "rank",
+    },
+    { name: "external", dir: 1 },
+  ]);
+  assert.equal(fromTanStackSortingState([], columns, current), null);
+  assert.deepEqual(
+    fromTanStackSortingState([{ id: "false", desc: false }], columns),
+    { name: "enabledSort", dir: 1 }
+  );
+});
+
+test("filter projection stores and restores complete compatibility entries", () => {
+  const getFilterValue = () => "Ada";
+  const customFilter = () => true;
+  const filterValue: TypeFilterValue = [
+    {
+      name: "nameFilter",
+      type: "string",
+      operator: "startsWith",
+      value: "A",
+      emptyValue: "",
+      active: false,
+      fn: customFilter,
+      getFilterValue,
+    },
+  ];
+
+  const projected = toTanStackColumnFiltersState(filterValue, columns);
+  assert.deepEqual(projected, [
+    {
+      id: "display",
+      value: {
+        ...filterValue[0],
+      },
+    },
+  ]);
+  assert.notEqual(projected[0]!.value, filterValue[0]);
+
+  assert.deepEqual(
+    fromTanStackColumnFiltersState(projected, columns),
+    filterValue
+  );
+});
+
+test("raw TanStack filter updates reuse required compatibility metadata", () => {
+  const current: TypeFilterValue = [
+    {
+      name: "nameFilter",
+      type: "string",
+      operator: "contains",
+      value: "old",
+      active: true,
+    },
+  ];
+
+  assert.deepEqual(
+    fromTanStackColumnFiltersState(
+      [{ id: "display", value: "new" }],
+      columns,
+      current
+    ),
+    [{ ...current[0], value: "new" }]
+  );
+  assert.equal(
+    fromTanStackColumnFiltersState(
+      [{ id: "unknown", value: "cannot infer operator" }],
+      columns
+    ),
+    null
+  );
+});
+
+test("selection conversion preserves numeric and other falsy row IDs", () => {
+  assert.deepEqual(toTanStackRowSelectionState(0), { "0": true });
+  assert.deepEqual(toTanStackRowSelectionState(false), { false: true });
+  assert.deepEqual(
+    toTanStackRowSelectionState({
+      "": { id: "" },
+      "0": { id: 0 },
+      false: { id: false },
+      disabled: false,
+    }),
+    { "": true, "0": true, false: true }
+  );
+  assert.deepEqual(
+    toTanStackRowSelectionState({
+      selected: 0,
+      data: { id: 0 },
+    }),
+    { "0": true }
+  );
+});
+
+test("selection restoration retains existing row objects when possible", () => {
+  const row = { id: 0, label: "zero" };
+
+  assert.deepEqual(
+    fromTanStackRowSelectionState(
+      { "0": true, stale: false, added: true, repaired: true },
+      { "0": row, repaired: false }
+    ),
+    { "0": row, added: true, repaired: true }
+  );
+});
+
+test("selection hydration uses current rows and drops stale selected IDs", () => {
+  const rows = [
+    { id: 0, version: "current" },
+    { id: false, version: "false-id" },
+    { id: "", version: "empty-id" },
+    { id: 0, version: "duplicate" },
+  ];
+
+  assert.deepEqual(
+    hydrateTanStackRowSelection(
+      { "0": true, false: true, "": true, stale: true },
+      rows,
+      (row) => row.id
+    ),
+    {
+      "0": rows[0],
+      false: rows[1],
+      "": rows[2],
+    }
+  );
+});
+
+test("column state projections preserve controlled false/zero values", () => {
+  const projectionColumns = [
+    {
+      id: 0,
+      name: "zero",
+      visible: false,
+      width: 5,
+      minWidth: 20,
+    },
+    {
+      id: false,
+      name: "false",
+      defaultHidden: true,
+      width: 200,
+      maxWidth: 100,
+    },
+    {
+      id: "plain",
+      defaultVisible: false,
+      defaultWidth: 0,
+    },
+  ] as unknown as TypeColumn[];
+
+  assert.deepEqual(
+    projectTanStackColumnVisibility(projectionColumns, {
+      "0": true,
+      false: false,
+    }),
+    { "0": true, false: false, plain: true }
+  );
+  assert.deepEqual(
+    projectTanStackColumnOrder(projectionColumns, [false, 0, "missing", 0]),
+    ["false", "0", "plain"]
+  );
+  assert.deepEqual(projectTanStackColumnSizing(projectionColumns, { "0": 0 }), {
+    "0": 20,
+    false: 100,
+    plain: 0,
+  });
+});

--- a/tests/playwright/default-props-compat.spec.ts
+++ b/tests/playwright/default-props-compat.spec.ts
@@ -22,11 +22,14 @@ test("defaultProps static is available from the ReactDataGrid default export", a
   await expect(page.getByTestId("default-props-keys")).toContainText(
     "virtualizeColumnsThreshold"
   );
+  await expect(page.getByTestId("default-props-keys")).toContainText(
+    "liveColumnResize"
+  );
   await expect(
     page.getByTestId("default-props-string-operators")
   ).toContainText("contains");
   await expect(page.getByTestId("default-props-values")).toHaveText(
-    "theme=default,virtualized=true,virtualizeColumnsThreshold=15,allowMobileTransform=false,rowHeight=44,emptyText=noRecords"
+    "theme=default,virtualized=true,virtualizeColumnsThreshold=15,allowMobileTransform=false,liveColumnResize=false,rowHeight=44,emptyText=noRecords"
   );
   await expect(page.getByTestId("default-props-filtered-count")).toContainText(
     "3"

--- a/tests/playwright/default-props-compat.spec.ts
+++ b/tests/playwright/default-props-compat.spec.ts
@@ -16,11 +16,17 @@ test("defaultProps static is available from the ReactDataGrid default export", a
     "filterTypes"
   );
   await expect(page.getByTestId("default-props-keys")).toContainText("theme");
+  await expect(page.getByTestId("default-props-keys")).toContainText(
+    "emptyText"
+  );
+  await expect(page.getByTestId("default-props-keys")).toContainText(
+    "virtualizeColumnsThreshold"
+  );
   await expect(
     page.getByTestId("default-props-string-operators")
   ).toContainText("contains");
   await expect(page.getByTestId("default-props-values")).toHaveText(
-    "theme=default,virtualized=true,allowMobileTransform=false,rowHeight=44"
+    "theme=default,virtualized=true,virtualizeColumnsThreshold=15,allowMobileTransform=false,rowHeight=44,emptyText=noRecords"
   );
   await expect(page.getByTestId("default-props-filtered-count")).toContainText(
     "3"

--- a/tests/playwright/example-row-height.spec.ts
+++ b/tests/playwright/example-row-height.spec.ts
@@ -1,0 +1,315 @@
+import { expect, test, type Locator } from "@playwright/test";
+
+type CellHeightGeometry = {
+  rowIndex: number | null;
+  rowHeight: number;
+  rowInlineHeight: string;
+  cellHeight: number;
+  cellTop: number;
+  cellBottom: number;
+  rowTop: number;
+  rowBottom: number;
+  contentClientHeight: number;
+  contentScrollHeight: number;
+  contentTop: number;
+  contentBottom: number;
+  contentInlineMaxHeight: string;
+  renderedTop: number;
+  renderedBottom: number;
+};
+
+async function readCellHeightGeometry(
+  cells: Locator
+): Promise<CellHeightGeometry[]> {
+  return cells.evaluateAll((cellElements): CellHeightGeometry[] =>
+    cellElements.map((cellElement) => {
+      const cell = cellElement as HTMLElement;
+      const row = cell.closest<HTMLElement>('[data-slot="grid-row"]');
+      const content = cell.querySelector<HTMLElement>(".tdg-cell-content");
+      const rendered = content?.firstElementChild as HTMLElement | null;
+
+      if (!row || !content || !rendered) {
+        throw new Error(
+          "Expected a rendered data row, cell content, and renderer"
+        );
+      }
+
+      const rowRect = row.getBoundingClientRect();
+      const cellRect = cell.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const renderedRect = rendered.getBoundingClientRect();
+      const parsedIndex = Number(row.dataset.rowIndex);
+
+      return {
+        rowIndex: Number.isFinite(parsedIndex) ? parsedIndex : null,
+        rowHeight: rowRect.height,
+        rowInlineHeight: row.style.height,
+        cellHeight: cellRect.height,
+        cellTop: cellRect.top,
+        cellBottom: cellRect.bottom,
+        rowTop: rowRect.top,
+        rowBottom: rowRect.bottom,
+        contentClientHeight: content.clientHeight,
+        contentScrollHeight: content.scrollHeight,
+        contentTop: contentRect.top,
+        contentBottom: contentRect.bottom,
+        contentInlineMaxHeight: content.style.maxHeight,
+        renderedTop: renderedRect.top,
+        renderedBottom: renderedRect.bottom,
+      };
+    })
+  );
+}
+
+function expectContentToFit(geometry: CellHeightGeometry): void {
+  const tolerance = 1;
+
+  expect(geometry.contentScrollHeight).toBeLessThanOrEqual(
+    geometry.contentClientHeight + tolerance
+  );
+  expect(geometry.renderedTop).toBeGreaterThanOrEqual(
+    geometry.contentTop - tolerance
+  );
+  expect(geometry.renderedBottom).toBeLessThanOrEqual(
+    geometry.contentBottom + tolerance
+  );
+  expect(geometry.cellTop).toBeGreaterThanOrEqual(geometry.rowTop - tolerance);
+  expect(geometry.cellBottom).toBeLessThanOrEqual(
+    geometry.rowBottom + tolerance
+  );
+  expect(
+    Math.abs(geometry.cellHeight - geometry.rowHeight)
+  ).toBeLessThanOrEqual(tolerance);
+}
+
+async function expectAdjacentRowsToShareAnEdge(
+  grid: Locator,
+  firstRowIndex: number,
+  secondRowIndex: number
+): Promise<void> {
+  const edgeDelta = await grid.evaluate(
+    (gridElement, { firstIndex, secondIndex }) => {
+      const firstRow = gridElement.querySelector<HTMLElement>(
+        `[data-slot="grid-row"][data-row-index="${firstIndex}"]`
+      );
+      const secondRow = gridElement.querySelector<HTMLElement>(
+        `[data-slot="grid-row"][data-row-index="${secondIndex}"]`
+      );
+
+      if (!firstRow || !secondRow) {
+        throw new Error(
+          `Expected adjacent rendered rows ${firstIndex} and ${secondIndex}`
+        );
+      }
+
+      const firstRect = firstRow.getBoundingClientRect();
+      const secondRect = secondRow.getBoundingClientRect();
+
+      return Math.abs(secondRect.top - firstRect.bottom);
+    },
+    { firstIndex: firstRowIndex, secondIndex: secondRowIndex }
+  );
+
+  expect(edgeDelta).toBeLessThanOrEqual(1);
+}
+
+async function waitForRowsToRemainRendered(
+  grid: Locator,
+  rowIndexes: number[]
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        grid.evaluate(async (gridElement, expectedIndexes) => {
+          const rowsAreRendered = () =>
+            expectedIndexes.every((rowIndex) =>
+              gridElement.querySelector(
+                `[data-slot="grid-row"][data-row-index="${rowIndex}"]`
+              )
+            );
+
+          // The virtualizer can briefly expose its initial range while React
+          // finishes the first post-scroll render. Requiring the requested
+          // range to survive several paints waits for the settled range rather
+          // than accepting that transient DOM.
+          for (let frame = 0; frame < 6; frame += 1) {
+            if (!rowsAreRendered()) return false;
+            await new Promise<void>((resolve) =>
+              window.requestAnimationFrame(() => resolve())
+            );
+          }
+
+          return rowsAreRendered();
+        }, rowIndexes),
+      { message: `rows ${rowIndexes.join(", ")} to remain rendered` }
+    )
+    .toBe(true);
+}
+
+test("selection example uses natural rows without clipping composite Account cells", async ({
+  page,
+}) => {
+  await page.goto("/examples/selection");
+
+  const grid = page
+    .getByTestId("selection-example-shell")
+    .locator(".InovuaReactDataGrid.tdg-root")
+    .first();
+  await expect(grid).toBeVisible();
+
+  const accountCells = grid.locator(
+    '[data-slot="grid-row"] [data-column-id="account"]'
+  );
+  await expect(accountCells).toHaveCount(8);
+
+  const geometry = await readCellHeightGeometry(accountCells);
+  for (const cell of geometry) {
+    expectContentToFit(cell);
+    expect(cell.rowHeight).toBeGreaterThanOrEqual(52);
+    // Natural mode leaves the renderer unconstrained and uses minRowHeight as
+    // a floor; the table may grow by a fractional pixel for its two text lines.
+    expect(cell.contentInlineMaxHeight).toBe("");
+    expect(cell.rowInlineHeight).toBe("52px");
+  }
+
+  await expectAdjacentRowsToShareAnEdge(grid, 0, 1);
+});
+
+test("columns example keeps fixed virtual rows and an offscreen Owner renderer aligned", async ({
+  page,
+}) => {
+  await page.goto("/examples/columns");
+
+  const shell = page.getByTestId("columns-grid-shell");
+  const grid = shell.locator(".InovuaReactDataGrid.tdg-root").first();
+  const viewport = grid.locator('[data-slot="scroll-area-viewport"]');
+  const headerViewport = grid.locator('[data-slot="grid-header-viewport"]');
+  await expect(grid).toBeVisible();
+
+  const initialOwnerCells = grid.locator(
+    '[data-slot="grid-row"] [data-column-id="owner"]'
+  );
+  await expect(initialOwnerCells.first()).toBeVisible();
+  for (const cell of await readCellHeightGeometry(initialOwnerCells)) {
+    expectContentToFit(cell);
+    expect(cell.rowHeight).toBeCloseTo(56, 0);
+    expect(cell.rowInlineHeight).toBe("56px");
+    expect(cell.contentInlineMaxHeight).toBe("40px");
+  }
+
+  const targetIndex = 77;
+  await viewport.evaluate(async (element, targetScrollTop) => {
+    element.scrollTo({ top: targetScrollTop });
+    await new Promise<void>((resolve) =>
+      window.requestAnimationFrame(() => resolve())
+    );
+  }, targetIndex * 56);
+
+  await waitForRowsToRemainRendered(grid, [targetIndex, targetIndex + 1]);
+
+  const targetRow = grid.locator(
+    `[data-slot="grid-row"][data-row-index="${targetIndex}"]`
+  );
+  const nextRow = grid.locator(
+    `[data-slot="grid-row"][data-row-index="${targetIndex + 1}"]`
+  );
+  await expect(targetRow).toBeVisible();
+  await expect(nextRow).toBeVisible();
+
+  const [targetGeometry] = await readCellHeightGeometry(
+    targetRow.locator('[data-column-id="owner"]')
+  );
+  expect(targetGeometry).toBeDefined();
+  expectContentToFit(targetGeometry!);
+  expect(targetGeometry?.rowHeight).toBeCloseTo(56, 0);
+  await expectAdjacentRowsToShareAnEdge(grid, targetIndex, targetIndex + 1);
+
+  const virtualOffset = await grid.evaluate(
+    (gridElement, { targetIndex: index, expectedRowHeight }) => {
+      const row = gridElement.querySelector<HTMLElement>(
+        `[data-slot="grid-row"][data-row-index="${index}"]`
+      );
+      const bodyViewport = gridElement.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-viewport"]'
+      );
+      const header = gridElement.querySelector<HTMLElement>(
+        '[data-slot="grid-header-viewport"]'
+      );
+
+      if (!row || !bodyViewport || !header) {
+        throw new Error(
+          "Expected the target row, grid body, and sticky header viewports"
+        );
+      }
+
+      const rowRect = row.getBoundingClientRect();
+      const viewportRect = bodyViewport.getBoundingClientRect();
+
+      return {
+        actualStart:
+          rowRect.top -
+          viewportRect.top +
+          bodyViewport.scrollTop -
+          header.getBoundingClientRect().height,
+        expectedStart: index * expectedRowHeight,
+      };
+    },
+    { targetIndex, expectedRowHeight: 56 }
+  );
+  expect(
+    Math.abs(virtualOffset.actualStart - virtualOffset.expectedStart)
+  ).toBeLessThanOrEqual(2);
+
+  // Keep the header locator live through the scroll: the row must begin below
+  // the same sticky layer rather than being virtually positioned under it.
+  await expect(headerViewport).toBeVisible();
+});
+
+test("columns natural-height toggle measures its three composite rows without clipping", async ({
+  page,
+}) => {
+  await page.goto("/examples/columns");
+  await page.getByTestId("columns-height-toggle").click();
+  await expect(page.getByTestId("columns-height-toggle")).toHaveText(
+    "Use fixed height"
+  );
+
+  const shell = page.getByTestId("columns-grid-shell");
+  const grid = shell.locator(".InovuaReactDataGrid.tdg-root").first();
+  const ownerCells = grid.locator(
+    '[data-slot="grid-row"] [data-column-id="owner"]'
+  );
+  await expect(ownerCells).toHaveCount(3);
+
+  const geometry = await readCellHeightGeometry(ownerCells);
+  for (const cell of geometry) {
+    expectContentToFit(cell);
+    expect(cell.rowHeight).toBeGreaterThanOrEqual(52);
+    expect(cell.rowInlineHeight).toBe("52px");
+    expect(cell.contentInlineMaxHeight).toBe("");
+  }
+
+  await expectAdjacentRowsToShareAnEdge(grid, 0, 1);
+  await expectAdjacentRowsToShareAnEdge(grid, 1, 2);
+
+  const layout = await shell.evaluate((element) => {
+    const gridElement = element.querySelector<HTMLElement>(".tdg-root");
+    const viewport = element.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+
+    if (!gridElement || !viewport) {
+      throw new Error("Expected the natural-height grid layout");
+    }
+
+    return {
+      shellHeight: element.getBoundingClientRect().height,
+      gridHeight: gridElement.getBoundingClientRect().height,
+      hasVerticalOverflow: viewport.scrollHeight > viewport.clientHeight + 1,
+    };
+  });
+
+  expect(layout.shellHeight).toBeLessThan(400);
+  expect(layout.gridHeight).toBeLessThanOrEqual(layout.shellHeight + 1);
+  expect(layout.hasVerticalOverflow).toBe(false);
+});

--- a/tests/playwright/examples-routing.spec.ts
+++ b/tests/playwright/examples-routing.spec.ts
@@ -193,6 +193,29 @@ test("navigates between docs and dedicated example pages", async ({ page }) => {
     page.getByRole("heading", { name: "ReactDataGrid prop reference" })
   ).toBeVisible();
   await expect(page.getByRole("heading", { name: "Core props" })).toBeVisible();
+  for (const propName of [
+    "onColumnFilterValueChange",
+    "enableSelection",
+    "virtualizeColumnsThreshold",
+    "virtualizeColumns",
+    "emptyText",
+  ]) {
+    await expect(
+      page.getByRole("cell", { name: propName, exact: true })
+    ).toBeVisible();
+  }
+
+  await page.goto("/docs/migration/inovua-status");
+  for (const feature of [
+    "Per-column filter change callback",
+    "Selection enablement and precedence",
+    "Horizontal column virtualization",
+    "Empty-state content",
+  ]) {
+    await expect(
+      page.getByRole("rowheader", { name: feature, exact: true })
+    ).toBeVisible();
+  }
 
   await page.goto("/docs/getting-started/quickstart");
   await expect(

--- a/tests/playwright/examples-routing.spec.ts
+++ b/tests/playwright/examples-routing.spec.ts
@@ -286,7 +286,7 @@ test("keeps the compatibility lab source bounded and internally scrollable", asy
     .getByRole("button");
 
   await expect(sourcePanel).toBeVisible();
-  await expect(scenarioButtons).toHaveCount(20);
+  await expect(scenarioButtons).toHaveCount(22);
   await expect
     .poll(async () => sourcePanel.evaluate((element) => element.clientHeight))
     .toBeLessThanOrEqual(640);

--- a/tests/playwright/inovua-parity.spec.ts
+++ b/tests/playwright/inovua-parity.spec.ts
@@ -36,6 +36,11 @@ type NaturalMeasurement = {
   totalVirtualHeight: number | null;
 };
 
+type SmoothScrollReport = {
+  target: number | null;
+  completed: number | null;
+};
+
 type EditEvent = {
   type: "start" | "stop" | "complete" | "cancel" | "value";
   rowId: string | number;
@@ -66,6 +71,61 @@ type CustomEditorContractReport = {
   hasGotoNext: boolean;
   hasGotoPrev: boolean;
   hasClickHandler: boolean;
+};
+
+type CellPresentationSnapshot = {
+  cellHeight: number;
+  cellWidth: number;
+  contentLeft: number;
+  contentTop: number;
+  contentWidth: number;
+  contentHeight: number;
+  textLeft: number;
+  textCenterY: number;
+  rowHeight: number;
+  nextRowOffset: number;
+  neighborOffset: number;
+  neighborWidth: number;
+  fontFamily: string;
+  fontSize: string;
+  fontWeight: string;
+  lineHeight: string;
+  color: string;
+  textAlign: string;
+};
+
+type EditorChromeSnapshot = {
+  borderTop: number;
+  borderRight: number;
+  borderBottom: number;
+  borderLeft: number;
+  borderRadius: number;
+  paddingTop: number;
+  paddingRight: number;
+  paddingBottom: number;
+  paddingLeft: number;
+  marginTop: number;
+  marginRight: number;
+  marginBottom: number;
+  marginLeft: number;
+  boxShadow: string;
+  outlineStyle: string;
+  backgroundColor: string;
+};
+
+type EditorPresentationSnapshot = CellPresentationSnapshot & {
+  inputLeft: number;
+  inputTop: number;
+  inputWidth: number;
+  inputHeight: number;
+  inputTextLeft: number;
+  surfaceLeft: number;
+  surfaceTop: number;
+  surfaceWidth: number;
+  surfaceHeight: number;
+  cellBoxShadow: string;
+  inputChrome: EditorChromeSnapshot;
+  surfaceChrome: EditorChromeSnapshot;
 };
 
 type ImperativeSnapshot = {
@@ -124,6 +184,343 @@ async function readWidth(locator: Locator): Promise<number> {
   return locator.evaluate((element) =>
     Math.round(element.getBoundingClientRect().width)
   );
+}
+
+async function readCellPresentation(
+  targetCell: Locator
+): Promise<CellPresentationSnapshot> {
+  return targetCell.evaluate((element) => {
+    const cell = element as HTMLElement;
+    const content = cell.querySelector<HTMLElement>(".tdg-cell-content");
+    const row = cell.closest<HTMLElement>('[data-slot="grid-row"]');
+    const grid = cell.closest<HTMLElement>(".tdg-root");
+    const neighbor = row?.querySelector<HTMLElement>('[data-column-id="city"]');
+    const nextRow = grid?.querySelector<HTMLElement>(
+      '[data-slot="grid-row"][data-row-id="row-2"]'
+    );
+    if (!content || !row || !neighbor || !nextRow) {
+      throw new Error("Expected editing geometry targets were not rendered");
+    }
+
+    const findTextNode = (node: Node): Text | null => {
+      for (const child of Array.from(node.childNodes)) {
+        if (child.nodeType === Node.TEXT_NODE && child.textContent?.trim()) {
+          return child as Text;
+        }
+        const nested = findTextNode(child);
+        if (nested) return nested;
+      }
+      return null;
+    };
+    const textNode = findTextNode(content);
+    if (!textNode) throw new Error("Expected rendered cell text");
+    const textRange = document.createRange();
+    textRange.selectNodeContents(textNode);
+
+    const cellRect = cell.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    const textRect = textRange.getBoundingClientRect();
+    const rowRect = row.getBoundingClientRect();
+    const nextRowRect = nextRow.getBoundingClientRect();
+    const neighborRect = neighbor.getBoundingClientRect();
+    const textStyle = getComputedStyle(textNode.parentElement ?? content);
+
+    return {
+      cellHeight: cellRect.height,
+      cellWidth: cellRect.width,
+      contentLeft: contentRect.left - cellRect.left,
+      contentTop: contentRect.top - cellRect.top,
+      contentWidth: contentRect.width,
+      contentHeight: contentRect.height,
+      textLeft: textRect.left - cellRect.left,
+      textCenterY: textRect.top + textRect.height / 2 - cellRect.top,
+      rowHeight: rowRect.height,
+      nextRowOffset: nextRowRect.top - rowRect.top,
+      neighborOffset: neighborRect.left - cellRect.left,
+      neighborWidth: neighborRect.width,
+      fontFamily: textStyle.fontFamily,
+      fontSize: textStyle.fontSize,
+      fontWeight: textStyle.fontWeight,
+      lineHeight: textStyle.lineHeight,
+      color: textStyle.color,
+      textAlign: textStyle.textAlign,
+    };
+  });
+}
+
+async function readEditorPresentation(
+  editor: Locator
+): Promise<EditorPresentationSnapshot> {
+  return editor.evaluate((element) => {
+    const input = element as HTMLInputElement;
+    const cell = input.closest<HTMLElement>('[data-column-id="name"]');
+    const content = cell?.querySelector<HTMLElement>(".tdg-cell-content");
+    const row = cell?.closest<HTMLElement>('[data-slot="grid-row"]');
+    const grid = cell?.closest<HTMLElement>(".tdg-root");
+    const neighbor = row?.querySelector<HTMLElement>('[data-column-id="city"]');
+    const nextRow = grid?.querySelector<HTMLElement>(
+      '[data-slot="grid-row"][data-row-id="row-2"]'
+    );
+    const surface =
+      input.closest<HTMLElement>(".inovua-react-toolkit-text-input") ?? input;
+    if (!cell || !content || !row || !neighbor || !nextRow) {
+      throw new Error(
+        "Expected active editor geometry targets were not rendered"
+      );
+    }
+
+    const px = (value: string): number => Number.parseFloat(value) || 0;
+    const readChrome = (target: HTMLElement): EditorChromeSnapshot => {
+      const style = getComputedStyle(target);
+      return {
+        borderTop: px(style.borderTopWidth),
+        borderRight: px(style.borderRightWidth),
+        borderBottom: px(style.borderBottomWidth),
+        borderLeft: px(style.borderLeftWidth),
+        borderRadius: px(style.borderTopLeftRadius),
+        paddingTop: px(style.paddingTop),
+        paddingRight: px(style.paddingRight),
+        paddingBottom: px(style.paddingBottom),
+        paddingLeft: px(style.paddingLeft),
+        marginTop: px(style.marginTop),
+        marginRight: px(style.marginRight),
+        marginBottom: px(style.marginBottom),
+        marginLeft: px(style.marginLeft),
+        boxShadow: style.boxShadow,
+        outlineStyle: style.outlineStyle,
+        backgroundColor: style.backgroundColor,
+      };
+    };
+
+    const cellRect = cell.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    const inputRect = input.getBoundingClientRect();
+    const surfaceRect = surface.getBoundingClientRect();
+    const rowRect = row.getBoundingClientRect();
+    const nextRowRect = nextRow.getBoundingClientRect();
+    const neighborRect = neighbor.getBoundingClientRect();
+    const inputStyle = getComputedStyle(input);
+    const cellStyle = getComputedStyle(cell);
+
+    return {
+      cellHeight: cellRect.height,
+      cellWidth: cellRect.width,
+      contentLeft: contentRect.left - cellRect.left,
+      contentTop: contentRect.top - cellRect.top,
+      contentWidth: contentRect.width,
+      contentHeight: contentRect.height,
+      textLeft: inputRect.left - cellRect.left,
+      textCenterY: inputRect.top + inputRect.height / 2 - cellRect.top,
+      rowHeight: rowRect.height,
+      nextRowOffset: nextRowRect.top - rowRect.top,
+      neighborOffset: neighborRect.left - cellRect.left,
+      neighborWidth: neighborRect.width,
+      fontFamily: inputStyle.fontFamily,
+      fontSize: inputStyle.fontSize,
+      fontWeight: inputStyle.fontWeight,
+      lineHeight: inputStyle.lineHeight,
+      color: inputStyle.color,
+      textAlign: inputStyle.textAlign,
+      inputLeft: inputRect.left - cellRect.left,
+      inputTop: inputRect.top - cellRect.top,
+      inputWidth: inputRect.width,
+      inputHeight: inputRect.height,
+      inputTextLeft:
+        inputRect.left -
+        cellRect.left +
+        px(inputStyle.borderLeftWidth) +
+        px(inputStyle.paddingLeft),
+      surfaceLeft: surfaceRect.left - cellRect.left,
+      surfaceTop: surfaceRect.top - cellRect.top,
+      surfaceWidth: surfaceRect.width,
+      surfaceHeight: surfaceRect.height,
+      cellBoxShadow: cellStyle.boxShadow,
+      inputChrome: readChrome(input),
+      surfaceChrome: readChrome(surface),
+    };
+  });
+}
+
+function expectBorderlessEditorChrome(chrome: EditorChromeSnapshot): void {
+  expect({
+    borderTop: chrome.borderTop,
+    borderRight: chrome.borderRight,
+    borderBottom: chrome.borderBottom,
+    borderLeft: chrome.borderLeft,
+    borderRadius: chrome.borderRadius,
+    marginTop: chrome.marginTop,
+    marginRight: chrome.marginRight,
+    marginBottom: chrome.marginBottom,
+    marginLeft: chrome.marginLeft,
+  }).toEqual({
+    borderTop: 0,
+    borderRight: 0,
+    borderBottom: 0,
+    borderLeft: 0,
+    borderRadius: 0,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+  });
+  expect(chrome.boxShadow).toBe("none");
+  expect(chrome.outlineStyle).toBe("none");
+  expect(chrome.backgroundColor).toBe("rgba(0, 0, 0, 0)");
+}
+
+function expectSeamlessEditorGeometry(
+  display: CellPresentationSnapshot,
+  editing: EditorPresentationSnapshot
+): void {
+  const delta = (left: number, right: number) => Math.abs(left - right);
+  expect(delta(editing.cellHeight, display.cellHeight)).toBeLessThanOrEqual(
+    0.5
+  );
+  expect(delta(editing.cellWidth, display.cellWidth)).toBeLessThanOrEqual(0.5);
+  expect(delta(editing.rowHeight, display.rowHeight)).toBeLessThanOrEqual(0.5);
+  expect(
+    delta(editing.nextRowOffset, display.nextRowOffset)
+  ).toBeLessThanOrEqual(0.5);
+  expect(
+    delta(editing.neighborOffset, display.neighborOffset)
+  ).toBeLessThanOrEqual(0.5);
+  expect(
+    delta(editing.neighborWidth, display.neighborWidth)
+  ).toBeLessThanOrEqual(0.5);
+  // The editing surface occupies the whole cell, while its internal text
+  // inset exactly replaces the display cell's padding. This creates a large
+  // hit target without moving the value when edit mode starts.
+  expect(Math.abs(editing.inputLeft)).toBeLessThanOrEqual(0.5);
+  expect(delta(editing.inputWidth, display.cellWidth)).toBeLessThanOrEqual(1);
+  expect(delta(editing.inputHeight, display.cellHeight)).toBeLessThanOrEqual(1);
+  expect(Math.abs(editing.surfaceLeft)).toBeLessThanOrEqual(0.5);
+  expect(delta(editing.surfaceWidth, display.cellWidth)).toBeLessThanOrEqual(1);
+  expect(delta(editing.surfaceHeight, display.cellHeight)).toBeLessThanOrEqual(
+    1
+  );
+  expect(delta(editing.inputTextLeft, display.textLeft)).toBeLessThanOrEqual(
+    0.5
+  );
+  expect(delta(editing.textCenterY, display.textCenterY)).toBeLessThanOrEqual(
+    1
+  );
+  expect(
+    Math.abs(editing.inputChrome.paddingTop - editing.inputChrome.paddingBottom)
+  ).toBeLessThanOrEqual(0.5);
+  expect(editing.inputTop).toBeGreaterThanOrEqual(-0.5);
+  expect(editing.inputTop + editing.inputHeight).toBeLessThanOrEqual(
+    editing.cellHeight + 0.5
+  );
+  expect(editing.surfaceTop).toBeGreaterThanOrEqual(-0.5);
+  expect(editing.surfaceTop + editing.surfaceHeight).toBeLessThanOrEqual(
+    editing.cellHeight + 0.5
+  );
+  expect({
+    fontFamily: editing.fontFamily,
+    fontSize: editing.fontSize,
+    fontWeight: editing.fontWeight,
+    lineHeight: editing.lineHeight,
+    color: editing.color,
+    textAlign: editing.textAlign,
+  }).toEqual({
+    fontFamily: display.fontFamily,
+    fontSize: display.fontSize,
+    fontWeight: display.fontWeight,
+    lineHeight: display.lineHeight,
+    color: display.color,
+    textAlign: display.textAlign,
+  });
+  expectBorderlessEditorChrome(editing.inputChrome);
+  expectBorderlessEditorChrome(editing.surfaceChrome);
+  expect(editing.cellBoxShadow).not.toBe("none");
+  expect(editing.cellBoxShadow).toContain("inset");
+}
+
+function expectCellPresentationStable(
+  initial: CellPresentationSnapshot,
+  next: CellPresentationSnapshot
+): void {
+  const numericKeys: Array<
+    keyof Pick<
+      CellPresentationSnapshot,
+      | "cellHeight"
+      | "cellWidth"
+      | "contentLeft"
+      | "contentTop"
+      | "contentWidth"
+      | "contentHeight"
+      | "textLeft"
+      | "textCenterY"
+      | "rowHeight"
+      | "nextRowOffset"
+      | "neighborOffset"
+      | "neighborWidth"
+    >
+  > = [
+    "cellHeight",
+    "cellWidth",
+    "contentLeft",
+    "contentTop",
+    "contentWidth",
+    "contentHeight",
+    "textLeft",
+    "textCenterY",
+    "rowHeight",
+    "nextRowOffset",
+    "neighborOffset",
+    "neighborWidth",
+  ];
+  for (const key of numericKeys) {
+    expect(Math.abs(next[key] - initial[key])).toBeLessThanOrEqual(0.5);
+  }
+  expect({
+    fontFamily: next.fontFamily,
+    fontSize: next.fontSize,
+    fontWeight: next.fontWeight,
+    lineHeight: next.lineHeight,
+    color: next.color,
+    textAlign: next.textAlign,
+  }).toEqual({
+    fontFamily: initial.fontFamily,
+    fontSize: initial.fontSize,
+    fontWeight: initial.fontWeight,
+    lineHeight: initial.lineHeight,
+    color: initial.color,
+    textAlign: initial.textAlign,
+  });
+}
+
+async function verifySeamlessEditor(
+  page: Page,
+  scenario: "editing-default" | "editing-custom"
+): Promise<void> {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  const { grid } = await openScenario(page, scenario);
+  const nameCell = cell(grid, "row-1", "name");
+  await nameCell.scrollIntoViewIfNeeded();
+  const display = await readCellPresentation(nameCell);
+
+  await nameCell.dblclick({ delay: 0 });
+  const editor =
+    scenario === "editing-custom"
+      ? nameCell.getByTestId("compat-custom-editor")
+      : nameCell.getByRole("textbox");
+  await expect(editor).toBeFocused();
+  await expect(editor).toHaveValue("Ada Lovelace");
+  await expect(nameCell).toHaveAttribute("data-editor-surface", "seamless");
+  expectSeamlessEditorGeometry(display, await readEditorPresentation(editor));
+
+  await editor.fill("Seamless editing draft");
+  await expect(editor).toBeFocused();
+  await expect(editor).toHaveValue("Seamless editing draft");
+  expectSeamlessEditorGeometry(display, await readEditorPresentation(editor));
+
+  await editor.press("Escape");
+  await expect(nameCell.getByRole("textbox")).toHaveCount(0);
+  await expect(nameCell).not.toHaveAttribute("data-editor-surface", "seamless");
+  expectCellPresentationStable(display, await readCellPresentation(nameCell));
+  expect(pageErrors).toEqual([]);
 }
 
 async function moveColumnBy(
@@ -214,6 +611,7 @@ test.describe("Inovua Community parity", () => {
 
     expect(tall.domHeight ?? 0).toBeGreaterThanOrEqual(104);
     expect(short.domHeight ?? 0).toBeGreaterThanOrEqual(52);
+    expect(tall.virtualStart).toBe(0);
     expect(
       Math.abs((tall.virtualHeight ?? 0) - (tall.domHeight ?? 0))
     ).toBeLessThanOrEqual(2);
@@ -225,12 +623,93 @@ test.describe("Inovua Community parity", () => {
     ).toBeLessThanOrEqual(2);
   });
 
+  test("keeps a natural virtual row measured while its tall cell is edited", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "natural-height");
+    await page.addStyleTag({
+      content: "*, *::before, *::after { box-sizing: content-box !important; }",
+    });
+    const tallRow = row(grid, "natural-tall");
+    const nextRow = row(grid, "natural-short");
+    const tallCell = cell(grid, "natural-tall", "contentHeight");
+
+    await expect(tallRow).toBeVisible();
+    await expect
+      .poll(() =>
+        tallCell.evaluate((element) => getComputedStyle(element).boxSizing)
+      )
+      .toBe("border-box");
+    await scope.getByTestId("capture-natural-height").click();
+    await expect
+      .poll(async () => {
+        const measurement = await readJson<NaturalMeasurement>(
+          scope.getByTestId("natural-tall-measurement")
+        );
+        return measurement.domHeight;
+      })
+      .not.toBeNull();
+
+    const before = await readJson<NaturalMeasurement>(
+      scope.getByTestId("natural-tall-measurement")
+    );
+    const beforeGeometry = await Promise.all([
+      readHeight(tallRow),
+      tallRow.evaluate((element) => element.getBoundingClientRect().top),
+      nextRow.evaluate((element) => element.getBoundingClientRect().top),
+    ]);
+
+    await tallCell.dblclick({ delay: 0 });
+    const editor = tallCell.getByRole("textbox");
+    await expect(editor).toBeFocused();
+    await expect(editor).toHaveValue("104");
+    await page.waitForTimeout(100);
+
+    const during = await readJson<NaturalMeasurement>(
+      scope.getByTestId("natural-tall-measurement")
+    );
+    const duringGeometry = await Promise.all([
+      readHeight(tallRow),
+      tallRow.evaluate((element) => element.getBoundingClientRect().top),
+      nextRow.evaluate((element) => element.getBoundingClientRect().top),
+    ]);
+
+    for (const [current, initial] of [
+      [during.domHeight, before.domHeight],
+      [during.virtualHeight, before.virtualHeight],
+      [during.virtualStart, before.virtualStart],
+      [during.nextVirtualStart, before.nextVirtualStart],
+    ] as const) {
+      expect(current).not.toBeNull();
+      expect(initial).not.toBeNull();
+      expect(Math.abs((current ?? 0) - (initial ?? 0))).toBeLessThanOrEqual(2);
+    }
+    duringGeometry.forEach((current, index) => {
+      expect(Math.abs(current - beforeGeometry[index]!)).toBeLessThanOrEqual(2);
+    });
+
+    await editor.press("Escape");
+    await expect(editor).toHaveCount(0);
+    await page.waitForTimeout(100);
+
+    const after = await readJson<NaturalMeasurement>(
+      scope.getByTestId("natural-tall-measurement")
+    );
+    expect(
+      Math.abs((after.domHeight ?? 0) - (before.domHeight ?? 0))
+    ).toBeLessThanOrEqual(2);
+    expect(
+      Math.abs((after.virtualHeight ?? 0) - (before.virtualHeight ?? 0))
+    ).toBeLessThanOrEqual(2);
+  });
+
   test("smooth-scrolls natural rows using measured virtual offsets", async ({
     page,
   }) => {
     const { scope, grid } = await openScenario(page, "natural-height");
     await expect(row(grid, "natural-tall")).toBeVisible();
     const viewport = grid.locator('[data-slot="scroll-area-viewport"]');
+    const headerViewport = grid.locator('[data-slot="grid-header-viewport"]');
 
     // Ensure the first row's 104px DOM height has replaced the 52px estimate
     // before asking for an offset beyond it.
@@ -255,42 +734,44 @@ test.describe("Inovua Community parity", () => {
     );
     expect(measuredTallRow.virtualHeight ?? 0).toBeGreaterThanOrEqual(104);
 
-    await viewport.evaluate((element) => {
-      const scrollElement = element as HTMLElement;
-      const originalScrollTo = scrollElement.scrollTo.bind(scrollElement);
-
-      scrollElement.scrollTo = ((
-        optionsOrX?: ScrollToOptions | number,
-        y?: number
-      ) => {
-        scrollElement.dataset.testScrollBehavior =
-          typeof optionsOrX === "object" && optionsOrX !== null
-            ? String(optionsOrX.behavior ?? "auto")
-            : "coordinates";
-        if (typeof optionsOrX === "number") {
-          originalScrollTo(optionsOrX, y ?? 0);
-        } else {
-          originalScrollTo(optionsOrX);
-        }
-      }) as typeof scrollElement.scrollTo;
-    });
     await scope.getByTestId("smooth-scroll-natural").click();
-    await expect(viewport).toHaveAttribute(
-      "data-test-scroll-behavior",
-      "smooth"
-    );
+    const reportOutput = scope.getByTestId("natural-smooth-scroll-report");
+    await expect
+      .poll(async () => {
+        const report = await readJson<SmoothScrollReport>(reportOutput);
+        return report.completed;
+      })
+      .not.toBeNull();
+
+    const report = await readJson<SmoothScrollReport>(reportOutput);
+    expect(report.target ?? 0).toBeGreaterThan(0);
+    expect(report.completed).toBe(report.target);
+    await expect
+      .poll(async () => {
+        const scrollTop = await viewport.evaluate(
+          (element) => (element as HTMLElement).scrollTop
+        );
+        return Math.abs(scrollTop - (report.target ?? 0));
+      })
+      .toBeLessThanOrEqual(2);
 
     const targetRow = row(grid, "natural-11");
     await expect(targetRow).toBeVisible();
     await expect
       .poll(async () => {
-        const [targetBox, viewportBox] = await Promise.all([
+        const [targetBox, headerBox, viewportBox] = await Promise.all([
           targetRow.boundingBox(),
+          headerViewport.boundingBox(),
           viewport.boundingBox(),
         ]);
-        if (!targetBox || !viewportBox) return Number.POSITIVE_INFINITY;
+        if (!targetBox || !headerBox || !viewportBox) {
+          return Number.POSITIVE_INFINITY;
+        }
 
-        return Math.abs(targetBox.y - viewportBox.y);
+        expect(headerBox.height).toBeGreaterThan(0);
+        expect(headerBox.y).toBeCloseTo(viewportBox.y, 0);
+
+        return Math.abs(targetBox.y - (headerBox.y + headerBox.height));
       })
       .toBeLessThanOrEqual(3);
   });
@@ -353,9 +834,61 @@ test.describe("Inovua Community parity", () => {
   test("remeasures natural virtual rows when a controlled column width changes", async ({
     page,
   }) => {
+    const runtimeErrors: string[] = [];
+    page.on("pageerror", (error) => runtimeErrors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") runtimeErrors.push(message.text());
+    });
+    page.on("crash", () => runtimeErrors.push("Renderer process crashed"));
+
+    await page.addInitScript(() => {
+      let prototype: object | null = HTMLElement.prototype;
+      let descriptor: PropertyDescriptor | undefined;
+      while (prototype && !descriptor) {
+        descriptor = Object.getOwnPropertyDescriptor(prototype, "offsetHeight");
+        if (!descriptor) prototype = Object.getPrototypeOf(prototype);
+      }
+      const originalGet = descriptor?.get;
+      if (!prototype || !descriptor || !originalGet) return;
+
+      const audit = { naturalRowHeightReads: 0 };
+      Object.defineProperty(window, "__tdgNaturalResizeAudit", {
+        configurable: false,
+        value: audit,
+      });
+      Object.defineProperty(prototype, "offsetHeight", {
+        configurable: descriptor.configurable,
+        enumerable: descriptor.enumerable,
+        get() {
+          if (
+            this instanceof HTMLElement &&
+            this.matches(
+              '[data-slot="grid-row"][data-row-id^="resize-natural-"]'
+            )
+          ) {
+            audit.naturalRowHeightReads += 1;
+          }
+          return originalGet.call(this);
+        },
+      });
+    });
+
     const { scope, grid } = await openScenario(page, "natural-resize");
     const firstRow = row(grid, "resize-natural-1");
+    const descriptionHeader = header(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
     await expect(firstRow).toBeVisible();
+    await expect(resizer).toBeVisible();
+
+    const resizerUx = await resizer.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        width: element.getBoundingClientRect().width,
+        cursor: style.cursor,
+      };
+    });
+    expect(resizerUx.width).toBeGreaterThanOrEqual(24);
+    expect(resizerUx.cursor).toBe("col-resize");
 
     await scope.getByTestId("capture-natural-resize").click();
     await expect
@@ -369,25 +902,106 @@ test.describe("Inovua Community parity", () => {
     const before = await readJson<NaturalMeasurement>(
       scope.getByTestId("natural-resize-measurement")
     );
+    const initialHeaderWidth = await readWidth(descriptionHeader);
+    const resizerBox = await resizer.boundingBox();
+    expect(resizerBox).not.toBeNull();
+    const startX = (resizerBox?.x ?? 0) + (resizerBox?.width ?? 0) / 2;
+    const startY = (resizerBox?.y ?? 0) + (resizerBox?.height ?? 0) / 2;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await expect(grid).toHaveAttribute("data-column-resizing", "true");
+    const resizeProxy = grid.locator(".InovuaReactDataGrid__resize-proxy");
+    await expect(resizeProxy).toBeVisible();
+    const initialProxyBox = await resizeProxy.boundingBox();
+    expect(initialProxyBox).not.toBeNull();
 
-    await scope.getByTestId("widen-natural-column").click();
-    await expect(scope.getByTestId("natural-resize-width")).toHaveText("360");
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        })
+    );
+    const initialHeightReads = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __tdgNaturalResizeAudit?: { naturalRowHeightReads: number };
+          }
+        ).__tdgNaturalResizeAudit?.naturalRowHeightReads ?? 0
+    );
+    expect(initialHeightReads).toBeGreaterThan(0);
+    await page.evaluate(() => {
+      (
+        window as typeof window & {
+          __tdgNaturalResizeAudit?: { naturalRowHeightReads: number };
+        }
+      ).__tdgNaturalResizeAudit!.naturalRowHeightReads = 0;
+    });
+
+    await page.mouse.move(startX + 180, startY, { steps: 60 });
     await expect
-      .poll(() => readWidth(header(grid, "description")))
-      .toBeGreaterThan(340);
+      .poll(async () => (await resizeProxy.boundingBox())?.x ?? 0)
+      .toBeGreaterThan((initialProxyBox?.x ?? 0) + 150);
+
+    const heightReadsDuringMoves = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __tdgNaturalResizeAudit?: { naturalRowHeightReads: number };
+          }
+        ).__tdgNaturalResizeAudit?.naturalRowHeightReads ?? 0
+    );
+    const mountedNaturalRows = await grid
+      .locator('[data-slot="grid-row"][data-row-id^="resize-natural-"]')
+      .count();
+    const proxyMotionStyle = await resizeProxy.evaluate((element) => ({
+      left: (element as HTMLElement).style.left,
+      transform: (element as HTMLElement).style.transform,
+    }));
+
+    expect(proxyMotionStyle.left).toBe("");
+    expect(proxyMotionStyle.transform).toContain("translate3d");
+    expect(heightReadsDuringMoves).toBeLessThanOrEqual(
+      Math.max(2, mountedNaturalRows * 2)
+    );
+    expect(await readWidth(descriptionHeader)).toBe(initialHeaderWidth);
+    await expect(scope.getByTestId("natural-resize-width")).toHaveText("140");
+    await expect(scope.getByTestId("natural-resize-event-count")).toHaveText(
+      "0"
+    );
+
+    await page.mouse.up();
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect(resizeProxy).toHaveCount(0);
+    await expect(scope.getByTestId("natural-resize-event-count")).toHaveText(
+      "1"
+    );
+    await expect(scope.getByTestId("natural-resize-width")).toHaveText("320");
+    await expect.poll(() => readWidth(descriptionHeader)).toBeGreaterThan(300);
     await expect
       .poll(() => readHeight(firstRow))
       .toBeLessThan((before.domHeight ?? 0) - 20);
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          cursor: document.body.style.cursor,
+          userSelect: document.body.style.userSelect,
+        }))
+      )
+      .toEqual({ cursor: "", userSelect: "" });
 
-    await scope.getByTestId("capture-natural-resize").click();
     await expect
       .poll(async () => {
+        await scope.getByTestId("capture-natural-resize").click();
         const value = await readJson<NaturalMeasurement>(
           scope.getByTestId("natural-resize-measurement")
         );
-        return value.domHeight;
+        return Math.abs(
+          (value.virtualHeight ?? Number.POSITIVE_INFINITY) -
+            (value.domHeight ?? 0)
+        );
       })
-      .toBeLessThan((before.domHeight ?? 0) - 20);
+      .toBeLessThanOrEqual(2);
     const after = await readJson<NaturalMeasurement>(
       scope.getByTestId("natural-resize-measurement")
     );
@@ -404,12 +1018,93 @@ test.describe("Inovua Community parity", () => {
     expect(
       Math.abs((after.nextVirtualStart ?? 0) - (after.virtualEnd ?? 0))
     ).toBeLessThanOrEqual(2);
+
+    await page.evaluate(() => {
+      (
+        window as typeof window & {
+          __tdgNaturalResizeAudit?: { naturalRowHeightReads: number };
+        }
+      ).__tdgNaturalResizeAudit!.naturalRowHeightReads = 0;
+    });
+    await scope.getByTestId("capture-natural-resize").click();
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        })
+    );
+    const readsAfterUnrelatedRender = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __tdgNaturalResizeAudit?: { naturalRowHeightReads: number };
+          }
+        ).__tdgNaturalResizeAudit?.naturalRowHeightReads ?? 0
+    );
+    expect(readsAfterUnrelatedRender).toBeLessThanOrEqual(1);
+
+    const settledReads = readsAfterUnrelatedRender;
+    await page.waitForTimeout(250);
+    const plateauReads = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __tdgNaturalResizeAudit?: { naturalRowHeightReads: number };
+          }
+        ).__tdgNaturalResizeAudit?.naturalRowHeightReads ?? 0
+    );
+    expect(plateauReads - settledReads).toBeLessThanOrEqual(1);
+
+    await resizer.focus();
+    await resizer.press("ArrowRight");
+    await expect(scope.getByTestId("natural-resize-event-count")).toHaveText(
+      "2"
+    );
+    await expect(scope.getByTestId("natural-resize-width")).toHaveText("330");
+
+    await scope.getByTestId("widen-natural-column").click();
+    await expect(scope.getByTestId("natural-resize-width")).toHaveText("360");
+    await expect(scope.getByTestId("capture-natural-resize")).toBeEnabled();
+    expect(runtimeErrors).toEqual([]);
   });
 
   test("emits the documented onColumnResize payload", async ({ page }) => {
     const { scope, grid } = await openScenario(page, "resize-callback");
+    const frame = scope.getByTestId("parity-grid-frame");
     const descriptionHeader = header(grid, "description");
     const initialWidth = await readWidth(descriptionHeader);
+
+    const initialGeometry = await frame.evaluate((element) => {
+      const viewport = element.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-viewport"]'
+      );
+      const headerTable =
+        element.querySelector<HTMLElement>(".tdg-header-table");
+      const bodyTable = element.querySelector<HTMLElement>(".tdg-body-table");
+
+      if (!viewport || !headerTable || !bodyTable) return null;
+
+      const frameRect = element.getBoundingClientRect();
+      const viewportRect = viewport.getBoundingClientRect();
+      const headerRect = headerTable.getBoundingClientRect();
+      const bodyRect = bodyTable.getBoundingClientRect();
+
+      return {
+        frameHeight: Math.round(frameRect.height),
+        frameWidth: Math.round(frameRect.width),
+        hasHorizontalOverflow: viewport.scrollWidth > viewport.clientWidth,
+        headerReachesViewport: headerRect.right >= viewportRect.right - 1,
+        bodyReachesViewport: bodyRect.right >= viewportRect.right - 1,
+      };
+    });
+
+    expect(initialGeometry).toEqual({
+      frameHeight: 280,
+      frameWidth: 560,
+      hasHorizontalOverflow: true,
+      headerReachesViewport: true,
+      bodyReachesViewport: true,
+    });
 
     await moveColumnBy(page, grid, "description", 100);
     await expect(scope.getByTestId("column-resize-event-count")).toHaveText(
@@ -558,6 +1253,132 @@ test.describe("Inovua Community parity", () => {
     await expect(idCell.getByRole("textbox")).toHaveCount(0);
   });
 
+  test("keeps the built-in editor visually seamless with the cell", async ({
+    page,
+  }) => {
+    await verifySeamlessEditor(page, "editing-default");
+  });
+
+  test("keeps custom editors visually seamless when they use the cell editor marker", async ({
+    page,
+  }) => {
+    await verifySeamlessEditor(page, "editing-custom");
+  });
+
+  test("tracks a custom editor marker without changing the editor DOM parent", async ({
+    page,
+  }) => {
+    const { grid } = await openScenario(page, "editing-custom");
+    const nameCell = cell(grid, "row-1", "name");
+
+    await nameCell.dblclick({ delay: 0 });
+    const editor = nameCell.getByRole("textbox");
+    await expect(editor).toBeFocused();
+    await expect(nameCell).toHaveAttribute("data-editor-surface", "seamless");
+    expect(
+      await editor.evaluate((input) =>
+        input.parentElement?.classList.contains("tdg-cell-content")
+      )
+    ).toBe(true);
+
+    await editor.evaluate((input) => {
+      input.classList.remove(
+        "tdg-cell-editor",
+        "InovuaReactDataGrid__cell__editor",
+        "InovuaReactDataGrid__cell__editor--text"
+      );
+      input.removeAttribute("data-slot");
+    });
+    await expect(nameCell).not.toHaveAttribute(
+      "data-editor-surface",
+      "seamless"
+    );
+
+    await editor.evaluate((input) => {
+      input.classList.add("tdg-cell-editor");
+      input.setAttribute("data-slot", "cell-editor");
+    });
+    await expect(nameCell).toHaveAttribute("data-editor-surface", "seamless");
+
+    await editor.press("Escape");
+    await expect(nameCell).not.toHaveAttribute(
+      "data-editor-surface",
+      "seamless"
+    );
+  });
+
+  test("preserves a falsy custom renderEditor result", async ({ page }) => {
+    await page.goto(
+      "/compat/inovua-parity?scenario=editing-custom&editorOutput=zero"
+    );
+    const scope = page.getByTestId("inovua-parity-scenario");
+    await expect(scope).toHaveAttribute("data-scenario", "editing-custom");
+    const grid = scope.locator(".InovuaReactDataGrid.tdg-root").first();
+    const nameCell = cell(grid, "row-1", "name");
+
+    await nameCell.dblclick({ delay: 0 });
+    await expect(nameCell).toHaveAttribute("data-editing", "true");
+    await expect(nameCell.locator(".tdg-cell-content")).toHaveText("0");
+    await expect(nameCell.getByText("Ada Lovelace")).toHaveCount(0);
+    await expect(nameCell).not.toHaveAttribute(
+      "data-editor-surface",
+      "seamless"
+    );
+  });
+
+  test("keeps an unmarked custom editor in the ordinary padded cell layout", async ({
+    page,
+  }) => {
+    const { grid } = await openScenario(page, "editing-navigation");
+    const nameCell = cell(grid, "row-1", "name");
+
+    await nameCell.dblclick({ delay: 0 });
+    const editor = nameCell.getByTestId("navigation-editor");
+    await expect(editor).toBeFocused();
+    await expect(nameCell).not.toHaveAttribute(
+      "data-editor-surface",
+      "seamless"
+    );
+
+    const geometry = await editor.evaluate((element) => {
+      const input = element as HTMLInputElement;
+      const content = input.closest<HTMLElement>(".tdg-cell-content");
+      const targetCell = input.closest<HTMLElement>('[data-column-id="name"]');
+      if (!content || !targetCell) {
+        throw new Error("Expected unmarked editor cell geometry");
+      }
+
+      const cellRect = targetCell.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const inputRect = input.getBoundingClientRect();
+      const inputStyle = getComputedStyle(input);
+
+      return {
+        cellHeight: cellRect.height,
+        contentLeft: contentRect.left - cellRect.left,
+        contentRight: cellRect.right - contentRect.right,
+        inputLeft: inputRect.left - cellRect.left,
+        inputHeight: inputRect.height,
+        borderWidth: Number.parseFloat(inputStyle.borderTopWidth) || 0,
+        borderRadius: Number.parseFloat(inputStyle.borderTopLeftRadius) || 0,
+        cellBoxShadow: getComputedStyle(targetCell).boxShadow,
+        markedEditorCount: content.querySelectorAll(
+          '.tdg-cell-editor[data-slot="cell-editor"]'
+        ).length,
+      };
+    });
+
+    expect(geometry.cellHeight).toBe(64);
+    expect(geometry.contentLeft).toBe(8);
+    expect(geometry.contentRight).toBeGreaterThanOrEqual(8);
+    expect(geometry.inputLeft).toBe(8);
+    expect(geometry.inputHeight).toBe(32);
+    expect(geometry.borderWidth).toBeGreaterThan(0);
+    expect(geometry.borderRadius).toBeGreaterThan(0);
+    expect(geometry.cellBoxShadow).toBe("none");
+    expect(geometry.markedEditorCount).toBe(0);
+  });
+
   test("passes the Inovua custom editor contract and renderEditor cell arguments", async ({
     page,
   }) => {
@@ -602,6 +1423,177 @@ test.describe("Inovua Community parity", () => {
     await expect(scope.getByTestId("custom-editor-bubbles")).toHaveText(
       String(bubblesBefore)
     );
+  });
+
+  test("rapidly replaces an active custom editor without duplicating its session", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    const consoleErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+
+    const { grid } = await openScenario(page, "editing-custom");
+    const firstName = cell(grid, "row-1", "name");
+    const secondName = cell(grid, "row-2", "name");
+
+    await firstName.dblclick({ delay: 0 });
+    const firstEditor = firstName.getByTestId("compat-custom-editor");
+    await firstEditor.fill("Row 1 draft");
+    const bubblesBeforeEditorDoubleClick = Number(
+      (await page.getByTestId("custom-editor-bubbles").textContent())?.trim()
+    );
+    await firstEditor.dblclick({ delay: 0 });
+
+    await expect(grid.getByTestId("compat-custom-editor")).toHaveCount(1);
+    await expect(firstName).toHaveAttribute("data-editing", "true");
+    await expect(firstEditor).toBeFocused();
+    await expect(firstEditor).toHaveValue("Row 1 draft");
+    await expect(page.getByTestId("custom-editor-bubbles")).toHaveText(
+      String(bubblesBeforeEditorDoubleClick)
+    );
+
+    // A synthetic double-click keeps focus on the first editor, isolating the
+    // grid's cross-target replacement behavior from editor-specific blur
+    // completion.
+    await secondName.dispatchEvent("dblclick");
+
+    const secondEditor = secondName.getByTestId("compat-custom-editor");
+    await expect(grid.getByTestId("compat-custom-editor")).toHaveCount(1);
+    await expect(firstName).toHaveAttribute("data-editing", "false");
+    await expect(firstEditor).toHaveCount(0);
+    await expect(secondName).toHaveAttribute("data-editing", "true");
+    await expect(secondEditor).toBeFocused();
+    await expect(secondEditor).toHaveValue("Grace Hopper");
+
+    const events = await readJson<EditEvent[]>(
+      page.getByTestId("custom-editor-events")
+    );
+    expect(
+      events.map(({ type, rowId, columnId, value }) => ({
+        type,
+        rowId,
+        columnId,
+        value,
+      }))
+    ).toEqual([
+      {
+        type: "start",
+        rowId: "row-1",
+        columnId: "name",
+        value: "Ada Lovelace",
+      },
+      {
+        type: "value",
+        rowId: "row-1",
+        columnId: "name",
+        value: "Row 1 draft",
+      },
+      {
+        type: "start",
+        rowId: "row-2",
+        columnId: "name",
+        value: "Grace Hopper",
+      },
+    ]);
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("completes a blur-aware custom editor once and immediately opens the next row", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+    const { scope, grid } = await openScenario(page, "editing-custom");
+    const firstName = cell(grid, "row-1", "name");
+    const secondName = cell(grid, "row-2", "name");
+    const outsideTarget = scope.getByTestId("custom-editor-outside-target");
+
+    await firstName.dblclick({ delay: 0 });
+    await firstName
+      .getByTestId("compat-custom-editor")
+      .fill("Outside-click draft");
+    await outsideTarget.click();
+
+    await expect(grid.getByTestId("compat-custom-editor")).toHaveCount(0);
+    await expect(grid.locator('[data-slot="grid-surface"]')).toBeFocused();
+
+    let events = await readJson<EditEvent[]>(
+      scope.getByTestId("custom-editor-events")
+    );
+    expect(events.map(({ type, rowId }) => ({ type, rowId }))).toEqual([
+      { type: "start", rowId: "row-1" },
+      { type: "value", rowId: "row-1" },
+      { type: "stop", rowId: "row-1" },
+      { type: "complete", rowId: "row-1" },
+    ]);
+
+    await firstName.dblclick({ delay: 0 });
+    await firstName
+      .getByTestId("compat-custom-editor")
+      .fill("Fast-switch draft");
+    await secondName.dblclick({ delay: 0 });
+
+    const secondEditor = secondName.getByTestId("compat-custom-editor");
+    await expect(grid.getByTestId("compat-custom-editor")).toHaveCount(1);
+    await expect(firstName).toHaveAttribute("data-editing", "false");
+    await expect(secondName).toHaveAttribute("data-editing", "true");
+    await expect(secondEditor).toBeFocused();
+    await expect(secondEditor).toHaveValue("Grace Hopper");
+
+    events = await readJson<EditEvent[]>(
+      scope.getByTestId("custom-editor-events")
+    );
+    expect(events.slice(4).map(({ type, rowId }) => ({ type, rowId }))).toEqual(
+      [
+        { type: "start", rowId: "row-1" },
+        { type: "value", rowId: "row-1" },
+        { type: "stop", rowId: "row-1" },
+        { type: "complete", rowId: "row-1" },
+        { type: "start", rowId: "row-2" },
+      ]
+    );
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("keeps one focused editor through rapid alternating activation", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+    const { scope, grid } = await openScenario(page, "editing-custom");
+    const firstName = cell(grid, "row-1", "name");
+    const secondName = cell(grid, "row-2", "name");
+    const targets = [firstName, secondName] as const;
+
+    for (let index = 0; index < 10; index += 1) {
+      const target = targets[index % targets.length];
+      await target.dispatchEvent("dblclick");
+      await expect(grid.getByTestId("compat-custom-editor")).toHaveCount(1);
+      await expect(target.getByTestId("compat-custom-editor")).toBeFocused();
+    }
+
+    const starts = (
+      await readJson<EditEvent[]>(scope.getByTestId("custom-editor-events"))
+    ).filter((event) => event.type === "start");
+    expect(starts).toHaveLength(10);
+    expect(starts.map((event) => event.rowId)).toEqual([
+      "row-1",
+      "row-2",
+      "row-1",
+      "row-2",
+      "row-1",
+      "row-2",
+      "row-1",
+      "row-2",
+      "row-1",
+      "row-2",
+    ]);
+
+    expect(pageErrors).toEqual([]);
   });
 
   test("invalidates stale async editability and contains falsy and rejected checks", async ({
@@ -1401,6 +2393,62 @@ test.describe("Inovua Community parity", () => {
     page,
   }) => {
     const { scope, grid } = await openScenario(page, "flex");
+    const initialGeometry = await grid.evaluate((element) => {
+      const viewport = element.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-viewport"]'
+      );
+      const headerTable =
+        element.querySelector<HTMLElement>(".tdg-header-table");
+      const bodyTable = element.querySelector<HTMLElement>(".tdg-body-table");
+      const trailingHandle = element.querySelector<HTMLElement>(
+        '[data-column-id="two"] [data-slot="column-resizer"]'
+      );
+      if (!viewport || !headerTable || !bodyTable || !trailingHandle) {
+        return null;
+      }
+
+      const viewportRect = viewport.getBoundingClientRect();
+      const headerRect = headerTable.getBoundingClientRect();
+      const bodyRect = bodyTable.getBoundingClientRect();
+      const handleRect = trailingHandle.getBoundingClientRect();
+      const actualOverflow = viewport.scrollWidth - viewport.clientWidth;
+      const paintedOverflow = Math.max(
+        0,
+        bodyRect.width - viewport.clientWidth
+      );
+
+      return {
+        actualOverflow,
+        paintedOverflow,
+        headerBodyWidthDelta: Math.abs(headerRect.width - bodyRect.width),
+        handleWidth: handleRect.width,
+        handleRightDelta: Math.abs(handleRect.right - viewportRect.right),
+      };
+    });
+
+    expect(initialGeometry).not.toBeNull();
+    expect(initialGeometry?.actualOverflow ?? Infinity).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(
+        (initialGeometry?.actualOverflow ?? Infinity) -
+          (initialGeometry?.paintedOverflow ?? 0)
+      )
+    ).toBeLessThanOrEqual(1);
+    expect(
+      initialGeometry?.headerBodyWidthDelta ?? Infinity
+    ).toBeLessThanOrEqual(1);
+    expect(initialGeometry?.handleWidth ?? 0).toBeGreaterThanOrEqual(24);
+    expect(initialGeometry?.handleRightDelta ?? Infinity).toBeLessThanOrEqual(
+      1
+    );
+
+    await grid.hover();
+    await expect(
+      grid.locator(
+        '[data-slot="scroll-area-scrollbar"][data-orientation="horizontal"]'
+      )
+    ).toBeHidden();
+
     const [fixedWidth, flexOneWidth, flexTwoWidth] = await Promise.all([
       readWidth(header(grid, "fixed")),
       readWidth(header(grid, "one")),
@@ -1409,6 +2457,11 @@ test.describe("Inovua Community parity", () => {
 
     expect.soft(Math.abs(fixedWidth - 120)).toBeLessThanOrEqual(3);
     expect(Math.abs(flexTwoWidth / flexOneWidth - 2)).toBeLessThanOrEqual(0.12);
+
+    const edgeCases = scope.getByTestId("flex-edge-cases");
+    await expect(edgeCases).not.toHaveAttribute("open", "");
+    await edgeCases.locator("summary").click();
+    await expect(edgeCases).toHaveAttribute("open", "");
 
     const constrainedGrid = scope
       .getByTestId("flex-constrained")
@@ -1420,13 +2473,75 @@ test.describe("Inovua Community parity", () => {
     expect(Math.abs(defaultMinWidth - 40)).toBeLessThanOrEqual(2);
     expect(zeroMinWidth).toBeGreaterThan(0);
     expect(zeroMinWidth).toBeLessThan(35);
+    expect(
+      await constrainedGrid
+        .locator('[data-slot="scroll-area-viewport"]')
+        .evaluate((element) => element.scrollWidth - element.clientWidth)
+    ).toBeLessThanOrEqual(1);
 
-    const unboundedGrid = scope
-      .getByTestId("flex-unbounded")
-      .locator(".InovuaReactDataGrid.tdg-root");
+    const unbounded = scope.getByTestId("flex-unbounded");
+    const unboundedGrid = unbounded.locator(".InovuaReactDataGrid.tdg-root");
     expect(await readWidth(header(unboundedGrid, "wide"))).toBeGreaterThan(
       10_000
     );
+    expect(
+      await unboundedGrid
+        .locator('[data-slot="scroll-area-viewport"]')
+        .evaluate((element) => element.scrollWidth - element.clientWidth)
+    ).toBeLessThanOrEqual(1);
+    expect(
+      await unbounded.evaluate(
+        (element) => element.scrollWidth - element.clientWidth
+      )
+    ).toBeGreaterThan(8_000);
+    expect(
+      await scope.evaluate(
+        (element) => element.scrollWidth - element.clientWidth
+      )
+    ).toBeLessThanOrEqual(1);
+  });
+
+  test("keeps the public flex checkpoint free of phantom and diagnostic scrollbars", async ({
+    page,
+  }) => {
+    await page.goto("/examples/inovua-parity?scenario=flex");
+    const scope = page.getByTestId("inovua-parity-scenario");
+    await expect(scope).toHaveAttribute("data-scenario", "flex");
+    const edgeCases = scope.getByTestId("flex-edge-cases");
+    await expect(edgeCases).not.toHaveAttribute("open", "");
+    await expect(scope.locator(".InovuaReactDataGrid.tdg-root")).toHaveCount(1);
+
+    const grid = scope.locator(".InovuaReactDataGrid.tdg-root");
+    const viewport = grid.locator('[data-slot="scroll-area-viewport"]');
+    await expect
+      .poll(() =>
+        viewport.evaluate(
+          (element) => element.scrollWidth - element.clientWidth
+        )
+      )
+      .toBeLessThanOrEqual(1);
+
+    await grid.hover();
+    await expect(
+      grid.locator(
+        '[data-slot="scroll-area-scrollbar"][data-orientation="horizontal"]'
+      )
+    ).toBeHidden();
+
+    const pageOverflow = await page.evaluate(() => ({
+      document:
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+      scenario:
+        document.querySelector<HTMLElement>(
+          '[data-testid="inovua-parity-scenario"]'
+        )!.scrollWidth -
+        document.querySelector<HTMLElement>(
+          '[data-testid="inovua-parity-scenario"]'
+        )!.clientWidth,
+    }));
+    expect(pageOverflow.document).toBeLessThanOrEqual(1);
+    expect(pageOverflow.scenario).toBeLessThanOrEqual(1);
   });
 
   test("converts resized defaultFlex to width and keeps controlled flex authoritative", async ({
@@ -1437,6 +2552,9 @@ test.describe("Inovua Community parity", () => {
     const controlledFlexHeader = header(grid, "two");
     const defaultFlexBefore = await readWidth(defaultFlexHeader);
     const controlledFlexBefore = await readWidth(controlledFlexHeader);
+    const viewport = grid.locator('[data-slot="scroll-area-viewport"]');
+    const bodyTable = grid.locator(".tdg-body-table");
+    const tableWidthBefore = await readWidth(bodyTable);
 
     await dragColumnBy(page, grid, "one", 80);
     await expect
@@ -1461,6 +2579,69 @@ test.describe("Inovua Community parity", () => {
     expect(
       Math.abs((defaultFlexEvents[1]?.flex ?? 0) - controlledFlexBefore)
     ).toBeLessThanOrEqual(3);
+
+    const grownGeometry = await Promise.all([
+      viewport.evaluate((element) => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      })),
+      readWidth(bodyTable),
+    ]).then(([viewportSize, tableWidth]) => ({
+      actualOverflow: viewportSize.scrollWidth - viewportSize.clientWidth,
+      paintedOverflow: Math.max(0, tableWidth - viewportSize.clientWidth),
+      tableGrowth: tableWidth - tableWidthBefore,
+    }));
+    expect(Math.abs(grownGeometry.tableGrowth - 80)).toBeLessThanOrEqual(2);
+    expect(
+      Math.abs(grownGeometry.actualOverflow - grownGeometry.paintedOverflow)
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(grownGeometry.actualOverflow - grownGeometry.tableGrowth)
+    ).toBeLessThanOrEqual(1);
+
+    const scrollArea = grid.locator('[data-slot="scroll-area"]');
+    const horizontalScrollbar = grid.locator(
+      '[data-slot="scroll-area-scrollbar"][data-orientation="horizontal"]'
+    );
+    await scrollArea.hover({ position: { x: 24, y: 4 } });
+    await expect(horizontalScrollbar).toBeVisible();
+
+    await viewport.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth;
+    });
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        })
+    );
+    const trailingAlignment = await grid.evaluate((element) => {
+      const viewportElement = element.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-viewport"]'
+      );
+      const trailingHeader = element.querySelector<HTMLElement>(
+        '[data-slot="grid-header-cell"][data-column-id="two"]'
+      );
+      const trailingCell = element.querySelector<HTMLElement>(
+        '[data-slot="grid-row"][data-row-id="flex-row"] [data-column-id="two"]'
+      );
+      if (!viewportElement || !trailingHeader || !trailingCell) return null;
+
+      const viewportRect = viewportElement.getBoundingClientRect();
+      const headerRect = trailingHeader.getBoundingClientRect();
+      const cellRect = trailingCell.getBoundingClientRect();
+      return {
+        headerBodyRightDelta: Math.abs(headerRect.right - cellRect.right),
+        viewportRightDelta: Math.abs(viewportRect.right - cellRect.right),
+      };
+    });
+    expect(trailingAlignment).not.toBeNull();
+    expect(
+      trailingAlignment?.headerBodyRightDelta ?? Infinity
+    ).toBeLessThanOrEqual(1);
+    expect(
+      trailingAlignment?.viewportRightDelta ?? Infinity
+    ).toBeLessThanOrEqual(1);
 
     const controlledBeforeDrag = await readWidth(controlledFlexHeader);
     await grid

--- a/tests/playwright/inovua-pending-parity.spec.ts
+++ b/tests/playwright/inovua-pending-parity.spec.ts
@@ -880,7 +880,11 @@ test.describe("unsafe implemented-contract edges", () => {
     page,
   }) => {
     const { scope, grid } = await openPendingScenario(page, "zebra-imperative");
+    const firstRow = row(grid, "row-1");
+    const secondRow = row(grid, "row-2");
     await expect(grid).toHaveAttribute("data-show-zebra-rows", "true");
+    await expect(firstRow).toHaveClass(/tdg-row--odd/);
+    await expect(secondRow).toHaveClass(/tdg-row--even/);
 
     await scope.getByTestId("disable-zebra-imperatively").click();
 
@@ -890,6 +894,8 @@ test.describe("unsafe implemented-contract edges", () => {
     await expect(grid).toHaveAttribute("data-show-zebra-rows", "false", {
       timeout: RED_ASSERTION_TIMEOUT,
     });
+    await expect(firstRow).toHaveClass(/tdg-row--no-zebra/);
+    await expect(secondRow).toHaveClass(/tdg-row--no-zebra/);
   });
 });
 

--- a/tests/playwright/inovua-pending-parity.spec.ts
+++ b/tests/playwright/inovua-pending-parity.spec.ts
@@ -7,11 +7,10 @@ import {
 } from "@playwright/test";
 
 /**
- * Intentionally red compatibility contracts.
+ * Inovua compatibility regression contracts.
  *
  * These tests exercise only the-datagrid's local fixture. They use ordinary
- * assertions and must turn green one behavior at a time as the pending
- * Inovua contracts are implemented or the unsafe behavior is corrected.
+ * assertions and must remain green as the compatibility implementation evolves.
  */
 
 type PendingScenario =
@@ -99,7 +98,7 @@ type EditCoordinateEvent = {
   value: unknown;
 };
 
-const RED_ASSERTION_TIMEOUT = 1_000;
+const CONTRACT_ASSERTION_TIMEOUT = 1_000;
 const baseSelectionRowIds = ["row-1", "row-2", "row-3"] as const;
 
 async function openPendingScenario(page: Page, scenario: PendingScenario) {
@@ -109,7 +108,7 @@ async function openPendingScenario(page: Page, scenario: PendingScenario) {
   await expect(scope).toHaveAttribute("data-scenario", scenario);
   await expect(
     scope.getByRole("heading", {
-      name: `Pending Inovua parity: ${scenario}`,
+      name: `Inovua parity contract: ${scenario}`,
     })
   ).toBeVisible();
 
@@ -169,7 +168,7 @@ async function captureColumnState(
   return readJson<ColumnStateSnapshot>(scope.getByTestId("column-state"));
 }
 
-test.describe("pending Inovua filtering contracts", () => {
+test.describe("Inovua filtering contracts", () => {
   test("onColumnFilterValueChange precedes the aggregate callback for editor changes", async ({
     page,
   }) => {
@@ -290,7 +289,7 @@ test.describe("pending Inovua filtering contracts", () => {
   });
 });
 
-test.describe("pending Inovua selection contracts", () => {
+test.describe("Inovua selection contracts", () => {
   test("enableSelection=true enables uncontrolled single row selection without a checkbox or callback", async ({
     page,
   }) => {
@@ -431,7 +430,7 @@ test.describe("pending Inovua selection contracts", () => {
   });
 });
 
-test.describe("pending Inovua column-virtualization contracts", () => {
+test.describe("Inovua column-virtualization contracts", () => {
   test("uses the default threshold at 15 and leaves 14 visible columns unvirtualized", async ({
     page,
   }) => {
@@ -543,11 +542,13 @@ test.describe("pending Inovua column-virtualization contracts", () => {
     await scope.getByTestId("scroll-last-column").click();
     await expect
       .poll(() => viewport.evaluate((element) => element.scrollLeft), {
-        timeout: RED_ASSERTION_TIMEOUT,
+        timeout: CONTRACT_ASSERTION_TIMEOUT,
       })
       .toBeGreaterThan(0);
-    await expect(lastHeader).toBeVisible({ timeout: RED_ASSERTION_TIMEOUT });
-    await expect(lastCell).toBeVisible({ timeout: RED_ASSERTION_TIMEOUT });
+    await expect(lastHeader).toBeVisible({
+      timeout: CONTRACT_ASSERTION_TIMEOUT,
+    });
+    await expect(lastCell).toBeVisible({ timeout: CONTRACT_ASSERTION_TIMEOUT });
     expect.soft(await firstHeader.count()).toBe(0);
 
     const scrollGeometry = await viewport.evaluate((element) => ({
@@ -621,7 +622,7 @@ test.describe("pending Inovua column-virtualization contracts", () => {
   });
 });
 
-test.describe("pending Inovua emptyText contracts", () => {
+test.describe("Inovua emptyText contracts", () => {
   test("a literal emptyText overrides i18n.noRecords", async ({ page }) => {
     const { grid } = await openPendingScenario(page, "empty-literal");
     const literal = grid.getByText("Literal empty state", { exact: true });
@@ -820,7 +821,7 @@ test.describe("unsafe implemented-contract edges", () => {
           readJson<EditCoordinateEvent[]>(
             scope.getByTestId("editing-coordinate-events")
           ),
-        { timeout: RED_ASSERTION_TIMEOUT }
+        { timeout: CONTRACT_ASSERTION_TIMEOUT }
       )
       .toContainEqual({
         type: "complete",
@@ -864,7 +865,7 @@ test.describe("unsafe implemented-contract edges", () => {
           readJson<EditCoordinateEvent[]>(
             scope.getByTestId("editing-coordinate-events")
           ),
-        { timeout: RED_ASSERTION_TIMEOUT }
+        { timeout: CONTRACT_ASSERTION_TIMEOUT }
       )
       .toContainEqual({
         type: "complete",
@@ -889,10 +890,10 @@ test.describe("unsafe implemented-contract edges", () => {
     await scope.getByTestId("disable-zebra-imperatively").click();
 
     await expect(scope.getByTestId("zebra-setter-present")).toHaveText("true", {
-      timeout: RED_ASSERTION_TIMEOUT,
+      timeout: CONTRACT_ASSERTION_TIMEOUT,
     });
     await expect(grid).toHaveAttribute("data-show-zebra-rows", "false", {
-      timeout: RED_ASSERTION_TIMEOUT,
+      timeout: CONTRACT_ASSERTION_TIMEOUT,
     });
     await expect(firstRow).toHaveClass(/tdg-row--no-zebra/);
     await expect(secondRow).toHaveClass(/tdg-row--no-zebra/);
@@ -947,7 +948,7 @@ test.describe("unsafe touch-resize contract", () => {
 
     await expect(scope.getByTestId("column-resize-event-count")).toHaveText(
       "1",
-      { timeout: RED_ASSERTION_TIMEOUT }
+      { timeout: CONTRACT_ASSERTION_TIMEOUT }
     );
     const event = await readJson<{
       columnId: string;

--- a/tests/playwright/inovua-pending-parity.spec.ts
+++ b/tests/playwright/inovua-pending-parity.spec.ts
@@ -1,0 +1,964 @@
+import {
+  devices,
+  expect,
+  test,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+
+/**
+ * Intentionally red compatibility contracts.
+ *
+ * These tests exercise only the-datagrid's local fixture. They use ordinary
+ * assertions and must turn green one behavior at a time as the pending
+ * Inovua contracts are implemented or the unsafe behavior is corrected.
+ */
+
+type PendingScenario =
+  | "filter-callback"
+  | "selection-enable"
+  | "selection-derived"
+  | "selection-disable"
+  | "selection-disable-controlled"
+  | "selection-callback-only"
+  | "columns-default-15"
+  | "columns-default-14"
+  | "columns-threshold-at"
+  | "columns-threshold-below"
+  | "columns-force-on"
+  | "columns-force-off"
+  | "columns-function-height"
+  | "columns-natural-height"
+  | "columns-scroll"
+  | "empty-literal"
+  | "empty-key"
+  | "empty-node"
+  | "empty-function"
+  | "empty-null"
+  | "empty-false"
+  | "empty-string"
+  | "empty-loading"
+  | "empty-filtered"
+  | "empty-remote"
+  | "empty-mobile"
+  | "row-height-authority"
+  | "editing-column-coordinate"
+  | "editing-row-coordinate"
+  | "zebra-imperative";
+
+type FilterLogEvent = {
+  kind: "column" | "aggregate";
+  columnId?: string;
+  columnIndex?: number;
+  filterValue:
+    | Array<{
+        name: string;
+        type: string;
+        operator: string;
+        value: unknown;
+        active?: boolean | null;
+      }>
+    | {
+        name: string;
+        type: string;
+        operator: string;
+        value: unknown;
+        active?: boolean | null;
+      }
+    | null;
+  cellPropsPresent?: boolean;
+  cellPropsId?: string | null;
+  cellPropsColumnIndex?: number | null;
+};
+
+type ColumnStateSnapshot = {
+  computedVirtualizeColumns: boolean | null;
+  rowStyleVirtualizeColumns: boolean | null;
+  rowStyleColumnRenderCount: number | null;
+  rowStyleTotalColumnCount: number | null;
+};
+
+type EditorVirtualizationSnapshot = {
+  columnId: string;
+  columnIndex: number;
+  virtualizeColumns: boolean | null;
+};
+
+type RowHeightSnapshot = {
+  domHeight: number | null;
+  virtualHeight: number | null;
+  totalHeight: number | null;
+};
+
+type EditCoordinateEvent = {
+  type: "stop" | "complete";
+  rowId: string;
+  rowIndex: number;
+  columnId: string;
+  columnIndex: number;
+  value: unknown;
+};
+
+const RED_ASSERTION_TIMEOUT = 1_000;
+const baseSelectionRowIds = ["row-1", "row-2", "row-3"] as const;
+
+async function openPendingScenario(page: Page, scenario: PendingScenario) {
+  await page.goto(`/compat/inovua-pending-parity?scenario=${scenario}`);
+
+  const scope = page.getByTestId("inovua-pending-parity-scenario");
+  await expect(scope).toHaveAttribute("data-scenario", scenario);
+  await expect(
+    scope.getByRole("heading", {
+      name: `Pending Inovua parity: ${scenario}`,
+    })
+  ).toBeVisible();
+
+  const grid = scope.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toBeVisible();
+  return { scope, grid };
+}
+
+function row(grid: Locator, rowId: string) {
+  return grid.locator(`[data-slot="grid-row"][data-row-id="${rowId}"]`);
+}
+
+function cell(grid: Locator, rowId: string, columnId: string) {
+  return row(grid, rowId).locator(`[data-column-id="${columnId}"]`);
+}
+
+function header(grid: Locator, columnId: string) {
+  return grid.locator(
+    `[data-slot="grid-header-cell"][data-column-id="${columnId}"]`
+  );
+}
+
+function renderedHeaders(grid: Locator) {
+  return grid.locator('[data-slot="grid-header-cell"][data-column-id]');
+}
+
+function renderedRowCells(grid: Locator, rowId: string) {
+  return row(grid, rowId).locator("[data-column-id]");
+}
+
+function nameFilterCell(grid: Locator) {
+  return grid.locator(
+    '.tdg-filter-cell:has([data-testid="pending-name-filter"])'
+  );
+}
+
+async function readJson<T>(locator: Locator): Promise<T> {
+  const text = (await locator.textContent())?.trim() ?? "";
+  return JSON.parse(text) as T;
+}
+
+async function waitForAggregateEvent(scope: Locator) {
+  await expect
+    .poll(async () => {
+      const events = await readJson<FilterLogEvent[]>(
+        scope.getByTestId("filter-event-log")
+      );
+      return events.some((event) => event.kind === "aggregate");
+    })
+    .toBe(true);
+}
+
+async function captureColumnState(
+  scope: Locator
+): Promise<ColumnStateSnapshot> {
+  await scope.getByTestId("capture-column-state").click();
+  return readJson<ColumnStateSnapshot>(scope.getByTestId("column-state"));
+}
+
+test.describe("pending Inovua filtering contracts", () => {
+  test("onColumnFilterValueChange precedes the aggregate callback for editor changes", async ({
+    page,
+  }) => {
+    const { scope } = await openPendingScenario(page, "filter-callback");
+    const editor = scope.getByTestId("pending-name-filter");
+    await expect(editor).toBeVisible();
+
+    await editor.fill("Grace");
+    await waitForAggregateEvent(scope);
+
+    const events = await readJson<FilterLogEvent[]>(
+      scope.getByTestId("filter-event-log")
+    );
+    expect(events.map((event) => event.kind)).toEqual(["column", "aggregate"]);
+    expect(events[0]).toMatchObject({
+      kind: "column",
+      columnId: "name",
+      columnIndex: 1,
+      filterValue: {
+        name: "name",
+        type: "string",
+        operator: "contains",
+        value: "Grace",
+        active: null,
+      },
+      cellPropsPresent: true,
+      cellPropsId: "name",
+      cellPropsColumnIndex: 1,
+    });
+  });
+
+  test("onColumnFilterValueChange reports operator changes before aggregate state", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "filter-callback");
+    const filterCell = nameFilterCell(grid);
+    await expect(filterCell).toBeVisible();
+
+    await filterCell.getByRole("button", { name: "Filter" }).click();
+    await page.getByRole("menuitemradio", { name: "Equals" }).click();
+    await waitForAggregateEvent(scope);
+
+    const events = await readJson<FilterLogEvent[]>(
+      scope.getByTestId("filter-event-log")
+    );
+    expect(events.map((event) => event.kind)).toEqual(["column", "aggregate"]);
+    expect(events[0]).toMatchObject({
+      columnId: "name",
+      columnIndex: 1,
+      filterValue: { operator: "eq", value: "Ada", active: null },
+      cellPropsPresent: true,
+    });
+  });
+
+  test("onColumnFilterValueChange reports an inline clear with filter-cell context", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "filter-callback");
+    const filterCell = nameFilterCell(grid);
+    const clearButton = filterCell.getByRole("button", { name: "Clear" });
+    await expect(clearButton).toBeVisible();
+
+    await clearButton.click();
+    await waitForAggregateEvent(scope);
+
+    const events = await readJson<FilterLogEvent[]>(
+      scope.getByTestId("filter-event-log")
+    );
+    expect(events.map((event) => event.kind)).toEqual(["column", "aggregate"]);
+    expect(events[0]).toMatchObject({
+      columnId: "name",
+      columnIndex: 1,
+      filterValue: { value: "", active: null },
+      cellPropsPresent: true,
+    });
+  });
+
+  test("imperative column set emits a per-column payload without cellProps", async ({
+    page,
+  }) => {
+    const { scope } = await openPendingScenario(page, "filter-callback");
+
+    await scope.getByTestId("set-column-filter").click();
+    await waitForAggregateEvent(scope);
+    const events = await readJson<FilterLogEvent[]>(
+      scope.getByTestId("filter-event-log")
+    );
+    expect(events.map((event) => event.kind)).toEqual(["column", "aggregate"]);
+    expect(events[0]).toMatchObject({
+      columnId: "name",
+      columnIndex: 1,
+      filterValue: { value: "Grace", active: null },
+      cellPropsPresent: false,
+      cellPropsId: null,
+      cellPropsColumnIndex: null,
+    });
+  });
+
+  test("imperative column clear emits a per-column payload without cellProps", async ({
+    page,
+  }) => {
+    const { scope } = await openPendingScenario(page, "filter-callback");
+
+    await scope.getByTestId("clear-column-filter").click();
+    await waitForAggregateEvent(scope);
+    const events = await readJson<FilterLogEvent[]>(
+      scope.getByTestId("filter-event-log")
+    );
+    expect(events.map((event) => event.kind)).toEqual(["column", "aggregate"]);
+    expect(events[0]).toMatchObject({
+      columnId: "name",
+      columnIndex: 1,
+      filterValue: { value: "", active: null },
+      cellPropsPresent: false,
+      cellPropsId: null,
+      cellPropsColumnIndex: null,
+    });
+  });
+});
+
+test.describe("pending Inovua selection contracts", () => {
+  test("enableSelection=true enables uncontrolled single row selection without a checkbox or callback", async ({
+    page,
+  }) => {
+    const { grid } = await openPendingScenario(page, "selection-enable");
+    const firstRow = row(grid, "row-1");
+    const secondRow = row(grid, "row-2");
+    await expect(firstRow).toHaveAttribute("data-selected", "false");
+
+    await firstRow.click();
+    expect.soft(await firstRow.getAttribute("data-selected")).toBe("true");
+
+    await secondRow.click();
+    expect({
+      first: await firstRow.getAttribute("data-selected"),
+      second: await secondRow.getAttribute("data-selected"),
+    }).toEqual({ first: "false", second: "true" });
+  });
+
+  test("defaultSelected infers enabled multi-selection when enableSelection is omitted", async ({
+    page,
+  }) => {
+    const { grid } = await openPendingScenario(page, "selection-derived");
+    const firstRow = row(grid, "row-1");
+    const secondRow = row(grid, "row-2");
+
+    await firstRow.click();
+    await secondRow.click({ modifiers: ["ControlOrMeta"] });
+
+    expect({
+      first: await firstRow.getAttribute("data-selected"),
+      second: await secondRow.getAttribute("data-selected"),
+    }).toEqual({ first: "true", second: "true" });
+  });
+
+  test("enableSelection=false overrides row-click selection and onSelectionChange", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(
+      page,
+      "selection-disable"
+    );
+    const firstRow = row(grid, "row-1");
+
+    await firstRow.click();
+
+    expect({
+      selected: await firstRow.getAttribute("data-selected"),
+      events: await readJson<unknown[]>(
+        scope.getByTestId("selection-event-log")
+      ),
+    }).toEqual({ selected: "false", events: [] });
+  });
+
+  test("enableSelection=false makes a row-checkbox action a no-op", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(
+      page,
+      "selection-disable"
+    );
+    const rowCheckboxes = grid.locator(
+      'tbody [data-slot="grid-row"] [role="checkbox"]'
+    );
+    await expect(rowCheckboxes).toHaveCount(3);
+
+    await rowCheckboxes
+      .nth(0)
+      .evaluate((element) => (element as HTMLElement).click());
+
+    expect({
+      events: await readJson<unknown[]>(
+        scope.getByTestId("selection-event-log")
+      ),
+      selected: await Promise.all(
+        baseSelectionRowIds.map((rowId) =>
+          row(grid, rowId).getAttribute("data-selected")
+        )
+      ),
+    }).toEqual({ events: [], selected: ["false", "false", "false"] });
+  });
+
+  test("enableSelection=false makes the header-checkbox action a no-op", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(
+      page,
+      "selection-disable"
+    );
+    const headerCheckbox = grid.locator('thead [role="checkbox"]');
+    await expect(headerCheckbox).toHaveCount(1);
+
+    await headerCheckbox.evaluate((element) =>
+      (element as HTMLElement).click()
+    );
+
+    expect({
+      events: await readJson<unknown[]>(
+        scope.getByTestId("selection-event-log")
+      ),
+      selected: await Promise.all(
+        baseSelectionRowIds.map((rowId) =>
+          row(grid, rowId).getAttribute("data-selected")
+        )
+      ),
+    }).toEqual({ events: [], selected: ["false", "false", "false"] });
+  });
+
+  test("enableSelection=false suppresses a controlled selected map", async ({
+    page,
+  }) => {
+    const { grid } = await openPendingScenario(
+      page,
+      "selection-disable-controlled"
+    );
+
+    expect(await row(grid, "row-1").getAttribute("data-selected")).toBe(
+      "false"
+    );
+  });
+
+  test("onSelectionChange alone does not opt a grid into selection", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(
+      page,
+      "selection-callback-only"
+    );
+    const firstRow = row(grid, "row-1");
+
+    await firstRow.click();
+
+    expect({
+      selected: await firstRow.getAttribute("data-selected"),
+      events: await readJson<unknown[]>(
+        scope.getByTestId("selection-event-log")
+      ),
+    }).toEqual({ selected: "false", events: [] });
+  });
+});
+
+test.describe("pending Inovua column-virtualization contracts", () => {
+  test("uses the default threshold at 15 and leaves 14 visible columns unvirtualized", async ({
+    page,
+  }) => {
+    let opened = await openPendingScenario(page, "columns-default-15");
+    const headerCount = await renderedHeaders(opened.grid).count();
+    const cellCount = await renderedRowCells(
+      opened.grid,
+      "virtual-row-1"
+    ).count();
+    expect.soft(headerCount).toBeGreaterThan(0);
+    expect.soft(headerCount).toBeLessThan(15);
+    expect.soft(cellCount).toBeGreaterThan(0);
+    expect.soft(cellCount).toBeLessThan(15);
+
+    let state = await captureColumnState(opened.scope);
+    expect.soft(state).toMatchObject({
+      computedVirtualizeColumns: true,
+      rowStyleVirtualizeColumns: true,
+      rowStyleTotalColumnCount: 15,
+    });
+    expect.soft(state.rowStyleColumnRenderCount ?? 15).toBeLessThan(15);
+
+    opened = await openPendingScenario(page, "columns-default-14");
+    await expect(renderedHeaders(opened.grid)).toHaveCount(14);
+    await expect(renderedRowCells(opened.grid, "virtual-row-1")).toHaveCount(
+      14
+    );
+    state = await captureColumnState(opened.scope);
+    expect(state).toMatchObject({
+      computedVirtualizeColumns: false,
+      rowStyleVirtualizeColumns: false,
+      rowStyleColumnRenderCount: 14,
+      rowStyleTotalColumnCount: 14,
+    });
+  });
+
+  test("virtualizeColumnsThreshold uses an inclusive visible-column boundary", async ({
+    page,
+  }) => {
+    let opened = await openPendingScenario(page, "columns-threshold-at");
+    expect.soft(await renderedHeaders(opened.grid).count()).toBeLessThan(20);
+    expect
+      .soft((await captureColumnState(opened.scope)).computedVirtualizeColumns)
+      .toBe(true);
+
+    opened = await openPendingScenario(page, "columns-threshold-below");
+    await expect(renderedHeaders(opened.grid)).toHaveCount(20);
+    await expect(renderedRowCells(opened.grid, "virtual-row-1")).toHaveCount(
+      20
+    );
+    expect(
+      (await captureColumnState(opened.scope)).computedVirtualizeColumns
+    ).toBe(false);
+  });
+
+  test("explicit virtualizeColumns overrides the threshold in both directions", async ({
+    page,
+  }) => {
+    let opened = await openPendingScenario(page, "columns-force-on");
+    expect.soft(await renderedHeaders(opened.grid).count()).toBeLessThan(14);
+    expect
+      .soft((await captureColumnState(opened.scope)).computedVirtualizeColumns)
+      .toBe(true);
+
+    opened = await openPendingScenario(page, "columns-force-off");
+    await expect(renderedHeaders(opened.grid)).toHaveCount(20);
+    expect(
+      (await captureColumnState(opened.scope)).computedVirtualizeColumns
+    ).toBe(false);
+  });
+
+  test("numeric row heights enable column virtualization while function and natural heights disable it", async ({
+    page,
+  }) => {
+    let opened = await openPendingScenario(page, "columns-force-on");
+    expect.soft(await renderedHeaders(opened.grid).count()).toBeLessThan(14);
+    expect
+      .soft((await captureColumnState(opened.scope)).computedVirtualizeColumns)
+      .toBe(true);
+
+    for (const scenario of [
+      "columns-function-height",
+      "columns-natural-height",
+    ] as const) {
+      opened = await openPendingScenario(page, scenario);
+      await expect(renderedHeaders(opened.grid)).toHaveCount(20);
+      await expect(renderedRowCells(opened.grid, "virtual-row-1")).toHaveCount(
+        20
+      );
+      expect(await captureColumnState(opened.scope)).toMatchObject({
+        computedVirtualizeColumns: false,
+        rowStyleVirtualizeColumns: false,
+        rowStyleColumnRenderCount: 20,
+        rowStyleTotalColumnCount: 20,
+      });
+    }
+  });
+
+  test("horizontal scrolling changes the mounted range while keeping header and body aligned", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "columns-scroll");
+    const firstHeader = header(grid, "col-00");
+    const lastHeader = header(grid, "col-23");
+    const lastCell = cell(grid, "virtual-row-1", "col-23");
+    const viewport = grid.locator('[data-slot="scroll-area-viewport"]');
+
+    expect.soft(await lastHeader.count()).toBe(0);
+    await scope.getByTestId("scroll-last-column").click();
+    await expect
+      .poll(() => viewport.evaluate((element) => element.scrollLeft), {
+        timeout: RED_ASSERTION_TIMEOUT,
+      })
+      .toBeGreaterThan(0);
+    await expect(lastHeader).toBeVisible({ timeout: RED_ASSERTION_TIMEOUT });
+    await expect(lastCell).toBeVisible({ timeout: RED_ASSERTION_TIMEOUT });
+    expect.soft(await firstHeader.count()).toBe(0);
+
+    const scrollGeometry = await viewport.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+    expect
+      .soft(scrollGeometry.scrollWidth)
+      .toBeGreaterThan(scrollGeometry.clientWidth);
+    expect.soft(scrollGeometry.scrollWidth).toBeGreaterThanOrEqual(24 * 140);
+    expect.soft(scrollGeometry.scrollWidth).toBeLessThanOrEqual(24 * 140 + 24);
+
+    const [headerBox, cellBox] = await Promise.all([
+      lastHeader.boundingBox(),
+      lastCell.boundingBox(),
+    ]);
+    expect(headerBox).not.toBeNull();
+    expect(cellBox).not.toBeNull();
+    expect(
+      Math.abs((headerBox?.x ?? 0) - (cellBox?.x ?? 0))
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs((headerBox?.width ?? 0) - (cellBox?.width ?? 0))
+    ).toBeLessThanOrEqual(1);
+
+    const state = await captureColumnState(scope);
+    expect(state.computedVirtualizeColumns).toBe(true);
+    expect(state.rowStyleVirtualizeColumns).toBe(true);
+    expect(state.rowStyleColumnRenderCount ?? 24).toBeLessThan(24);
+  });
+
+  test("a far virtualized column remains filterable after imperative scrolling", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "columns-scroll");
+    expect.soft(await header(grid, "col-23").count()).toBe(0);
+
+    await scope.getByTestId("scroll-last-column").click();
+    const editor = scope.getByTestId("last-column-filter");
+    await expect(editor).toBeVisible();
+    await editor.fill("needle");
+
+    await expect(
+      grid.locator('[data-slot="grid-row"][data-row-id]')
+    ).toHaveCount(1);
+    await expect(row(grid, "virtual-row-1")).toBeVisible();
+    expect((await captureColumnState(scope)).rowStyleVirtualizeColumns).toBe(
+      true
+    );
+  });
+
+  test("far-column editing reports virtualized cell metadata", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "columns-scroll");
+    await scope.getByTestId("scroll-last-column").click();
+    const targetCell = cell(grid, "virtual-row-1", "col-23");
+    await expect(targetCell).toBeVisible();
+
+    await targetCell.dblclick();
+    await expect(targetCell.getByRole("textbox")).toBeFocused();
+
+    const state = await readJson<EditorVirtualizationSnapshot>(
+      scope.getByTestId("column-editor-state")
+    );
+    expect(state).toMatchObject({
+      columnId: "col-23",
+      columnIndex: 23,
+      virtualizeColumns: true,
+    });
+  });
+});
+
+test.describe("pending Inovua emptyText contracts", () => {
+  test("a literal emptyText overrides i18n.noRecords", async ({ page }) => {
+    const { grid } = await openPendingScenario(page, "empty-literal");
+    const literal = grid.getByText("Literal empty state", { exact: true });
+    const fallback = grid.getByText("Localized empty fallback", {
+      exact: true,
+    });
+
+    expect({
+      literalCount: await literal.count(),
+      literalVisible: await literal.isVisible(),
+      fallbackCount: await fallback.count(),
+    }).toEqual({ literalCount: 1, literalVisible: true, fallbackCount: 0 });
+  });
+
+  test("an emptyText i18n key resolves through the supplied map", async ({
+    page,
+  }) => {
+    const { grid } = await openPendingScenario(page, "empty-key");
+    const localized = grid.getByText("Localized custom empty", {
+      exact: true,
+    });
+    const fallback = grid.getByText("Localized empty fallback", {
+      exact: true,
+    });
+
+    expect({
+      localizedCount: await localized.count(),
+      localizedVisible: await localized.isVisible(),
+      fallbackCount: await fallback.count(),
+    }).toEqual({ localizedCount: 1, localizedVisible: true, fallbackCount: 0 });
+  });
+
+  test("emptyText preserves an interactive React node", async ({ page }) => {
+    const { scope, grid } = await openPendingScenario(page, "empty-node");
+    const action = grid.getByTestId("empty-node-action");
+    expect({
+      count: await action.count(),
+      visible: await action.isVisible(),
+    }).toEqual({ count: 1, visible: true });
+
+    await action.click();
+    await expect(scope.getByTestId("empty-action-count")).toHaveText("1");
+  });
+
+  test("emptyText invokes and renders a zero-argument function", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "empty-function");
+    const action = grid.getByTestId("empty-function-action");
+    expect({
+      count: await action.count(),
+      visible: await action.isVisible(),
+    }).toEqual({ count: 1, visible: true });
+
+    await action.click();
+    await expect(scope.getByTestId("empty-action-count")).toHaveText("1");
+  });
+
+  for (const { scenario, label } of [
+    { scenario: "empty-null", label: "null" },
+    { scenario: "empty-false", label: "false" },
+    { scenario: "empty-string", label: "an empty string" },
+  ] as const) {
+    test(`${label} suppresses empty-state content`, async ({ page }) => {
+      const { grid } = await openPendingScenario(page, scenario);
+      const fallback = grid.getByText("Localized empty fallback", {
+        exact: true,
+      });
+      const bodyText = (await grid.locator("tbody").allTextContents())
+        .join("")
+        .trim();
+
+      expect({ fallbackCount: await fallback.count(), bodyText }).toEqual({
+        fallbackCount: 0,
+        bodyText: "",
+      });
+    });
+  }
+
+  test("loading suppresses emptyText until loading finishes", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "empty-loading");
+    await expect(grid.getByText("Loading…", { exact: true })).toBeVisible();
+    await expect(grid.getByTestId("loading-empty-content")).toHaveCount(0);
+
+    await scope.getByTestId("finish-empty-loading").click();
+    await expect(grid.getByText("Loading…", { exact: true })).toHaveCount(0);
+    const customContent = grid.getByTestId("loading-empty-content");
+    expect({
+      count: await customContent.count(),
+      visible: await customContent.isVisible(),
+    }).toEqual({ count: 1, visible: true });
+  });
+
+  test("filtered local data uses emptyText after the filter removes every row", async ({
+    page,
+  }) => {
+    const { grid } = await openPendingScenario(page, "empty-filtered");
+    await expect(
+      grid.locator('[data-slot="grid-row"][data-row-id]')
+    ).toHaveCount(0);
+    const customContent = grid.getByTestId("filtered-empty-content");
+    expect({
+      count: await customContent.count(),
+      visible: await customContent.isVisible(),
+    }).toEqual({ count: 1, visible: true });
+  });
+
+  test("remote empty data hides emptyText while loading and shows it after resolution", async ({
+    page,
+  }) => {
+    const { grid } = await openPendingScenario(page, "empty-remote");
+    await expect(grid.getByText("Loading…", { exact: true })).toBeVisible();
+    await expect(grid.getByTestId("remote-empty-content")).toHaveCount(0);
+
+    await page.getByTestId("resolve-remote-empty").click();
+    await expect(grid.getByText("Loading…", { exact: true })).toHaveCount(0);
+    const customContent = grid.getByTestId("remote-empty-content");
+    expect({
+      count: await customContent.count(),
+      visible: await customContent.isVisible(),
+    }).toEqual({ count: 1, visible: true });
+  });
+
+  test("mobile-list empty state uses the same emptyText resolver", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 800, height: 900 });
+    const { grid } = await openPendingScenario(page, "empty-mobile");
+    await expect(grid).toHaveAttribute("data-layout", "mobile-list");
+    const list = grid.locator('[data-slot="mobile-grid-list"] [role="list"]');
+    await expect(list).toBeVisible();
+    const customContent = list.getByTestId("mobile-empty-content");
+    const fallback = list.getByText("Localized empty fallback", {
+      exact: true,
+    });
+    expect({
+      customCount: await customContent.count(),
+      customVisible: await customContent.isVisible(),
+      fallbackCount: await fallback.count(),
+    }).toEqual({ customCount: 1, customVisible: true, fallbackCount: 0 });
+  });
+});
+
+test.describe("unsafe implemented-contract edges", () => {
+  test("an explicit numeric rowHeight remains authoritative over minRowHeight", async ({
+    page,
+  }) => {
+    const { scope } = await openPendingScenario(page, "row-height-authority");
+    await scope.getByTestId("capture-row-height-authority").click();
+    const snapshot = await readJson<RowHeightSnapshot>(
+      scope.getByTestId("row-height-authority-state")
+    );
+
+    expect(snapshot).toEqual({
+      domHeight: 60,
+      virtualHeight: 60,
+      totalHeight: 1200,
+    });
+  });
+
+  test("active editing stays coordinate-anchored when columns reorder", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(
+      page,
+      "editing-column-coordinate"
+    );
+    const originalName = cell(grid, "edit-r1", "name");
+    await originalName.dblclick();
+    const activeEditor = grid.getByRole("textbox");
+    await expect(activeEditor).toHaveCount(1);
+    await activeEditor.fill("Draft column");
+
+    await scope.getByTestId("reorder-edit-columns").click();
+    await expect(header(grid, "team")).toHaveAttribute(
+      "data-column-index",
+      "0"
+    );
+    expect
+      .soft({
+        teamEditors: await cell(grid, "edit-r1", "team")
+          .getByRole("textbox")
+          .count(),
+        nameEditors: await cell(grid, "edit-r1", "name")
+          .getByRole("textbox")
+          .count(),
+      })
+      .toEqual({ teamEditors: 1, nameEditors: 0 });
+
+    await grid.getByRole("textbox").press("Enter");
+    await expect
+      .poll(
+        async () =>
+          readJson<EditCoordinateEvent[]>(
+            scope.getByTestId("editing-coordinate-events")
+          ),
+        { timeout: RED_ASSERTION_TIMEOUT }
+      )
+      .toContainEqual({
+        type: "complete",
+        rowId: "edit-r1",
+        rowIndex: 0,
+        columnId: "team",
+        columnIndex: 0,
+        value: "Draft column",
+      });
+  });
+
+  test("active editing stays coordinate-anchored when rows reorder", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(
+      page,
+      "editing-row-coordinate"
+    );
+    await cell(grid, "edit-r1", "name").dblclick();
+    const activeEditor = grid.getByRole("textbox");
+    await expect(activeEditor).toHaveCount(1);
+    await activeEditor.fill("Draft row");
+
+    await scope.getByTestId("reorder-edit-rows").click();
+    await expect(row(grid, "edit-r2")).toHaveAttribute("data-row-index", "0");
+    expect
+      .soft({
+        secondRowEditors: await cell(grid, "edit-r2", "name")
+          .getByRole("textbox")
+          .count(),
+        firstRowEditors: await cell(grid, "edit-r1", "name")
+          .getByRole("textbox")
+          .count(),
+      })
+      .toEqual({ secondRowEditors: 1, firstRowEditors: 0 });
+
+    await grid.getByRole("textbox").press("Enter");
+    await expect
+      .poll(
+        async () =>
+          readJson<EditCoordinateEvent[]>(
+            scope.getByTestId("editing-coordinate-events")
+          ),
+        { timeout: RED_ASSERTION_TIMEOUT }
+      )
+      .toContainEqual({
+        type: "complete",
+        rowId: "edit-r2",
+        rowIndex: 0,
+        columnId: "name",
+        columnIndex: 0,
+        value: "Draft row",
+      });
+  });
+
+  test("the computed API can update uncontrolled showZebraRows state", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openPendingScenario(page, "zebra-imperative");
+    await expect(grid).toHaveAttribute("data-show-zebra-rows", "true");
+
+    await scope.getByTestId("disable-zebra-imperatively").click();
+
+    await expect(scope.getByTestId("zebra-setter-present")).toHaveText("true", {
+      timeout: RED_ASSERTION_TIMEOUT,
+    });
+    await expect(grid).toHaveAttribute("data-show-zebra-rows", "false", {
+      timeout: RED_ASSERTION_TIMEOUT,
+    });
+  });
+});
+
+test.describe("unsafe touch-resize contract", () => {
+  test.use({
+    userAgent: devices["Pixel 7"].userAgent,
+    viewport: devices["Pixel 7"].viewport,
+    deviceScaleFactor: devices["Pixel 7"].deviceScaleFactor,
+    isMobile: devices["Pixel 7"].isMobile,
+    hasTouch: devices["Pixel 7"].hasTouch,
+  });
+
+  test("touch dragging a resize handle resizes and emits onColumnResize", async ({
+    page,
+  }) => {
+    await page.goto("/compat/inovua-parity?scenario=resize-callback");
+    const scope = page.getByTestId("inovua-parity-scenario");
+    const grid = scope.locator(".InovuaReactDataGrid.tdg-root").first();
+    await expect(grid).toBeVisible();
+    const descriptionHeader = header(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    await expect(resizer).toHaveCount(1);
+    const beforeWidth = await descriptionHeader.evaluate((element) =>
+      Math.round(element.getBoundingClientRect().width)
+    );
+    const box = await resizer.boundingBox();
+    expect(box).not.toBeNull();
+
+    const session = await page.context().newCDPSession(page);
+    const x = Math.round((box?.x ?? 0) + (box?.width ?? 0) / 2);
+    const y = Math.round((box?.y ?? 0) + (box?.height ?? 0) / 2);
+    await session.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x, y }],
+    });
+    await session.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x: x + 1, y }],
+    });
+    await session.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x: x + 91, y }],
+    });
+    await session.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+    await session.detach();
+
+    await expect(scope.getByTestId("column-resize-event-count")).toHaveText(
+      "1",
+      { timeout: RED_ASSERTION_TIMEOUT }
+    );
+    const event = await readJson<{
+      columnId: string;
+      width: number;
+      flex: number | null;
+      reservedViewportWidth: number;
+    }>(scope.getByTestId("column-resize-last-event"));
+    expect(event).toMatchObject({
+      columnId: "description",
+      flex: null,
+      reservedViewportWidth: 0,
+    });
+    expect(event.width).toBeGreaterThan(beforeWidth + 75);
+    expect(
+      await descriptionHeader.evaluate((element) =>
+        Math.round(element.getBoundingClientRect().width)
+      )
+    ).toBeGreaterThan(beforeWidth + 75);
+  });
+});

--- a/tests/playwright/live-column-resize.spec.ts
+++ b/tests/playwright/live-column-resize.spec.ts
@@ -1,0 +1,673 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const MAX_GEOMETRY_DRIFT_PX = 2;
+const MAX_INTERACTION_DELAY_MS = 250;
+const MAX_LONG_TASK_MS = 250;
+const POINTER_BURST_SIZE = 180;
+
+type ResizePayload = {
+  columnId: string;
+  width: number | null;
+  flex: number | null;
+  reservedViewportWidth: number | null;
+};
+
+type ResizeListenerSnapshot = Record<string, number>;
+
+async function openScenario(
+  page: Page,
+  scenario: "resize-callback" | "live-resize" | "controlled-live-resize"
+) {
+  await page.goto(`/compat/inovua-parity?scenario=${scenario}`);
+
+  const scope = page.getByTestId("inovua-parity-scenario");
+  await expect(scope).toHaveAttribute("data-scenario", scenario);
+
+  const grid = scope.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toBeVisible();
+
+  return { scope, grid };
+}
+
+function header(grid: Locator, columnId: string): Locator {
+  return grid.locator(
+    `[data-slot="grid-header-cell"][data-column-id="${columnId}"]`
+  );
+}
+
+function firstCell(grid: Locator, columnId: string): Locator {
+  return grid
+    .locator(
+      `[data-slot="grid-row"][data-row-id] [data-column-id="${columnId}"]`
+    )
+    .first();
+}
+
+async function readWidth(locator: Locator): Promise<number> {
+  return locator.evaluate((element) => element.getBoundingClientRect().width);
+}
+
+async function readCount(locator: Locator): Promise<number> {
+  return Number((await locator.textContent())?.trim() ?? "0");
+}
+
+async function readPayload(locator: Locator): Promise<ResizePayload> {
+  return JSON.parse(
+    (await locator.textContent())?.trim() ?? "null"
+  ) as ResizePayload;
+}
+
+async function readPayloads(locator: Locator): Promise<ResizePayload[]> {
+  return JSON.parse(
+    (await locator.textContent())?.trim() ?? "[]"
+  ) as ResizePayload[];
+}
+
+async function settleFrames(page: Page, count = 2): Promise<void> {
+  await page.evaluate(async (frameCount) => {
+    for (let index = 0; index < frameCount; index += 1) {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve())
+      );
+    }
+  }, count);
+}
+
+async function dragStartPoint(resizer: Locator) {
+  const box = await resizer.boundingBox();
+  expect(box).not.toBeNull();
+
+  return {
+    x: (box?.x ?? 0) + (box?.width ?? 0) / 2,
+    y: (box?.y ?? 0) + (box?.height ?? 0) / 2,
+  };
+}
+
+async function installResizeListenerAudit(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const eventTypes = [
+      "blur",
+      "mousemove",
+      "mouseup",
+      "pointermove",
+      "pointerup",
+      "pointercancel",
+    ] as const;
+    const active = Object.fromEntries(
+      eventTypes.map((type) => [
+        type,
+        new Set<EventListenerOrEventListenerObject>(),
+      ])
+    ) as Record<string, Set<EventListenerOrEventListenerObject>>;
+    const nativeAdd = window.addEventListener.bind(window);
+    const nativeRemove = window.removeEventListener.bind(window);
+
+    window.addEventListener = ((type, listener, options) => {
+      if (listener && active[type]) active[type].add(listener);
+      nativeAdd(type, listener, options);
+    }) as typeof window.addEventListener;
+    window.removeEventListener = ((type, listener, options) => {
+      if (listener && active[type]) active[type].delete(listener);
+      nativeRemove(type, listener, options);
+    }) as typeof window.removeEventListener;
+
+    Object.defineProperty(window, "__tdgLiveResizeListenerAudit", {
+      configurable: false,
+      value: active,
+    });
+  });
+}
+
+async function readResizeListenerAudit(
+  page: Page
+): Promise<ResizeListenerSnapshot> {
+  return page.evaluate(() => {
+    const active = (
+      window as typeof window & {
+        __tdgLiveResizeListenerAudit: Record<
+          string,
+          Set<EventListenerOrEventListenerObject>
+        >;
+      }
+    ).__tdgLiveResizeListenerAudit;
+
+    return Object.fromEntries(
+      Object.entries(active).map(([type, listeners]) => [type, listeners.size])
+    );
+  });
+}
+
+test.describe("live column resizing", () => {
+  test("updates header and body geometry during drag and commits the latest payload", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "live-resize");
+    const descriptionHeader = header(grid, "description");
+    const descriptionCell = firstCell(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const latestEvent = scope.getByTestId("column-resize-last-event");
+    const initialWidth = await readWidth(descriptionHeader);
+    const start = await dragStartPoint(resizer);
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await expect(grid).toHaveAttribute("data-column-resizing", "true");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+
+    await page.mouse.move(start.x + 100, start.y, { steps: 12 });
+    await expect
+      .poll(() => readWidth(descriptionHeader))
+      .toBeGreaterThan(initialWidth + 75);
+
+    const widthDuringDrag = await readWidth(descriptionHeader);
+    const bodyWidthDuringDrag = await readWidth(descriptionCell);
+    expect(Math.abs(widthDuringDrag - bodyWidthDuringDrag)).toBeLessThanOrEqual(
+      MAX_GEOMETRY_DRIFT_PX
+    );
+    await expect(eventCount).toHaveText("0");
+    await expect(latestEvent).toHaveText("none");
+    await settleFrames(page);
+
+    await page.mouse.up();
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+    await settleFrames(page);
+
+    // Live mode changes only when geometry is painted. The public Inovua-style
+    // callback remains a completion event and fires once with the final size.
+    await expect(eventCount).toHaveText("1");
+    const renderedWidth = await readWidth(descriptionHeader);
+    const finalPayload = await readPayload(latestEvent);
+    expect(finalPayload.columnId).toBe("description");
+    expect(finalPayload.width).not.toBeNull();
+    expect(renderedWidth).toBeGreaterThan(initialWidth + 75);
+    expect(
+      Math.abs(renderedWidth - (finalPayload.width ?? 0))
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX + 1);
+    expect(finalPayload.reservedViewportWidth).not.toBeNull();
+  });
+
+  test("keeps deferred proxy resizing as the default", async ({ page }) => {
+    const { scope, grid } = await openScenario(page, "resize-callback");
+    const descriptionHeader = header(grid, "description");
+    const descriptionCell = firstCell(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const initialWidth = await readWidth(descriptionHeader);
+    const start = await dragStartPoint(resizer);
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 100, start.y, { steps: 12 });
+    await settleFrames(page);
+
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toBeVisible();
+    expect(
+      Math.abs((await readWidth(descriptionHeader)) - initialWidth)
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs((await readWidth(descriptionCell)) - initialWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    await expect(eventCount).toHaveText("0");
+
+    await page.mouse.up();
+    await expect(eventCount).toHaveText("1");
+    await expect
+      .poll(() => readWidth(descriptionHeader))
+      .toBeGreaterThan(initialWidth + 75);
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+  });
+
+  test("previews a controlled width but leaves ownership with the consumer", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "controlled-live-resize");
+    const controlledHeader = header(grid, "controlled");
+    const controlledCell = firstCell(grid, "controlled");
+    const resizer = controlledHeader.locator('[data-slot="column-resizer"]');
+    const proposals = scope.getByTestId("controlled-resize-events");
+    const controlledValue = scope.getByTestId("controlled-width-value");
+    const initialWidth = await readWidth(controlledHeader);
+    const start = await dragStartPoint(resizer);
+
+    await expect(controlledValue).toHaveText("180");
+    expect(await readPayloads(proposals)).toEqual([]);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 100, start.y, { steps: 12 });
+
+    await expect
+      .poll(() => readWidth(controlledHeader))
+      .toBeGreaterThan(initialWidth + 75);
+    expect(
+      Math.abs(
+        (await readWidth(controlledHeader)) - (await readWidth(controlledCell))
+      )
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(await readPayloads(proposals)).toEqual([]);
+    await expect(controlledValue).toHaveText("180");
+
+    await page.mouse.up();
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(async () => (await readPayloads(proposals)).length)
+      .toBe(1);
+    const [proposal] = await readPayloads(proposals);
+    expect(proposal?.columnId).toBe("controlled");
+    expect(proposal?.width ?? 0).toBeGreaterThan(initialWidth + 75);
+    await expect
+      .poll(async () =>
+        Math.abs((await readWidth(controlledHeader)) - initialWidth)
+      )
+      .toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(controlledCell)) - initialWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    await expect(controlledValue).toHaveText("180");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+  });
+
+  test("cancelling restores a controlled width updated during the live drag", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "controlled-live-resize");
+    const controlledHeader = header(grid, "controlled");
+    const controlledCell = firstCell(grid, "controlled");
+    const fillerHeader = header(grid, "filler");
+    const bodyTable = grid.locator(".tdg-body-table");
+    const resizer = controlledHeader.locator('[data-slot="column-resizer"]');
+    const proposals = scope.getByTestId("controlled-resize-events");
+    const controlledValue = scope.getByTestId("controlled-width-value");
+    const setControlledWidth = scope.getByTestId("set-controlled-width");
+    const initialWidth = await readWidth(controlledHeader);
+    const fillerWidth = await readWidth(fillerHeader);
+    const start = await dragStartPoint(resizer);
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 70, start.y, { steps: 10 });
+    await settleFrames(page);
+
+    const previewWidth = await readWidth(controlledHeader);
+    expect(previewWidth).toBeGreaterThan(initialWidth + 50);
+    expect(await readPayloads(proposals)).toEqual([]);
+
+    // Dispatch a consumer action without releasing the held resize pointer.
+    await setControlledWidth.evaluate((element) =>
+      (element as HTMLElement).click()
+    );
+    await expect(controlledValue).toHaveText("300");
+    await settleFrames(page);
+
+    // The active pointer preview remains on top of the new controlled base.
+    expect(
+      Math.abs((await readWidth(controlledHeader)) - previewWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(bodyTable)) - (previewWidth + fillerWidth))
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX + 1);
+    expect(await readPayloads(proposals)).toEqual([]);
+
+    await page.evaluate(() => window.dispatchEvent(new Event("blur")));
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(async () => Math.abs((await readWidth(controlledHeader)) - 300))
+      .toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(controlledCell)) - 300)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(bodyTable)) - (300 + fillerWidth))
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX + 1);
+    await expect(controlledValue).toHaveText("300");
+    expect(await readPayloads(proposals)).toEqual([]);
+
+    // Reset Playwright's mouse state; the grid listener is already gone.
+    await page.mouse.up();
+  });
+
+  test("rolls a cancelled live preview back without emitting completion", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "live-resize");
+    const descriptionHeader = header(grid, "description");
+    const descriptionCell = firstCell(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const initialWidth = await readWidth(descriptionHeader);
+    const pointerId = 29;
+
+    const start = await resizer.evaluate((element, id) => {
+      const rect = element.getBoundingClientRect();
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      element.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          button: 0,
+          buttons: 1,
+          pointerId: id,
+          pointerType: "mouse",
+          isPrimary: true,
+        })
+      );
+      return { x, y };
+    }, pointerId);
+
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 90,
+            clientY: y,
+            buttons: 1,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+    await settleFrames(page, 2);
+    await expect
+      .poll(() => readWidth(descriptionHeader))
+      .toBeGreaterThan(initialWidth + 65);
+    await expect(eventCount).toHaveText("0");
+
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointercancel", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 90,
+            clientY: y,
+            buttons: 0,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(async () =>
+        Math.abs((await readWidth(descriptionHeader)) - initialWidth)
+      )
+      .toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(descriptionCell)) - initialWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    await expect(eventCount).toHaveText("0");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+  });
+
+  test("coalesces pointer bursts and releases every drag listener", async ({
+    page,
+  }) => {
+    await installResizeListenerAudit(page);
+    const { scope, grid } = await openScenario(page, "live-resize");
+    const descriptionHeader = header(grid, "description");
+    const fillerContent = firstCell(grid, "filler").locator(
+      ".tdg-cell-content"
+    );
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const initialWidth = await readWidth(descriptionHeader);
+    const baselineListeners = await readResizeListenerAudit(page);
+    const mountedRows = grid.locator('[data-slot="grid-row"][data-row-id]');
+    const initialMountedRowCount = await mountedRows.count();
+    expect(initialMountedRowCount).toBeGreaterThan(0);
+    expect(initialMountedRowCount).toBeLessThan(500);
+    const pointerId = 41;
+
+    const start = await resizer.evaluate((element, id) => {
+      const rect = element.getBoundingClientRect();
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      element.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          button: 0,
+          buttons: 1,
+          pointerId: id,
+          pointerType: "mouse",
+          isPrimary: true,
+        })
+      );
+      return { x, y };
+    }, pointerId);
+    await expect(grid).toHaveAttribute("data-column-resizing", "true");
+
+    const burst = await grid.evaluate(
+      async (
+        gridElement,
+        args: {
+          pointerId: number;
+          startX: number;
+          startY: number;
+          moveCount: number;
+        }
+      ) => {
+        const descriptionHeader = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-header-cell"][data-column-id="description"]'
+        );
+        const descriptionCell = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id] [data-column-id="description"]'
+        );
+        const fillerContent = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id] [data-column-id="filler"] .tdg-cell-content'
+        );
+        if (!descriptionHeader || !descriptionCell || !fillerContent) {
+          throw new Error(
+            "Expected resize performance targets were not mounted"
+          );
+        }
+
+        const descriptionColumns = Array.from(
+          gridElement.querySelectorAll<HTMLTableColElement>(
+            'col[data-column-id="description"]'
+          )
+        );
+        const owningTables = Array.from(
+          new Set(
+            descriptionColumns
+              .map((element) => element.closest("table"))
+              .filter(
+                (element): element is HTMLTableElement =>
+                  element instanceof HTMLTableElement
+              )
+          )
+        );
+        if (descriptionColumns.length < 2 || owningTables.length < 2) {
+          throw new Error(
+            "Expected separate header/body column preview targets"
+          );
+        }
+
+        let columnStyleMutations = 0;
+        let tableStyleMutations = 0;
+        const styleObserver = new MutationObserver((records) => {
+          for (const record of records) {
+            if (
+              descriptionColumns.includes(record.target as HTMLTableColElement)
+            ) {
+              columnStyleMutations += 1;
+            }
+            if (owningTables.includes(record.target as HTMLTableElement)) {
+              tableStyleMutations += 1;
+            }
+          }
+        });
+        for (const target of [...descriptionColumns, ...owningTables]) {
+          styleObserver.observe(target, {
+            attributes: true,
+            attributeFilter: ["style"],
+          });
+        }
+
+        const longTasks: number[] = [];
+        const longTaskObserver =
+          typeof PerformanceObserver === "function" &&
+          PerformanceObserver.supportedEntryTypes.includes("longtask")
+            ? new PerformanceObserver((list) => {
+                for (const entry of list.getEntries()) {
+                  longTasks.push(entry.duration);
+                }
+              })
+            : null;
+        longTaskObserver?.observe({ entryTypes: ["longtask"] });
+
+        const preservedFillerContent = fillerContent;
+        const startedAt = performance.now();
+        for (let index = 1; index <= args.moveCount; index += 1) {
+          window.dispatchEvent(
+            new PointerEvent("pointermove", {
+              bubbles: true,
+              cancelable: true,
+              clientX: args.startX + (120 * index) / args.moveCount,
+              clientY: args.startY,
+              button: -1,
+              buttons: 1,
+              pointerId: args.pointerId,
+              pointerType: "mouse",
+              isPrimary: true,
+            })
+          );
+        }
+        const dispatchDuration = performance.now() - startedAt;
+        const firstFrameAt = await new Promise<number>((resolve) =>
+          requestAnimationFrame(resolve)
+        );
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve())
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+        const currentFillerContent = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id] [data-column-id="filler"] .tdg-cell-content'
+        );
+        styleObserver.disconnect();
+        longTaskObserver?.disconnect();
+
+        return {
+          cellWidth: descriptionCell.getBoundingClientRect().width,
+          dispatchDuration,
+          fillerContentPreserved:
+            currentFillerContent === preservedFillerContent,
+          firstFrameDelay: firstFrameAt - startedAt,
+          headerWidth: descriptionHeader.getBoundingClientRect().width,
+          columnStyleMutations,
+          maxLongTask: Math.max(0, ...longTasks),
+          mountedRowCount: gridElement.querySelectorAll(
+            '[data-slot="grid-row"][data-row-id]'
+          ).length,
+          tableStyleMutations,
+        };
+      },
+      {
+        pointerId,
+        startX: start.x,
+        startY: start.y,
+        moveCount: POINTER_BURST_SIZE,
+      }
+    );
+
+    expect(burst.dispatchDuration).toBeLessThan(MAX_INTERACTION_DELAY_MS);
+    expect(burst.firstFrameDelay).toBeLessThan(MAX_INTERACTION_DELAY_MS);
+    expect(burst.maxLongTask).toBeLessThan(MAX_LONG_TASK_MS);
+    expect(burst.headerWidth).toBeGreaterThan(initialWidth + 95);
+    expect(Math.abs(burst.headerWidth - burst.cellWidth)).toBeLessThanOrEqual(
+      MAX_GEOMETRY_DRIFT_PX
+    );
+    expect(burst.fillerContentPreserved).toBe(true);
+    expect(burst.mountedRowCount).toBe(initialMountedRowCount);
+    expect(burst.columnStyleMutations).toBeGreaterThan(0);
+    expect(burst.tableStyleMutations).toBeGreaterThan(0);
+    expect(
+      burst.columnStyleMutations + burst.tableStyleMutations
+    ).toBeLessThanOrEqual(12);
+
+    // A synchronous event burst must be reduced to frame-sized DOM work. The
+    // public callback remains completion-only even though geometry is live.
+    await expect(eventCount).toHaveText("0");
+
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointerup", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 120,
+            clientY: y,
+            button: 0,
+            buttons: 0,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(() => readResizeListenerAudit(page))
+      .toEqual(baselineListeners);
+    await settleFrames(page);
+    await expect(eventCount).toHaveText("1");
+
+    const settledWidth = await readWidth(descriptionHeader);
+    const settledCount = await readCount(eventCount);
+    expect(settledCount).toBe(1);
+    expect(await mountedRows.count()).toBe(initialMountedRowCount);
+    expect(await fillerContent.isVisible()).toBe(true);
+
+    // A stale pointer event after completion must not enqueue more width work.
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 180,
+            clientY: y,
+            buttons: 1,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+    await settleFrames(page, 3);
+    expect(await readWidth(descriptionHeader)).toBeCloseTo(settledWidth, 1);
+    expect(await readCount(eventCount)).toBe(settledCount);
+  });
+});

--- a/tests/playwright/mobile-transform.spec.ts
+++ b/tests/playwright/mobile-transform.spec.ts
@@ -134,8 +134,11 @@ test.describe("allowMobileTransform", () => {
       );
 
       return {
-        gutterWidth: clipRight - headerRect.right,
         handleWidth: handleRect.width,
+        handleInsideHeader:
+          handleRect.left >= headerRect.left - 1 &&
+          handleRect.right <= headerRect.right + 1,
+        edgeAlignment: Math.abs(clipRight - headerRect.right),
         handleFullyVisible: handleRect.right <= clipRight + 1,
         handleClearsScrollbar:
           !scrollbarRect || handleRect.right <= scrollbarRect.left + 1,
@@ -155,9 +158,9 @@ test.describe("allowMobileTransform", () => {
     expect(edgeLayout).not.toBeNull();
     expect(edgeLayout?.headerFullyVisible).toBe(true);
     expect(edgeLayout?.labelFullyVisible).toBe(true);
-    expect(edgeLayout?.gutterWidth ?? 0).toBeGreaterThanOrEqual(
-      (edgeLayout?.handleWidth ?? 0) / 2
-    );
+    expect(edgeLayout?.handleWidth ?? 0).toBeGreaterThanOrEqual(24);
+    expect(edgeLayout?.handleInsideHeader).toBe(true);
+    expect(edgeLayout?.edgeAlignment ?? Infinity).toBeLessThanOrEqual(1);
     expect(edgeLayout?.handleFullyVisible).toBe(true);
     expect(edgeLayout?.handleClearsScrollbar).toBe(true);
     expect(edgeLayout?.handleHitTarget).toBe(true);

--- a/tests/playwright/overflow.spec.ts
+++ b/tests/playwright/overflow.spec.ts
@@ -30,11 +30,40 @@ test("keeps the grid contained inside a constrained parent shell", async ({
     const bodyViewport = shell?.querySelector<HTMLElement>(
       '[data-slot="scroll-area-viewport"]'
     );
+    const headerTable = shell?.querySelector<HTMLElement>(".tdg-header-table");
+    const bodyTable = shell?.querySelector<HTMLElement>(".tdg-body-table");
 
-    if (!shell || !grid || !headerViewport || !bodyViewport) return null;
+    if (
+      !shell ||
+      !grid ||
+      !headerViewport ||
+      !bodyViewport ||
+      !headerTable ||
+      !bodyTable
+    ) {
+      return null;
+    }
 
     const shellRect = shell.getBoundingClientRect();
     const gridRect = grid.getBoundingClientRect();
+    const headerTableRect = headerTable.getBoundingClientRect();
+    const bodyTableRect = bodyTable.getBoundingClientRect();
+    const headerActualOverflow = Math.max(
+      0,
+      headerViewport.scrollWidth - headerViewport.clientWidth
+    );
+    const bodyActualOverflow = Math.max(
+      0,
+      bodyViewport.scrollWidth - bodyViewport.clientWidth
+    );
+    const headerPaintedOverflow = Math.max(
+      0,
+      headerTableRect.width - headerViewport.clientWidth
+    );
+    const bodyPaintedOverflow = Math.max(
+      0,
+      bodyTableRect.width - bodyViewport.clientWidth
+    );
 
     return {
       shellClientWidth: shell.clientWidth,
@@ -50,21 +79,20 @@ test("keeps the grid contained inside a constrained parent shell", async ({
       bodyViewportScrollWidth: bodyViewport.scrollWidth,
       rootOverflowsParent: gridRect.width > shellRect.width + 0.5,
       shellHasHorizontalOverflow: shell.scrollWidth > shell.clientWidth + 0.5,
-      headerViewportHasHorizontalOverflow:
-        headerViewport.scrollWidth > headerViewport.clientWidth + 0.5,
-      bodyViewportHasHorizontalOverflow:
-        bodyViewport.scrollWidth > bodyViewport.clientWidth + 0.5,
+      headerOverflowDelta: Math.abs(
+        headerActualOverflow - headerPaintedOverflow
+      ),
+      bodyOverflowDelta: Math.abs(bodyActualOverflow - bodyPaintedOverflow),
+      tableWidthDelta: Math.abs(headerTableRect.width - bodyTableRect.width),
     };
   });
 
   expect(layout).not.toBeNull();
   expect(layout?.rootOverflowsParent).toBe(false);
   expect(layout?.shellHasHorizontalOverflow).toBe(false);
-  expect(layout?.headerViewportHasHorizontalOverflow).toBe(true);
-  expect(
-    Boolean(layout?.headerViewportHasHorizontalOverflow) ||
-      Boolean(layout?.bodyViewportHasHorizontalOverflow)
-  ).toBe(true);
+  expect(layout?.headerOverflowDelta ?? Infinity).toBeLessThanOrEqual(1);
+  expect(layout?.bodyOverflowDelta ?? Infinity).toBeLessThanOrEqual(1);
+  expect(layout?.tableWidthDelta ?? Infinity).toBeLessThanOrEqual(1);
 });
 
 test("keeps the horizontal scrollbar above cells and draggable", async ({
@@ -103,11 +131,13 @@ test("keeps the horizontal scrollbar above cells and draggable", async ({
     .locator('[data-slot="scroll-area-thumb"]')
     .first();
 
-  await expect.poll(async () => {
-    return viewport.evaluate((element) => {
-      return element.scrollWidth > element.clientWidth;
-    });
-  }).toBe(true);
+  await expect
+    .poll(async () => {
+      return viewport.evaluate((element) => {
+        return element.scrollWidth > element.clientWidth;
+      });
+    })
+    .toBe(true);
 
   await scrollArea.hover({
     position: {
@@ -161,7 +191,9 @@ test("keeps the horizontal scrollbar above cells and draggable", async ({
   );
   await page.mouse.up();
 
-  await expect.poll(async () => {
-    return viewport.evaluate((element) => element.scrollLeft);
-  }).toBeGreaterThan(beforeScrollLeft + 20);
+  await expect
+    .poll(async () => {
+      return viewport.evaluate((element) => element.scrollLeft);
+    })
+    .toBeGreaterThan(beforeScrollLeft + 20);
 });

--- a/tests/playwright/table-search.spec.ts
+++ b/tests/playwright/table-search.spec.ts
@@ -295,13 +295,33 @@ test.describe("optional table search", () => {
         );
         const rootStyle = getComputedStyle(element);
         const controlStyle = control ? getComputedStyle(control) : null;
+        const toRenderedRgba = (color: string | null) => {
+          if (!color) return null;
+
+          const canvas = document.createElement("canvas");
+          canvas.width = 1;
+          canvas.height = 1;
+          const context = canvas.getContext("2d");
+          if (!context) return null;
+
+          context.clearRect(0, 0, 1, 1);
+          context.fillStyle = color;
+          context.fillRect(0, 0, 1, 1);
+          return Array.from(context.getImageData(0, 0, 1, 1).data);
+        };
 
         return {
           backgroundColor: rootStyle.backgroundColor,
+          backgroundRgba: toRenderedRgba(rootStyle.backgroundColor),
           color: rootStyle.color,
+          colorRgba: toRenderedRgba(rootStyle.color),
           colorScheme: rootStyle.colorScheme,
           controlBackgroundColor: controlStyle?.backgroundColor ?? null,
+          controlBackgroundRgba: toRenderedRgba(
+            controlStyle?.backgroundColor ?? null
+          ),
           controlColor: controlStyle?.color ?? null,
+          controlColorRgba: toRenderedRgba(controlStyle?.color ?? null),
         };
       }),
       scope.evaluate((element) => {
@@ -314,10 +334,10 @@ test.describe("optional table search", () => {
       }),
     ]);
     expect(searchStyles.colorScheme).toBe("dark");
-    expect(searchStyles.backgroundColor).toBe(
-      searchStyles.controlBackgroundColor
+    expect(searchStyles.backgroundRgba).toEqual(
+      searchStyles.controlBackgroundRgba
     );
-    expect(searchStyles.color).toBe(searchStyles.controlColor);
+    expect(searchStyles.colorRgba).toEqual(searchStyles.controlColorRgba);
     expect(searchStyles.backgroundColor).not.toBe(hostStyles.backgroundColor);
     expect(searchStyles.color).not.toBe(hostStyles.color);
     await expect(page.getByTestId("search-remote-filtered-count")).toHaveText(

--- a/tests/playwright/tanstack-column-engine.spec.ts
+++ b/tests/playwright/tanstack-column-engine.spec.ts
@@ -1,0 +1,306 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const COLUMN_COUNT = 24;
+const COLUMN_WIDTH = 140;
+const MAX_GEOMETRY_DRIFT = 2;
+
+function header(grid: Locator, columnId: string) {
+  return grid.locator(
+    `[data-slot="grid-header-cell"][data-column-id="${columnId}"]`
+  );
+}
+
+function rowCell(grid: Locator, rowId: string, columnId: string) {
+  return grid.locator(
+    `[data-slot="grid-row"][data-row-id="${rowId}"] [data-column-id="${columnId}"]`
+  );
+}
+
+async function renderedColumnIds(locator: Locator) {
+  return locator.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("data-column-id"))
+  );
+}
+
+async function width(locator: Locator) {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  return box?.width ?? 0;
+}
+
+async function scrollToHorizontalEnd(viewport: Locator) {
+  await viewport.evaluate((element) => {
+    element.scrollLeft = element.scrollWidth;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+
+  await expect
+    .poll(() =>
+      viewport.evaluate(
+        (element) =>
+          element.scrollWidth - element.clientWidth - element.scrollLeft
+      )
+    )
+    .toBeLessThanOrEqual(1);
+}
+
+function captureRuntimeFailures(page: Page) {
+  const failures: string[] = [];
+  const renderLoopPattern =
+    /too many re-renders|maximum update depth|cannot update a component while rendering/i;
+
+  page.on("pageerror", (error) => failures.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error" && renderLoopPattern.test(message.text())) {
+      failures.push(message.text());
+    }
+  });
+
+  return failures;
+}
+
+test.describe("TanStack column engine regression contracts", () => {
+  test("virtual columns share one real scroll geometry without render feedback", async ({
+    page,
+  }) => {
+    const runtimeFailures = captureRuntimeFailures(page);
+
+    await page.goto("/compat/inovua-pending-parity?scenario=columns-scroll");
+
+    const scope = page.getByTestId("inovua-pending-parity-scenario");
+    const grid = scope.locator(".InovuaReactDataGrid.tdg-root").first();
+    const viewport = grid.locator('[data-slot="scroll-area-viewport"]');
+    const renderedHeaders = grid.locator(
+      '[data-slot="grid-header-cell"][data-column-id]'
+    );
+    const renderedCells = grid.locator(
+      '[data-slot="grid-row"][data-row-id="virtual-row-1"] [data-column-id]'
+    );
+
+    await expect(grid).toBeVisible();
+    await expect(renderedHeaders).not.toHaveCount(0);
+
+    const initialIds = {
+      headers: await renderedColumnIds(renderedHeaders),
+      cells: await renderedColumnIds(renderedCells),
+    };
+    expect(initialIds.headers).toEqual(initialIds.cells);
+    expect(initialIds.headers.length).toBeLessThan(COLUMN_COUNT);
+
+    const initialScrollGeometry = await viewport.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+    expect(initialScrollGeometry.scrollWidth).toBeGreaterThan(
+      initialScrollGeometry.clientWidth
+    );
+    expect(initialScrollGeometry.scrollWidth).toBeGreaterThanOrEqual(
+      COLUMN_COUNT * COLUMN_WIDTH
+    );
+    expect(initialScrollGeometry.scrollWidth).toBeLessThanOrEqual(
+      COLUMN_COUNT * COLUMN_WIDTH + COLUMN_COUNT
+    );
+
+    await scrollToHorizontalEnd(viewport);
+
+    const lastHeader = header(grid, "col-23");
+    const lastCell = rowCell(grid, "virtual-row-1", "col-23");
+    await expect(lastHeader).toBeVisible();
+    await expect(lastCell).toBeVisible();
+    await expect(header(grid, "col-00")).toHaveCount(0);
+
+    const farIds = {
+      headers: await renderedColumnIds(renderedHeaders),
+      cells: await renderedColumnIds(renderedCells),
+    };
+    expect(farIds.headers).toEqual(farIds.cells);
+    expect(farIds.headers.at(-1)).toBe("col-23");
+
+    const endGeometry = await viewport.evaluate((element) => {
+      const viewportRect = element.getBoundingClientRect();
+      const lastHeaderElement = document.querySelector<HTMLElement>(
+        '[data-slot="grid-header-cell"][data-column-id="col-23"]'
+      );
+      const lastCellElement = element.querySelector<HTMLElement>(
+        '[data-slot="grid-row"][data-row-id="virtual-row-1"] [data-column-id="col-23"]'
+      );
+      const lastHeaderRect = lastHeaderElement?.getBoundingClientRect();
+      const lastCellRect = lastCellElement?.getBoundingClientRect();
+
+      return {
+        remainingScroll:
+          element.scrollWidth - element.clientWidth - element.scrollLeft,
+        headerBodyRightDrift:
+          (lastHeaderRect?.right ?? 0) - (lastCellRect?.right ?? 0),
+        headerViewportRightGap:
+          viewportRect.right - (lastHeaderRect?.right ?? 0),
+        bodyViewportRightGap: viewportRect.right - (lastCellRect?.right ?? 0),
+      };
+    });
+    expect(Math.abs(endGeometry.remainingScroll)).toBeLessThanOrEqual(1);
+    expect(Math.abs(endGeometry.headerBodyRightDrift)).toBeLessThanOrEqual(
+      MAX_GEOMETRY_DRIFT
+    );
+    expect(Math.abs(endGeometry.headerViewportRightGap)).toBeLessThanOrEqual(
+      MAX_GEOMETRY_DRIFT
+    );
+    expect(Math.abs(endGeometry.bodyViewportRightGap)).toBeLessThanOrEqual(
+      MAX_GEOMETRY_DRIFT
+    );
+
+    const neighbourWidthBefore = await width(header(grid, "col-22"));
+    const lastWidthBefore = await width(lastHeader);
+    const scrollWidthBeforeResize = await viewport.evaluate(
+      (element) => element.scrollWidth
+    );
+
+    const lastResizer = lastHeader.locator('[data-slot="column-resizer"]');
+    await lastResizer.focus();
+    await lastResizer.press("ArrowRight");
+
+    // These fixture columns use controlled `width` values. A resize key press
+    // may propose a new width, but rendered geometry must remain owned by the
+    // controlled value and must not leak to the neighbouring virtual item.
+    expect(await width(lastHeader)).toBeCloseTo(lastWidthBefore, 1);
+    expect(await width(lastCell)).toBeCloseTo(lastWidthBefore, 1);
+    expect(await width(header(grid, "col-22"))).toBeCloseTo(
+      neighbourWidthBefore,
+      1
+    );
+    expect(await viewport.evaluate((element) => element.scrollWidth)).toBe(
+      scrollWidthBeforeResize
+    );
+
+    // Unmount and remount the resize target. Its controlled size must remain
+    // attached to the stable column id rather than to a virtual item index.
+    await scope.getByTestId("scroll-first-column").click();
+    await expect(header(grid, "col-00")).toBeVisible();
+    await expect(lastHeader).toHaveCount(0);
+    await scope.getByTestId("scroll-last-column").click();
+    await expect(lastHeader).toBeVisible();
+    expect(await width(lastHeader)).toBeCloseTo(lastWidthBefore, 1);
+    expect(await width(lastCell)).toBeCloseTo(lastWidthBefore, 1);
+
+    expect(runtimeFailures).toEqual([]);
+  });
+
+  test("imperative hide and reorder preserve geometry by column id", async ({
+    page,
+  }) => {
+    const runtimeFailures = captureRuntimeFailures(page);
+
+    await page.goto("/compat/computed-props");
+
+    const grid = page.locator(".InovuaReactDataGrid.tdg-root").first();
+    const firstRow = grid
+      .locator('[data-slot="grid-row"][data-row-id]')
+      .first();
+    await expect(grid).toBeVisible();
+    await expect(header(grid, "city")).toBeVisible();
+
+    const initialWidths = {
+      id: await width(header(grid, "id")),
+      name: await width(header(grid, "name")),
+    };
+    expect(initialWidths.name).toBeGreaterThan(initialWidths.id);
+
+    await page.getByTestId("compat-run").click();
+
+    await expect(header(grid, "city")).toHaveCount(0);
+    await expect
+      .poll(() =>
+        renderedColumnIds(grid.locator('[data-slot="grid-header-cell"]'))
+      )
+      .toEqual(["name", "id"]);
+    await expect
+      .poll(() => renderedColumnIds(firstRow.locator("[data-column-id]")))
+      .toEqual(["name", "id"]);
+
+    const reorderedWidths = {
+      name: await width(header(grid, "name")),
+      id: await width(header(grid, "id")),
+    };
+    // Hiding `city` legitimately reallocates free viewport space. Relative
+    // width identity must still follow each column after reordering; an
+    // index-keyed size cache would swap these values.
+    expect(reorderedWidths.name).toBeGreaterThan(reorderedWidths.id);
+
+    for (const columnId of ["name", "id"] as const) {
+      const currentHeader = header(grid, columnId);
+      const currentCell = firstRow.locator(`[data-column-id="${columnId}"]`);
+      expect(await width(currentCell)).toBeCloseTo(
+        reorderedWidths[columnId],
+        1
+      );
+
+      const [headerBox, cellBox] = await Promise.all([
+        currentHeader.boundingBox(),
+        currentCell.boundingBox(),
+      ]);
+      expect(headerBox).not.toBeNull();
+      expect(cellBox).not.toBeNull();
+      expect(
+        Math.abs((headerBox?.x ?? 0) - (cellBox?.x ?? 0))
+      ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT);
+    }
+
+    expect(runtimeFailures).toEqual([]);
+  });
+
+  test("imperative visibility can hide a column that is not user-hideable", async ({
+    page,
+  }) => {
+    const runtimeFailures = captureRuntimeFailures(page);
+
+    await page.goto("/compat/computed-props");
+
+    const probe = page.getByTestId("visibility-reconciliation-probe");
+    const grid = probe.locator(".InovuaReactDataGrid.tdg-root");
+    const hideLocked = probe.getByTestId("visibility-hide-locked");
+    await expect(grid).toBeVisible();
+    await expect(hideLocked).toBeEnabled();
+    await expect(header(grid, "locked")).toBeVisible();
+
+    await hideLocked.click();
+
+    await expect(header(grid, "locked")).toHaveCount(0);
+    await expect(header(grid, "alpha")).toBeVisible();
+    await expect(header(grid, "beta")).toBeVisible();
+    expect(runtimeFailures).toEqual([]);
+  });
+
+  test("a rerender still reconciles an unrelated column's visible prop", async ({
+    page,
+  }) => {
+    const runtimeFailures = captureRuntimeFailures(page);
+
+    await page.goto("/compat/computed-props");
+
+    const probe = page.getByTestId("visibility-reconciliation-probe");
+    const grid = probe.locator(".InovuaReactDataGrid.tdg-root");
+    const hideAlpha = probe.getByTestId("visibility-hide-alpha");
+    const toggleBetaProp = probe.getByTestId("visibility-toggle-beta-prop");
+    const betaProp = probe.getByTestId("visibility-beta-prop");
+    await expect(grid).toBeVisible();
+    await expect(hideAlpha).toBeEnabled();
+    await expect(header(grid, "alpha")).toBeVisible();
+    await expect(header(grid, "beta")).toBeVisible();
+
+    await hideAlpha.click();
+    await expect(header(grid, "alpha")).toHaveCount(0);
+
+    await toggleBetaProp.click();
+    await expect(betaProp).toHaveText("false");
+    await expect(header(grid, "beta")).toHaveCount(0);
+    await expect(header(grid, "alpha")).toHaveCount(0);
+    await expect(header(grid, "locked")).toBeVisible();
+
+    // Changing the prop back must restore beta without clearing alpha's
+    // independent imperative visibility override.
+    await toggleBetaProp.click();
+    await expect(betaProp).toHaveText("true");
+    await expect(header(grid, "beta")).toBeVisible();
+    await expect(header(grid, "alpha")).toHaveCount(0);
+    expect(runtimeFailures).toEqual([]);
+  });
+});

--- a/tests/playwright/ui-ux-regression.spec.ts
+++ b/tests/playwright/ui-ux-regression.spec.ts
@@ -1,0 +1,273 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function documentGeometry(page: Page) {
+  return page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    viewportWidth: window.innerWidth,
+    windowScrollY: window.scrollY,
+  }));
+}
+
+test.describe("documentation shell UI", () => {
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 1024, height: 768 },
+    { width: 390, height: 844 },
+    { width: 320, height: 568 },
+  ]) {
+    test(`contains scrolling at ${viewport.width}x${viewport.height}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.goto("/docs/reference/reactdatagrid");
+
+      const content = page.getByTestId("docs-content");
+      await expect(content).toBeVisible();
+      await expect
+        .poll(() =>
+          content.evaluate(
+            (element) => element.scrollHeight > element.clientHeight
+          )
+        )
+        .toBe(true);
+
+      const before = await documentGeometry(page);
+      expect(before.scrollWidth).toBeLessThanOrEqual(before.clientWidth);
+      expect(before.clientWidth).toBeLessThanOrEqual(before.viewportWidth);
+      expect(
+        await page.evaluate(() => ({
+          body: getComputedStyle(document.body).overflow,
+          root: getComputedStyle(document.documentElement).overflow,
+        }))
+      ).toEqual({ body: "hidden", root: "hidden" });
+
+      await page.evaluate(() => window.scrollTo({ top: 500 }));
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+
+      await content.hover();
+      await page.mouse.wheel(0, 500);
+      await expect
+        .poll(() => content.evaluate((element) => element.scrollTop))
+        .toBeGreaterThan(0);
+
+      if (viewport.width === 320) {
+        await page.goto("/examples/basic");
+        expect(
+          await page.evaluate(() => ({
+            body: getComputedStyle(document.body).overflow,
+            root: getComputedStyle(document.documentElement).overflow,
+          }))
+        ).toEqual({ body: "visible", root: "visible" });
+      }
+    });
+  }
+
+  test("keeps short-screen mobile navigation reachable", async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto("/docs/getting-started/quickstart");
+
+    const trigger = page.getByRole("button", {
+      name: "Open navigation menu",
+    });
+    await trigger.click();
+
+    const navigation = page.getByRole("navigation", {
+      name: "Mobile navigation",
+    });
+    await expect(navigation).toBeVisible();
+    await expect(
+      navigation.getByRole("link", { name: "GitHub", exact: true })
+    ).toBeInViewport();
+
+    await page.keyboard.press("Escape");
+    await expect(navigation).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  test("uses one accessible copy control per code block", async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, "__lastCopiedText", {
+        configurable: true,
+        writable: true,
+        value: "",
+      });
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: async (text: string) => {
+            (window as { __lastCopiedText: string }).__lastCopiedText = text;
+          },
+        },
+      });
+    });
+    await page.goto("/docs/getting-started/quickstart");
+
+    const block = page.getByTestId("copy-code-block-tsx");
+    const copyButton = block.getByRole("button", {
+      name: "Copy tsx code button",
+    });
+
+    await expect(block).not.toHaveAttribute("role", "button");
+    await expect(block).not.toHaveAttribute("tabindex", "0");
+    await expect(copyButton).toHaveCount(1);
+    expect(
+      await copyButton.evaluate((element) =>
+        Boolean(element.parentElement?.closest('[role="button"]'))
+      )
+    ).toBe(false);
+
+    await copyButton.focus();
+    await copyButton.press("Enter");
+    await expect(copyButton.getByText("Copied")).toBeAttached();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as { __lastCopiedText: string }).__lastCopiedText
+        )
+      )
+      .not.toBe("");
+  });
+
+  test("keeps long-form prose at a readable measure", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/docs/getting-started/styling");
+
+    const paragraph = page.locator("#packaged-css").locator("p").first();
+    await expect(paragraph).toBeVisible();
+    await expect
+      .poll(() =>
+        paragraph.evaluate((element) => element.getBoundingClientRect().width)
+      )
+      .toBeLessThanOrEqual(768);
+  });
+});
+
+test.describe("grid interaction UI", () => {
+  test("restores a visible focus ring after closing a column menu", async ({
+    page,
+  }) => {
+    await page.goto("/examples/columns");
+    await page.addStyleTag({
+      content: "button { box-shadow: none !important; }",
+    });
+
+    const trigger = page
+      .getByRole("button", { name: "Column menu", exact: true })
+      .first();
+    await trigger.press("Enter");
+    const firstItem = page
+      .getByRole("menu", { name: "Column menu" })
+      .getByRole("menuitem")
+      .first();
+    await expect(firstItem).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await expect(firstItem).toBeHidden();
+    await expect(trigger).toBeFocused();
+    await expect(trigger).toHaveCSS("outline-style", "none");
+    expect(
+      await trigger.evaluate((element) => element.matches(":focus-visible"))
+    ).toBe(true);
+    await expect
+      .poll(() =>
+        trigger.evaluate((element) => getComputedStyle(element).boxShadow)
+      )
+      .toContain("inset");
+
+    const resizeHandle = page.locator('[data-slot="column-resizer"]').first();
+    const resizeHandleBox = await resizeHandle.boundingBox();
+    expect(resizeHandleBox?.width).toBeGreaterThanOrEqual(24);
+  });
+
+  test("closes mobile sorting with Escape and restores focus", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/examples/mobile-transform");
+
+    const trigger = page.getByRole("button", { name: /^Sort(?:$|:)/ });
+    await trigger.click();
+    const panel = page.locator('[data-slot="mobile-sort-panel"]');
+    await expect(panel).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(panel).toBeHidden();
+    await expect(trigger).toBeFocused();
+
+    await trigger.click();
+    const sortBy = page.getByRole("combobox", {
+      name: "Sort by",
+      exact: true,
+    });
+    await expect(panel).toBeVisible();
+    await sortBy.focus();
+    await page.keyboard.press("Escape");
+
+    await expect(panel).toBeHidden();
+    await expect(trigger).toBeFocused();
+
+    await trigger.click();
+    await sortBy.click();
+    const listbox = page.getByRole("listbox");
+    await expect(listbox).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(listbox).toBeHidden();
+    await expect(panel).toBeVisible();
+    await expect(sortBy).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(panel).toBeHidden();
+    await expect(trigger).toBeFocused();
+
+    await trigger.click();
+    await page.getByRole("button", { name: "Apply sort", exact: true }).click();
+    await expect(panel).toBeHidden();
+    await expect(trigger).toBeFocused();
+
+    await trigger.click();
+    await page.getByRole("button", { name: "Clear sort", exact: true }).click();
+    await expect(panel).toBeHidden();
+    await expect(trigger).toBeFocused();
+    const geometry = await documentGeometry(page);
+    expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth);
+  });
+
+  test("keeps the narrow mobile toolbar and sort panel in bounds", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto("/examples/mobile-transform");
+
+    const grid = page.locator('[data-slot="mobile-grid-list"]');
+    const search = page.getByRole("search", { name: "Search all fields" });
+    const sort = page.getByRole("button", { name: "Sort", exact: true });
+    const columns = page.getByRole("button", {
+      name: "Display columns",
+      exact: true,
+    });
+    const gridBox = await grid.boundingBox();
+    expect(gridBox).not.toBeNull();
+
+    for (const control of [search, sort, columns]) {
+      const box = await control.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.x).toBeGreaterThanOrEqual(gridBox!.x);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(
+        gridBox!.x + gridBox!.width
+      );
+      expect(box!.height).toBeGreaterThanOrEqual(36);
+    }
+
+    await sort.click();
+    const panelBox = await page
+      .locator('[data-slot="mobile-sort-panel"]')
+      .boundingBox();
+    expect(panelBox).not.toBeNull();
+    expect(panelBox!.x).toBeGreaterThanOrEqual(gridBox!.x);
+    expect(panelBox!.x + panelBox!.width).toBeLessThanOrEqual(
+      gridBox!.x + gridBox!.width
+    );
+
+    const geometry = await documentGeometry(page);
+    expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth);
+  });
+});

--- a/tests/playwright/users-column-visibility.spec.ts
+++ b/tests/playwright/users-column-visibility.spec.ts
@@ -1,0 +1,378 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Timing is a secondary guard because CI scheduling can be noisy. DOM identity
+// below is the deterministic signal for the expensive renderer churn.
+const MAX_FRAME_DELAY_MS = 250;
+const MAX_LONG_TASK_MS = 250;
+const MAX_GEOMETRY_DRIFT_PX = 2;
+const MAX_LAYOUT_DRIFT_PX = 1;
+const OPTIONAL_COLUMNS = [
+  { label: "Failed logins", id: "failed_login_attempts" },
+  { label: "Last login", id: "date_last_successful_login" },
+  { label: "Password changed", id: "date_pwdchanged" },
+  { label: "Language", id: "lang" },
+] as const;
+
+function captureRuntimeFailures(page: Page) {
+  const failures: string[] = [];
+  const renderLoopPattern =
+    /too many re-renders|maximum update depth|cannot update a component while rendering/i;
+
+  page.on("pageerror", (error) => failures.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error" && renderLoopPattern.test(message.text())) {
+      failures.push(message.text());
+    }
+  });
+
+  return failures;
+}
+
+test("Visible columns toggles stay responsive and geometrically consistent", async ({
+  page,
+}) => {
+  const runtimeFailures = captureRuntimeFailures(page);
+
+  // This width exposed the old icon-driven wrap: toggling a hidden column
+  // changed the toolbar from one line to two and moved the complete grid.
+  await page.setViewportSize({ width: 940, height: 900 });
+  await page.goto("/users");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const toggleGroup = preview.getByRole("group", {
+    name: "Visible column toggles",
+  });
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const failedLoginsButton = toggleGroup.getByRole("button", {
+    name: "Failed logins",
+    exact: true,
+  });
+  const failedLoginsHeader = grid.locator(
+    '[data-slot="grid-header-cell"][data-column-id="failed_login_attempts"]'
+  );
+
+  await expect(preview).toBeVisible();
+  await expect(grid).toBeVisible();
+  await expect(failedLoginsButton).toBeVisible();
+  await expect(failedLoginsHeader).toHaveCount(0);
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "false");
+
+  const mountedRows = grid.locator('[data-slot="grid-row"][data-row-id]');
+  await expect(mountedRows.first()).toBeVisible();
+  const mountedRowCount = await mountedRows.count();
+  expect(mountedRowCount).toBeGreaterThan(0);
+  expect(mountedRowCount).toBeLessThan(48);
+
+  // Column toggles are text controls. Their state must not add an eye icon or
+  // change the button's accessible name when a column is hidden.
+  const initialIconCount = await toggleGroup.locator("svg").count();
+
+  // Exercise one browser-driven round trip before the in-page probe. This
+  // catches pointer/focus regressions that a synthetic click alone would miss.
+  await failedLoginsButton.click();
+  await expect(failedLoginsHeader).toBeVisible();
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "true");
+  await failedLoginsButton.click();
+  await expect(failedLoginsHeader).toHaveCount(0);
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "false");
+
+  const result = await preview.evaluate(
+    async (previewElement, optionalColumns) => {
+      const gridElement = previewElement.querySelector<HTMLElement>(
+        ".InovuaReactDataGrid.tdg-root"
+      );
+      const group = previewElement.querySelector<HTMLElement>(
+        '[role="group"][aria-label="Visible column toggles"]'
+      );
+      if (!gridElement || !group) {
+        return { error: "Visibility controls or grid were not found" } as const;
+      }
+
+      const longTasks: number[] = [];
+      const observer =
+        typeof PerformanceObserver === "function" &&
+        PerformanceObserver.supportedEntryTypes.includes("longtask")
+          ? new PerformanceObserver((list) => {
+              for (const entry of list.getEntries()) {
+                longTasks.push(entry.duration);
+              }
+            })
+          : null;
+
+      observer?.observe({ entryTypes: ["longtask"] });
+
+      const nextFrame = () =>
+        new Promise<number>((resolve) => requestAnimationFrame(resolve));
+
+      // Do not attribute route initialization or first-paint work to toggles.
+      await nextFrame();
+      await nextFrame();
+
+      const samples: Array<{
+        frameDelay: number;
+        geometryDrift: number;
+        headerIds: string[];
+        bodyIds: string[];
+        expectedVisible: boolean;
+        visibleOnNextFrame: boolean;
+        iconCount: number;
+        label: string;
+        pressedOnNextFrame: boolean;
+        replacedContentNodes: number;
+        buttonWidthDrift: number;
+        groupHeightDrift: number;
+        gridTopDrift: number;
+      }> = [];
+
+      const toggleColumn = async (
+        target: { label: string; id: string },
+        expectedVisible: boolean
+      ) => {
+        const button = Array.from(
+          group.querySelectorAll<HTMLButtonElement>("button")
+        ).find((element) => element.textContent?.trim() === target.label);
+        if (!button) throw new Error(`Missing ${target.label} toggle`);
+
+        // Existing renderers are the strongest deterministic proxy for work:
+        // adding one column must not remount content in every unaffected cell.
+        const preservedContent = new Map<string, Element>();
+        for (const rowElement of gridElement.querySelectorAll<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id]'
+        )) {
+          for (const cellElement of rowElement.querySelectorAll<HTMLElement>(
+            `[data-column-id]:not([data-column-id="${target.id}"])`
+          )) {
+            const content = cellElement.querySelector(".tdg-cell-content > *");
+            if (!content) continue;
+
+            preservedContent.set(
+              `${rowElement.dataset.rowId}\u0000${cellElement.dataset.columnId}`,
+              content
+            );
+          }
+        }
+
+        const buttonWidthBefore = button.getBoundingClientRect().width;
+        const groupHeightBefore = group.getBoundingClientRect().height;
+        const gridTopBefore = gridElement.getBoundingClientRect().top;
+        const clickTime = performance.now();
+        button.click();
+        const frameTime = await nextFrame();
+
+        const header = gridElement.querySelector<HTMLElement>(
+          `[data-slot="grid-header-cell"][data-column-id="${target.id}"]`
+        );
+        const firstRow = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id]'
+        );
+        const headers = Array.from(
+          gridElement.querySelectorAll<HTMLElement>(
+            '[data-slot="grid-header-cell"][data-column-id]'
+          )
+        );
+        const cells = Array.from(
+          firstRow?.querySelectorAll<HTMLElement>("[data-column-id]") ?? []
+        );
+        const headerIds = headers.map(
+          (element) => element.dataset.columnId ?? ""
+        );
+        const bodyIds = cells.map((element) => element.dataset.columnId ?? "");
+        let replacedContentNodes = 0;
+        for (const [key, previousContent] of preservedContent) {
+          const [rowId, columnId] = key.split("\u0000");
+          const currentContent = gridElement.querySelector(
+            `[data-slot="grid-row"][data-row-id="${rowId}"] ` +
+              `[data-column-id="${columnId}"] .tdg-cell-content > *`
+          );
+
+          if (currentContent !== previousContent) replacedContentNodes += 1;
+        }
+        const geometryDrift = headers.reduce(
+          (maximum, headerElement, index) => {
+            const cellElement = cells[index];
+            if (!cellElement) return Number.POSITIVE_INFINITY;
+
+            const headerRect = headerElement.getBoundingClientRect();
+            const cellRect = cellElement.getBoundingClientRect();
+            return Math.max(
+              maximum,
+              Math.abs(headerRect.left - cellRect.left),
+              Math.abs(headerRect.width - cellRect.width)
+            );
+          },
+          0
+        );
+
+        samples.push({
+          frameDelay: frameTime - clickTime,
+          geometryDrift,
+          headerIds,
+          bodyIds,
+          expectedVisible,
+          visibleOnNextFrame: Boolean(header),
+          iconCount: group.querySelectorAll("svg").length,
+          label: target.label,
+          pressedOnNextFrame:
+            button.getAttribute("aria-pressed") === String(expectedVisible),
+          replacedContentNodes,
+          buttonWidthDrift: Math.abs(
+            button.getBoundingClientRect().width - buttonWidthBefore
+          ),
+          groupHeightDrift: Math.abs(
+            group.getBoundingClientRect().height - groupHeightBefore
+          ),
+          gridTopDrift: Math.abs(
+            gridElement.getBoundingClientRect().top - gridTopBefore
+          ),
+        });
+      };
+
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        for (const target of optionalColumns) {
+          await toggleColumn(target, true);
+        }
+        for (const target of [...optionalColumns].reverse()) {
+          await toggleColumn(target, false);
+        }
+      }
+
+      // Let PerformanceObserver deliver any entry generated by the final
+      // toggle before disconnecting it.
+      await nextFrame();
+      observer?.disconnect();
+
+      return {
+        error: null,
+        longTasks,
+        samples,
+      };
+    },
+    OPTIONAL_COLUMNS
+  );
+
+  expect(result.error).toBeNull();
+  if (result.error) return;
+
+  expect(result.samples).toHaveLength(16);
+  for (const sample of result.samples) {
+    // A click is a discrete React event, so the complete header/body state must
+    // be committed before the next paint rather than settling over many frames.
+    expect(sample.visibleOnNextFrame).toBe(sample.expectedVisible);
+    expect(sample.pressedOnNextFrame).toBe(true);
+    expect(sample.headerIds).toEqual(sample.bodyIds);
+    expect(sample.geometryDrift).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(sample.replacedContentNodes).toBe(0);
+    expect(sample.buttonWidthDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
+    expect(sample.groupHeightDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
+    expect(sample.gridTopDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
+    expect(sample.frameDelay).toBeLessThan(MAX_FRAME_DELAY_MS);
+  }
+
+  expect(Math.max(0, ...result.longTasks)).toBeLessThan(MAX_LONG_TASK_MS);
+  await expect(failedLoginsHeader).toHaveCount(0);
+
+  const filterLifecycle = await preview.evaluate(async (previewElement) => {
+    const initialGridRoot = previewElement.querySelector<HTMLElement>(
+      ".InovuaReactDataGrid.tdg-root"
+    );
+    const group = previewElement.querySelector<HTMLElement>(
+      '[role="group"][aria-label="Visible column toggles"]'
+    );
+    const failedLoginsToggle = Array.from(
+      group?.querySelectorAll<HTMLButtonElement>("button") ?? []
+    ).find((element) => element.textContent?.trim() === "Failed logins");
+
+    if (!initialGridRoot || !failedLoginsToggle) {
+      return { error: "Grid root or visibility toggle was not found" } as const;
+    }
+
+    let rootWasDisconnected = false;
+    const rootObserver = new MutationObserver(() => {
+      if (!initialGridRoot.isConnected) rootWasDisconnected = true;
+    });
+    rootObserver.observe(previewElement, { childList: true, subtree: true });
+
+    const nextFrame = () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    const findButton = (label: string) =>
+      Array.from(
+        previewElement.querySelectorAll<HTMLButtonElement>("button")
+      ).find((element) => element.textContent?.trim() === label);
+    const currentGridRoot = () =>
+      previewElement.querySelector<HTMLElement>(
+        ".InovuaReactDataGrid.tdg-root"
+      );
+    const failedLoginsIsVisible = () =>
+      Boolean(
+        currentGridRoot()?.querySelector(
+          '[data-slot="grid-header-cell"][data-column-id="failed_login_attempts"]'
+        )
+      );
+
+    failedLoginsToggle.click();
+    await nextFrame();
+    const afterColumnShow = {
+      sameRoot: currentGridRoot() === initialGridRoot,
+      columnVisible: failedLoginsIsVisible(),
+      pressed: failedLoginsToggle.getAttribute("aria-pressed"),
+    };
+
+    const hideFilters = findButton("Hide filters");
+    hideFilters?.click();
+    await nextFrame();
+    const afterFilterHide = {
+      sameRoot: currentGridRoot() === initialGridRoot,
+      columnVisible: failedLoginsIsVisible(),
+      filterCellCount:
+        currentGridRoot()?.querySelectorAll(".tdg-filter-cell").length ?? -1,
+    };
+
+    const showFilters = findButton("Show filters");
+    showFilters?.click();
+    await nextFrame();
+    const afterFilterShow = {
+      sameRoot: currentGridRoot() === initialGridRoot,
+      columnVisible: failedLoginsIsVisible(),
+      filterCellCount:
+        currentGridRoot()?.querySelectorAll(".tdg-filter-cell").length ?? -1,
+    };
+
+    rootObserver.disconnect();
+
+    return {
+      error: hideFilters && showFilters ? null : "Filter toggle was not found",
+      afterColumnShow,
+      afterFilterHide,
+      afterFilterShow,
+      rootWasDisconnected,
+    };
+  });
+
+  expect(filterLifecycle.error).toBeNull();
+  if (filterLifecycle.error) return;
+
+  expect(filterLifecycle.afterColumnShow).toEqual({
+    sameRoot: true,
+    columnVisible: true,
+    pressed: "true",
+  });
+  expect(filterLifecycle.afterFilterHide).toEqual({
+    sameRoot: true,
+    columnVisible: true,
+    filterCellCount: 0,
+  });
+  expect(filterLifecycle.afterFilterShow.sameRoot).toBe(true);
+  expect(filterLifecycle.afterFilterShow.columnVisible).toBe(true);
+  expect(filterLifecycle.afterFilterShow.filterCellCount).toBeGreaterThan(0);
+  expect(filterLifecycle.rootWasDisconnected).toBe(false);
+  await expect(failedLoginsHeader).toBeVisible();
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "true");
+
+  expect(runtimeFailures).toEqual([]);
+  expect(
+    Math.max(
+      initialIconCount,
+      ...result.samples.map((sample) => sample.iconCount)
+    )
+  ).toBe(0);
+});

--- a/tests/types/type-computed-props-compat.ts
+++ b/tests/types/type-computed-props-compat.ts
@@ -41,6 +41,7 @@ export function assertComputedPropsCompat(
   api.scrollToCell?.({ rowIndex: 0, columnIndex: 0 });
   api.scrollToColumn?.(0);
   api.setShowHeader?.(false);
+  api.setShowZebraRows((current) => !current);
   api.setEnableFiltering?.(false);
   api.setLoading?.(false);
   api.selectAll?.();

--- a/tests/types/type-computed-props-compat.ts
+++ b/tests/types/type-computed-props-compat.ts
@@ -48,6 +48,16 @@ export function assertComputedPropsCompat(
   api.deselectAll?.();
   virtualList.scrollToIndex(0);
   virtualList.smoothScrollTo(0);
+  virtualList.smoothScrollTo(120, null);
+  virtualList.smoothScrollTo(120, (value) => value.toFixed());
+  virtualList.smoothScrollTo(
+    120,
+    { duration: 0, orientation: "horizontal" },
+    (value) => value.toFixed()
+  );
+
+  // @ts-expect-error smoothScrollTo follows Inovua's pixel/config contract.
+  virtualList.smoothScrollTo(0, { direction: "top" });
 
   // @ts-expect-error TanStack Virtualizer internals must not be exposed here.
   virtualList.getVirtualItems();

--- a/tests/types/type-default-props-compat.ts
+++ b/tests/types/type-default-props-compat.ts
@@ -31,6 +31,10 @@ const defaultFilterTypes: TypeFilterTypes = defaultExportDefaults.filterTypes;
 const namedFilterTypes: TypeFilterTypes = namedExportDefaults.filterTypes;
 const defaultTheme: string = defaultExportDefaults.theme;
 const defaultVirtualized: boolean = defaultExportDefaults.virtualized;
+const defaultVirtualizeColumnsThreshold: number =
+  defaultExportDefaults.virtualizeColumnsThreshold;
+const defaultEmptyText: TypeDataGridProps["emptyText"] =
+  defaultExportDefaults.emptyText;
 
 export const defaultPropsCompat = {
   defaultPropsShape,
@@ -38,5 +42,7 @@ export const defaultPropsCompat = {
   namedFilterTypes,
   defaultTheme,
   defaultVirtualized,
+  defaultVirtualizeColumnsThreshold,
+  defaultEmptyText,
   stringOperatorCount: defaultFilterTypes.string.operators.length,
 };

--- a/tests/types/type-default-props-compat.ts
+++ b/tests/types/type-default-props-compat.ts
@@ -33,6 +33,7 @@ const defaultTheme: string = defaultExportDefaults.theme;
 const defaultVirtualized: boolean = defaultExportDefaults.virtualized;
 const defaultVirtualizeColumnsThreshold: number =
   defaultExportDefaults.virtualizeColumnsThreshold;
+const defaultLiveColumnResize: boolean = defaultExportDefaults.liveColumnResize;
 const defaultEmptyText: TypeDataGridProps["emptyText"] =
   defaultExportDefaults.emptyText;
 
@@ -43,6 +44,7 @@ export const defaultPropsCompat = {
   defaultTheme,
   defaultVirtualized,
   defaultVirtualizeColumnsThreshold,
+  defaultLiveColumnResize,
   defaultEmptyText,
   stringOperatorCount: defaultFilterTypes.string.operators.length,
 };

--- a/tests/types/type-issue-17-fixed-prop-contract.ts
+++ b/tests/types/type-issue-17-fixed-prop-contract.ts
@@ -28,11 +28,10 @@ type Issue17ImplementedProp =
   | "defaultShowZebraRows"
   | "enableSelection"
   | "virtualizeColumnsThreshold"
-  | "virtualizeColumns";
-
-type Issue17UnsupportedProp =
-  | "emptyText"
+  | "virtualizeColumns"
   | "onColumnFilterValueChange";
+
+type Issue17UnsupportedProp = "emptyText";
 
 type AssertNever<T extends never> = T;
 
@@ -303,8 +302,18 @@ export const issue17EmptyTextReproduction = acceptGridProps({
 
 export const issue17ColumnFilterCallbackReproduction = acceptGridProps({
   ...issue17FixedContractProps,
-  // @ts-expect-error This callback is not part of the approved public surface.
-  onColumnFilterValueChange: () => {},
+  onColumnFilterValueChange: (event) => {
+    const columnId: string = event.columnId;
+    const columnIndex: number = event.columnIndex;
+    const filterName: string = event.filterValue.name;
+    const cellColumnIndex: number | undefined =
+      event.cellProps?.computedVisibleIndex;
+
+    void columnId;
+    void columnIndex;
+    void filterName;
+    void cellColumnIndex;
+  },
 });
 
 export const issue17EnableSelectionReproduction = acceptGridProps({

--- a/tests/types/type-issue-17-fixed-prop-contract.ts
+++ b/tests/types/type-issue-17-fixed-prop-contract.ts
@@ -29,9 +29,10 @@ type Issue17ImplementedProp =
   | "enableSelection"
   | "virtualizeColumnsThreshold"
   | "virtualizeColumns"
-  | "onColumnFilterValueChange";
+  | "onColumnFilterValueChange"
+  | "emptyText";
 
-type Issue17UnsupportedProp = "emptyText";
+type Issue17UnsupportedProp = never;
 
 type AssertNever<T extends never> = T;
 
@@ -296,8 +297,17 @@ export async function exerciseIssue17EditingApi(
 
 export const issue17EmptyTextReproduction = acceptGridProps({
   ...issue17FixedContractProps,
-  // @ts-expect-error Use i18n.noRecords instead of an emptyText root prop.
   emptyText: "No issue #17 rows match the current view",
+});
+
+export const issue17EmptyTextRendererReproduction = acceptGridProps({
+  ...issue17FixedContractProps,
+  emptyText: () =>
+    React.createElement(
+      "button",
+      { type: "button" },
+      "No issue #17 rows match the current view"
+    ),
 });
 
 export const issue17ColumnFilterCallbackReproduction = acceptGridProps({

--- a/tests/types/type-issue-17-fixed-prop-contract.ts
+++ b/tests/types/type-issue-17-fixed-prop-contract.ts
@@ -26,12 +26,13 @@ type Issue17ImplementedProp =
   | "onEditValueChange"
   | "showZebraRows"
   | "defaultShowZebraRows"
-  | "enableSelection";
+  | "enableSelection"
+  | "virtualizeColumnsThreshold"
+  | "virtualizeColumns";
 
 type Issue17UnsupportedProp =
   | "emptyText"
-  | "onColumnFilterValueChange"
-  | "virtualizeColumnsThreshold";
+  | "onColumnFilterValueChange";
 
 type AssertNever<T extends never> = T;
 
@@ -313,6 +314,6 @@ export const issue17EnableSelectionReproduction = acceptGridProps({
 
 export const issue17VirtualizeColumnsThresholdReproduction = acceptGridProps({
   ...issue17FixedContractProps,
-  // @ts-expect-error Column virtualization thresholds are not public API.
   virtualizeColumnsThreshold: 20,
+  virtualizeColumns: true,
 });

--- a/tests/types/type-issue-17-fixed-prop-contract.ts
+++ b/tests/types/type-issue-17-fixed-prop-contract.ts
@@ -25,12 +25,12 @@ type Issue17ImplementedProp =
   | "onEditCancel"
   | "onEditValueChange"
   | "showZebraRows"
-  | "defaultShowZebraRows";
+  | "defaultShowZebraRows"
+  | "enableSelection";
 
 type Issue17UnsupportedProp =
   | "emptyText"
   | "onColumnFilterValueChange"
-  | "enableSelection"
   | "virtualizeColumnsThreshold";
 
 type AssertNever<T extends never> = T;
@@ -308,7 +308,6 @@ export const issue17ColumnFilterCallbackReproduction = acceptGridProps({
 
 export const issue17EnableSelectionReproduction = acceptGridProps({
   ...issue17FixedContractProps,
-  // @ts-expect-error Selection is configured through the supported selection props.
   enableSelection: true,
 });
 

--- a/tests/types/type-live-column-resize.ts
+++ b/tests/types/type-live-column-resize.ts
@@ -1,0 +1,23 @@
+import type { TypeDataGridProps } from "../../src/main";
+
+const baseProps = {
+  idProperty: "id",
+  columns: [{ name: "name", defaultWidth: 180 }],
+  dataSource: [{ id: 1, name: "Ada Lovelace" }],
+} satisfies TypeDataGridProps;
+
+export const deferredResizeProps = {
+  ...baseProps,
+  liveColumnResize: false,
+} satisfies TypeDataGridProps;
+
+export const interactiveResizeProps = {
+  ...baseProps,
+  liveColumnResize: true,
+  onColumnResize: (info, context) => {
+    void info.column;
+    void info.width;
+    void info.flex;
+    void context.reservedViewportWidth;
+  },
+} satisfies TypeDataGridProps;


### PR DESCRIPTION
## Summary

- completes the planned Inovua compatibility contracts for filtering callbacks, selection enablement, column virtualization, empty states, sizing, row presentation, editing stability, and touch resizing
- stabilizes TanStack-driven row/column geometry, flex allocation, editing identity, and high-frequency visibility/resize interactions
- adds opt-in `liveColumnResize` while preserving the deferred Inovua-compatible default
- updates public documentation, compatibility ledgers, manual checkpoints, and focused regression coverage

## Notable contracts

- `onColumnFilterValueChange` ordering and imperative payloads
- `enableSelection` precedence, inference, checkbox, and controlled-state behavior
- `virtualizeColumnsThreshold` and explicit column-virtualization overrides
- `emptyText` for literal, i18n, React-node, loading, filtered, remote, and mobile states
- numeric, functional, and natural row heights with bounds and remeasurement
- editing identity through row/column reordering
- functional zebra-row updates and mobile touch resizing
- live header/body column resizing with completion-only callbacks, controlled-width reconciliation, cancellation, and listener cleanup
- lag-free Users-example column visibility with stable unaffected DOM

## Validation

- `176 passed` — complete serial Chromium Playwright suite locally
- focused live-resize suite repeated three times: `18 passed`
- GitHub source-type, packed-build, and full end-to-end jobs passed on the final #47 commit before it joined this branch
- library build, declarations, packed TypeScript consumers, CSS scope, optional-search boundary, Prettier, scoped ESLint, and clean diff checks
- `npm pack --dry-run`: `@geovi/the-datagrid@0.0.8`

Merging this PR produces the exact `main` tree that will be tagged as `v0.0.8`. npm publication is intentionally left to the maintainer.
