### PR TITLE
Polish live resizing, row sizing, and column visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ method allowlists.
   `defaultWidth`/`defaultFlex`, `minWidth`/`maxWidth` clamps, proportional flex
   allocation, the upstream 40px implicit column minimum (while preserving an
   explicit `minWidth={0}`), deterministic autosizing from a bounded row sample,
-  mouse drag resizing with `onColumnResize`, and double-click autosizing. Rows
-  support numeric, functional, and natural measured heights with
+  mouse/pen/touch drag resizing with `onColumnResize`, opt-in
+  animation-frame-coalesced `liveColumnResize`, and double-click autosizing.
+  Rows support numeric, functional, and natural measured heights with
   minimum/maximum bounds and width-change remeasurement.
 - **Filtering and sorting:** controlled and uncontrolled state, local operators,
   custom filter registries and editors, filter operator menus, single sorting,
@@ -572,16 +573,17 @@ sentinels (`-1`, `false`, and `0`).
 
 ### Columns
 
-| Prop                   | Type                        | Default | Description                                                                 |
-| ---------------------- | --------------------------- | ------- | --------------------------------------------------------------------------- |
-| `columnOrder`          | `string[]`                  | -       | Ordered array of column ids/names                                           |
-| `onColumnOrderChange`  | `(order: string[]) => void` | -       | Fired when column order changes; drag reordering requires this callback     |
-| `reorderColumns`       | `boolean`                   | `true`  | Disable user drag reordering while continuing to render `columnOrder`       |
-| `resizable`            | `boolean`                   | `true`  | Enable header resize handles                                                |
-| `onColumnResize`       | `(info, context) => void`   | -       | Reports proposed width/flex and reserved viewport width                     |
-| `enableColumnAutosize` | `boolean`                   | `true`  | Estimate widths from a bounded row sample when no numeric width is supplied |
-| `skipHeaderOnAutoSize` | `boolean`                   | `false` | Skip header text when estimating an automatic width                         |
-| `showColumnMenuTool`   | `boolean`                   | `false` | Show the header menu tool                                                   |
+| Prop                   | Type                        | Default | Description                                                                   |
+| ---------------------- | --------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `columnOrder`          | `string[]`                  | -       | Ordered array of column ids/names                                             |
+| `onColumnOrderChange`  | `(order: string[]) => void` | -       | Fired when column order changes; drag reordering requires this callback       |
+| `reorderColumns`       | `boolean`                   | `true`  | Disable user drag reordering while continuing to render `columnOrder`         |
+| `resizable`            | `boolean`                   | `true`  | Enable header resize handles                                                  |
+| `liveColumnResize`     | `boolean`                   | `false` | Resize header and body geometry during drag; callbacks remain completion-only |
+| `onColumnResize`       | `(info, context) => void`   | -       | Reports proposed width/flex and reserved viewport width                       |
+| `enableColumnAutosize` | `boolean`                   | `true`  | Estimate widths from a bounded row sample when no numeric width is supplied   |
+| `skipHeaderOnAutoSize` | `boolean`                   | `false` | Skip header text when estimating an automatic width                           |
+| `showColumnMenuTool`   | `boolean`                   | `false` | Show the header menu tool                                                     |
 
 ### Filtering
 

--- a/examples/src/ColumnsGridExample.tsx
+++ b/examples/src/ColumnsGridExample.tsx
@@ -405,6 +405,8 @@ export default function ColumnsGridExample() {
           filteredRowsCount={setFilteredRows}
           onColumnOrderChange={setColumnOrder}
           virtualized
+          rowHeight={naturalHeight ? null : 56}
+          minRowHeight={52}
           columnUserSelect
           showCellBorders={showCellBorders}
           i18n={i18n}

--- a/examples/src/DefaultPropsCompatPage.tsx
+++ b/examples/src/DefaultPropsCompatPage.tsx
@@ -27,6 +27,7 @@ export default function DefaultPropsCompatPage() {
     `virtualized=${String(defaultProps.virtualized)}`,
     `virtualizeColumnsThreshold=${defaultProps.virtualizeColumnsThreshold}`,
     `allowMobileTransform=${String(defaultProps.allowMobileTransform)}`,
+    `liveColumnResize=${String(defaultProps.liveColumnResize)}`,
     `rowHeight=${defaultProps.rowHeight}`,
     `emptyText=${String(defaultProps.emptyText)}`,
   ].join(",");

--- a/examples/src/InovuaParityCompatPage.tsx
+++ b/examples/src/InovuaParityCompatPage.tsx
@@ -28,6 +28,7 @@ type ParityScenario =
   | "bounded-row-height"
   | "natural-resize"
   | "resize-callback"
+  | "live-resize"
   | "zebra-default"
   | "zebra-disabled"
   | "editing-default"
@@ -42,7 +43,8 @@ type ParityScenario =
   | "row-style-static"
   | "row-style-contract"
   | "flex"
-  | "controlled-width";
+  | "controlled-width"
+  | "controlled-live-resize";
 
 const scenarios = new Set<ParityScenario>([
   "natural-height",
@@ -50,6 +52,7 @@ const scenarios = new Set<ParityScenario>([
   "bounded-row-height",
   "natural-resize",
   "resize-callback",
+  "live-resize",
   "zebra-default",
   "zebra-disabled",
   "editing-default",
@@ -65,6 +68,7 @@ const scenarios = new Set<ParityScenario>([
   "row-style-contract",
   "flex",
   "controlled-width",
+  "controlled-live-resize",
 ]);
 
 type ScenarioGroupId = "rows" | "columns" | "appearance" | "editing";
@@ -132,6 +136,13 @@ const scenarioGroups: ScenarioGroup[] = [
           "Drag the Description header edge and compare the latest callback width with the rendered header width.",
       },
       {
+        id: "live-resize",
+        label: "Live column resize",
+        summary: "The column follows the pointer without a resize proxy.",
+        instructions:
+          "Drag the Description header edge. Header and body geometry should update together before release, while the completion callback still fires exactly once on drop.",
+      },
+      {
         id: "flex",
         label: "Flex allocation",
         summary: "Remaining width split through flex and defaultFlex.",
@@ -144,6 +155,13 @@ const scenarioGroups: ScenarioGroup[] = [
         summary: "A supplied width remains authoritative during drag.",
         instructions:
           "Drag Controlled to a proposed width and inspect the clamped callback payload—it should render at 180px until the button supplies 300px.",
+      },
+      {
+        id: "controlled-live-resize",
+        label: "Controlled live resize",
+        summary: "A controlled width previews live without losing ownership.",
+        instructions:
+          "Drag Controlled and hold to inspect the live preview. On release it returns to 180px unless the consumer applies the completion proposal.",
       },
     ],
   },
@@ -862,8 +880,25 @@ function sanitizeResizeEvent(
   };
 }
 
-function ResizeCallbackScenario(): React.ReactNode {
+function ResizeCallbackScenario(props: {
+  liveColumnResize?: boolean;
+}): React.ReactNode {
   const [events, setEvents] = React.useState<ResizeEvent[]>([]);
+  const rows = React.useMemo(
+    () =>
+      props.liveColumnResize
+        ? Array.from({ length: 500 }, (_, index) => ({
+            id: `live-resize-${index + 1}`,
+            description: `Interactive resize row ${index + 1}`,
+            filler: `Stable virtualized content ${index + 1}`,
+          }))
+        : baseRows.map((row) => ({
+            ...row,
+            description: `${row.name} description`,
+            filler: row.city,
+          })),
+    [props.liveColumnResize]
+  );
   const columns = React.useMemo<TypeColumns>(
     () => [
       {
@@ -892,14 +927,11 @@ function ResizeCallbackScenario(): React.ReactNode {
         <CommonGrid
           idProperty="id"
           columns={columns}
-          dataSource={baseRows.map((row) => ({
-            ...row,
-            description: `${row.name} description`,
-            filler: row.city,
-          }))}
+          dataSource={rows}
           columnOrder={["description", "filler"]}
-          virtualized={false}
+          virtualized={Boolean(props.liveColumnResize)}
           resizable
+          liveColumnResize={props.liveColumnResize}
           onColumnResize={(info, context) => {
             const event = sanitizeResizeEvent(info, context);
             setEvents((current) => [...current, event]);
@@ -2348,7 +2380,9 @@ function FlexScenario(): React.ReactNode {
   );
 }
 
-function ControlledWidthScenario(): React.ReactNode {
+function ControlledWidthScenario(props: {
+  liveColumnResize?: boolean;
+}): React.ReactNode {
   const [controlledWidth, setControlledWidth] = React.useState(180);
   const [events, setEvents] = React.useState<ResizeEvent[]>([]);
   const columns = React.useMemo<TypeColumns>(
@@ -2399,6 +2433,7 @@ function ControlledWidthScenario(): React.ReactNode {
           columnOrder={["controlled", "filler"]}
           virtualized={false}
           resizable
+          liveColumnResize={props.liveColumnResize}
           onColumnResize={(info, context) => {
             const event = sanitizeResizeEvent(info, context);
             setEvents((current) => [...current, event]);
@@ -2421,6 +2456,8 @@ function ScenarioContent(props: { scenario: ParityScenario }): React.ReactNode {
       return <NaturalResizeScenario />;
     case "resize-callback":
       return <ResizeCallbackScenario />;
+    case "live-resize":
+      return <ResizeCallbackScenario liveColumnResize />;
     case "zebra-default":
       return <ZebraScenario disabled={false} />;
     case "zebra-disabled":
@@ -2451,6 +2488,8 @@ function ScenarioContent(props: { scenario: ParityScenario }): React.ReactNode {
       return <FlexScenario />;
     case "controlled-width":
       return <ControlledWidthScenario />;
+    case "controlled-live-resize":
+      return <ControlledWidthScenario liveColumnResize />;
     default:
       return null;
   }

--- a/examples/src/SelectionGridExample.tsx
+++ b/examples/src/SelectionGridExample.tsx
@@ -297,7 +297,10 @@ export default function SelectionGridExample() {
     columns.map((column) => column.name ?? "")
   );
   const [filteredCount, setFilteredCount] = useState(rows.length);
-  const selectedMap = useMemo(() => extractSelectedMap(selectedRows), [selectedRows]);
+  const selectedMap = useMemo(
+    () => extractSelectedMap(selectedRows),
+    [selectedRows]
+  );
 
   const selectedAccounts = useMemo(() => {
     return Object.values(selectedMap);
@@ -405,6 +408,8 @@ export default function SelectionGridExample() {
           filteredRowsCount={setFilteredCount}
           onColumnOrderChange={setColumnOrder}
           virtualized={false}
+          rowHeight={null}
+          minRowHeight={52}
           columnUserSelect
           enableColumnAutosize={false}
           skipHeaderOnAutoSize={false}

--- a/examples/src/UsersGridExample.tsx
+++ b/examples/src/UsersGridExample.tsx
@@ -1,5 +1,5 @@
-import { Download, EyeOff, Filter, FilterX, Pencil, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Download, Filter, FilterX, Pencil, Trash2 } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import ReactDataGrid, {
   DateFilter,
@@ -7,6 +7,7 @@ import ReactDataGrid, {
   SelectFilter,
   type TypeColumn,
   type TypeColumns,
+  type TypeComputedProps,
   type TypeFilterValue,
   type TypeI18n,
   type TypeShowCellBorders,
@@ -33,6 +34,13 @@ const roleOptions = [
 ];
 
 const languageOptions = ["en", "de", "fr", "it"];
+const dateTimeFormatter = new Intl.DateTimeFormat("en-GB", {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
 
 type ExportFormat = "csv" | "json";
 
@@ -70,11 +78,17 @@ function getColumnId(column: TypeColumn): string {
 }
 
 function getColumnLabel(column: TypeColumn): string {
-  return typeof column.header === "string" ? column.header : getColumnId(column);
+  return typeof column.header === "string"
+    ? column.header
+    : getColumnId(column);
 }
 
 function extractCellValue(valueOrCellProps: unknown): unknown {
-  if (typeof valueOrCellProps === "object" && valueOrCellProps !== null && "value" in valueOrCellProps) {
+  if (
+    typeof valueOrCellProps === "object" &&
+    valueOrCellProps !== null &&
+    "value" in valueOrCellProps
+  ) {
     return (valueOrCellProps as { value?: unknown }).value;
   }
 
@@ -82,7 +96,11 @@ function extractCellValue(valueOrCellProps: unknown): unknown {
 }
 
 function extractRowData(valueOrCellProps: unknown): ExampleUser | null {
-  if (typeof valueOrCellProps === "object" && valueOrCellProps !== null && "data" in valueOrCellProps) {
+  if (
+    typeof valueOrCellProps === "object" &&
+    valueOrCellProps !== null &&
+    "data" in valueOrCellProps
+  ) {
     return (valueOrCellProps as { data?: ExampleUser }).data ?? null;
   }
 
@@ -95,13 +113,7 @@ function formatDateTime(value: unknown): string {
   const date = value instanceof Date ? value : new Date(String(value));
   if (Number.isNaN(date.getTime())) return String(value);
 
-  return new Intl.DateTimeFormat("en-GB", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
+  return dateTimeFormatter.format(date);
 }
 
 function formatBooleanPill(value: boolean) {
@@ -118,7 +130,10 @@ function formatBooleanPill(value: boolean) {
   );
 }
 
-function getUserFieldValue(row: ExampleUser, columnId: keyof ExampleUser): ExampleUser[keyof ExampleUser] {
+function getUserFieldValue(
+  row: ExampleUser,
+  columnId: keyof ExampleUser
+): ExampleUser[keyof ExampleUser] {
   return row[columnId];
 }
 
@@ -135,8 +150,12 @@ function createUsers(): ExampleUser[] {
       csrolename: role,
       csemail: `user.${id}@ikarus.demo`,
       failed_login_attempts: index % 5,
-      date_last_successful_login: new Date(Date.UTC(2026, 1, 10 + (index % 18), 8 + (index % 9), 15)).toISOString(),
-      date_pwdchanged: new Date(Date.UTC(2026, 0, 2 + (index % 24), 6 + (index % 7), 45)).toISOString(),
+      date_last_successful_login: new Date(
+        Date.UTC(2026, 1, 10 + (index % 18), 8 + (index % 9), 15)
+      ).toISOString(),
+      date_pwdchanged: new Date(
+        Date.UTC(2026, 0, 2 + (index % 24), 6 + (index % 7), 45)
+      ).toISOString(),
       lang: language,
       disabled,
       tfa_enabled: tfaEnabled,
@@ -165,9 +184,15 @@ function downloadTextFile(filename: string, content: string, mimeType: string) {
 }
 
 function orderColumns(columns: TypeColumns, order: string[]) {
-  const indexed = new Map(columns.map((column) => [getColumnId(column), column]));
-  const ordered = order.map((columnId) => indexed.get(columnId)).filter((column): column is TypeColumn => Boolean(column));
-  const remaining = columns.filter((column) => !order.includes(getColumnId(column)));
+  const indexed = new Map(
+    columns.map((column) => [getColumnId(column), column])
+  );
+  const ordered = order
+    .map((columnId) => indexed.get(columnId))
+    .filter((column): column is TypeColumn => Boolean(column));
+  const remaining = columns.filter(
+    (column) => !order.includes(getColumnId(column))
+  );
   return [...ordered, ...remaining];
 }
 
@@ -180,9 +205,14 @@ function UsersToolbar({
   onToggleFilters,
   onExport,
 }: UsersToolbarProps) {
-  const orderedColumns = useMemo(() => orderColumns(columns, order), [columns, order]);
+  const orderedColumns = useMemo(
+    () => orderColumns(columns, order),
+    [columns, order]
+  );
 
-  const visibleColumnNames = selectedColumns.filter((name) => name !== FILTER_RESERVED_COLNAME);
+  const visibleColumnNames = selectedColumns.filter(
+    (name) => name !== FILTER_RESERVED_COLNAME
+  );
   const visibleSet = new Set(visibleColumnNames);
 
   function toggleColumn(columnName: string) {
@@ -193,7 +223,9 @@ function UsersToolbar({
     }
 
     if (isVisible) {
-      onSelectedColumnsChange(visibleColumnNames.filter((name) => name !== columnName));
+      onSelectedColumnsChange(
+        visibleColumnNames.filter((name) => name !== columnName)
+      );
       return;
     }
 
@@ -205,12 +237,16 @@ function UsersToolbar({
       <div className="flex flex-col gap-1">
         <div className="text-sm font-medium">Visible columns</div>
         <div className="text-xs text-muted-foreground">
-          Toggle columns, export the current dataset shape, and show or hide the filter row.
+          Toggle columns, export the current dataset shape, and show or hide the
+          filter row.
         </div>
       </div>
 
       <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-        <ButtonGroup aria-label="Visible column toggles" className="flex max-w-full flex-wrap gap-2">
+        <ButtonGroup
+          aria-label="Visible column toggles"
+          className="flex max-w-full flex-wrap gap-2"
+        >
           {orderedColumns.map((column) => {
             const columnId = getColumnId(column);
             const isVisible = visibleSet.has(columnId);
@@ -222,9 +258,9 @@ function UsersToolbar({
                 variant={isVisible ? "secondary" : "outline"}
                 size="sm"
                 className="rounded-md"
+                aria-pressed={isVisible}
                 onClick={() => toggleColumn(columnId)}
               >
-                {isVisible ? null : <EyeOff className="size-3.5" />}
                 {getColumnLabel(column)}
               </Button>
             );
@@ -243,14 +279,27 @@ function UsersToolbar({
               <DropdownMenuLabel>Download example data</DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuGroup>
-                <DropdownMenuItem onSelect={() => onExport("csv")}>Export CSV</DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => onExport("json")}>Export JSON</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onExport("csv")}>
+                  Export CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onExport("json")}>
+                  Export JSON
+                </DropdownMenuItem>
               </DropdownMenuGroup>
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <Button type="button" variant={filtersActive ? "secondary" : "outline"} size="sm" onClick={onToggleFilters}>
-            {filtersActive ? <FilterX className="size-4" /> : <Filter className="size-4" />}
+          <Button
+            type="button"
+            variant={filtersActive ? "secondary" : "outline"}
+            size="sm"
+            onClick={onToggleFilters}
+          >
+            {filtersActive ? (
+              <FilterX className="size-4" />
+            ) : (
+              <Filter className="size-4" />
+            )}
             {filtersActive ? "Hide filters" : "Show filters"}
           </Button>
         </div>
@@ -272,14 +321,29 @@ export default function UsersGridExample({
       { name: "csuserid", operator: "eq", type: "string", value: "" },
       { name: "csrolename", operator: "eq", type: "select", value: null },
       { name: "csemail", operator: "contains", type: "string", value: "" },
-      { name: "failed_login_attempts", operator: "eq", type: "number", value: null },
-      { name: "date_last_successful_login", operator: "afterOrOn", type: "date", value: null },
-      { name: "date_pwdchanged", operator: "afterOrOn", type: "date", value: null },
+      {
+        name: "failed_login_attempts",
+        operator: "eq",
+        type: "number",
+        value: null,
+      },
+      {
+        name: "date_last_successful_login",
+        operator: "afterOrOn",
+        type: "date",
+        value: null,
+      },
+      {
+        name: "date_pwdchanged",
+        operator: "afterOrOn",
+        type: "date",
+        value: null,
+      },
       { name: "lang", operator: "eq", type: "select", value: null },
       { name: "disabled", operator: "eq", type: "select", value: null },
       { name: "tfa_enabled", operator: "eq", type: "select", value: null },
     ],
-    [],
+    []
   );
 
   const baseColumns = useMemo<TypeColumns>(
@@ -314,6 +378,7 @@ export default function UsersGridExample({
         header: "Failed logins",
         defaultWidth: 152,
         defaultHidden: true,
+        visible: false,
         type: "number",
         filterType: "number",
         filterEditor: NumberFilter,
@@ -322,6 +387,7 @@ export default function UsersGridExample({
         name: "date_last_successful_login",
         header: "Last login",
         defaultHidden: true,
+        visible: false,
         defaultWidth: 212,
         filterType: "date",
         filterEditor: DateFilter,
@@ -335,6 +401,7 @@ export default function UsersGridExample({
         name: "date_pwdchanged",
         header: "Password changed",
         defaultHidden: true,
+        visible: false,
         defaultWidth: 212,
         filterType: "date",
         filterEditor: DateFilter,
@@ -349,11 +416,15 @@ export default function UsersGridExample({
         header: "Language",
         defaultWidth: 132,
         defaultHidden: true,
+        visible: false,
         filterType: "select",
         filterEditor: SelectFilter,
         filterEditorProps: {
           placeholder: "All languages",
-          dataSource: languageOptions.map((language) => ({ id: language, label: language.toUpperCase() })),
+          dataSource: languageOptions.map((language) => ({
+            id: language,
+            label: language.toUpperCase(),
+          })),
         },
         render: (valueOrCellProps: unknown) =>
           String(extractCellValue(valueOrCellProps) ?? "").toUpperCase(),
@@ -431,12 +502,16 @@ export default function UsersGridExample({
         },
       },
     ],
-    [],
+    []
   );
 
-  const [columnOrder, setColumnOrder] = useState<string[]>(() => baseColumns.map(getColumnId));
+  const [columnOrder, setColumnOrder] = useState<string[]>(() =>
+    baseColumns.map(getColumnId)
+  );
   const [selectedColumns, setSelectedColumns] = useState<string[]>(() => [
-    ...baseColumns.filter((column) => column.defaultHidden !== true).map(getColumnId),
+    ...baseColumns
+      .filter((column) => column.defaultHidden !== true)
+      .map(getColumnId),
     FILTER_RESERVED_COLNAME,
   ]);
   const [filteredRows, setFilteredRows] = useState(rows.length);
@@ -444,22 +519,33 @@ export default function UsersGridExample({
   const filtersActive = selectedColumns.includes(FILTER_RESERVED_COLNAME);
   const visibleColumnNames = useMemo(
     () => selectedColumns.filter((name) => name !== FILTER_RESERVED_COLNAME),
-    [selectedColumns],
+    [selectedColumns]
   );
+  const gridApiRef = useRef<TypeComputedProps | null>(null);
 
-  const gridColumns = useMemo(
-    () => baseColumns.filter((column) => visibleColumnNames.includes(getColumnId(column))),
-    [baseColumns, visibleColumnNames],
-  );
-  const gridColumnOrder = useMemo(
-    () =>
-      orderColumns(baseColumns, columnOrder)
-        .map((column) => getColumnId(column))
-        .filter((columnId) => visibleColumnNames.includes(columnId)),
-    [baseColumns, columnOrder, visibleColumnNames],
+  const captureGridApi = useCallback(
+    (ref: { current: TypeComputedProps | null }) => {
+      gridApiRef.current = ref.current;
+    },
+    []
   );
 
   function handleSelectedColumnsChange(nextColumns: string[]) {
+    const currentVisible = new Set(visibleColumnNames);
+    const nextVisible = new Set(nextColumns);
+
+    // Visibility is presentation state. Keep the complete column model stable
+    // so toggling one button does not recreate TanStack definitions, rerun the
+    // local data pipeline, or remount every filter editor.
+    for (const column of baseColumns) {
+      const columnId = getColumnId(column);
+      const wasVisible = currentVisible.has(columnId);
+      const willBeVisible = nextVisible.has(columnId);
+      if (wasVisible !== willBeVisible) {
+        gridApiRef.current?.setColumnVisible?.(columnId, willBeVisible);
+      }
+    }
+
     const filtersMarker = filtersActive ? [FILTER_RESERVED_COLNAME] : [];
     setSelectedColumns([...nextColumns, ...filtersMarker]);
   }
@@ -468,16 +554,18 @@ export default function UsersGridExample({
     setSelectedColumns((current) =>
       current.includes(FILTER_RESERVED_COLNAME)
         ? current.filter((name) => name !== FILTER_RESERVED_COLNAME)
-        : [...current, FILTER_RESERVED_COLNAME],
+        : [...current, FILTER_RESERVED_COLNAME]
     );
     setFilteredRows(rows.length);
   }
 
   function handleExport(format: ExportFormat) {
-    const exportColumns = orderColumns(baseColumns, columnOrder).filter((column) => {
-      const columnId = getColumnId(column);
-      return selectedColumns.includes(columnId) && columnId !== "actions";
-    });
+    const exportColumns = orderColumns(baseColumns, columnOrder).filter(
+      (column) => {
+        const columnId = getColumnId(column);
+        return selectedColumns.includes(columnId) && columnId !== "actions";
+      }
+    );
 
     const exportedRows = rows.map((row) =>
       Object.fromEntries(
@@ -488,21 +576,34 @@ export default function UsersGridExample({
               ? row[columnId as "disabled" | "tfa_enabled"]
                 ? "Yes"
                 : "No"
-              : columnId === "date_last_successful_login" || columnId === "date_pwdchanged"
-                ? formatDateTime(row[columnId as "date_last_successful_login" | "date_pwdchanged"])
+              : columnId === "date_last_successful_login" ||
+                  columnId === "date_pwdchanged"
+                ? formatDateTime(
+                    row[
+                      columnId as
+                        | "date_last_successful_login"
+                        | "date_pwdchanged"
+                    ]
+                  )
                 : getUserFieldValue(row, columnId as keyof ExampleUser);
 
           return [getColumnLabel(column), value];
-        }),
-      ),
+        })
+      )
     );
 
     if (format === "json") {
-      downloadTextFile("users-grid.json", JSON.stringify(exportedRows, null, 2), "application/json;charset=utf-8");
+      downloadTextFile(
+        "users-grid.json",
+        JSON.stringify(exportedRows, null, 2),
+        "application/json;charset=utf-8"
+      );
       return;
     }
 
-    const header = exportColumns.map((column) => escapeCsv(getColumnLabel(column))).join(",");
+    const header = exportColumns
+      .map((column) => escapeCsv(getColumnLabel(column)))
+      .join(",");
     const body = exportedRows
       .map((row) =>
         exportColumns
@@ -510,11 +611,15 @@ export default function UsersGridExample({
             const key = getColumnLabel(column);
             return escapeCsv(row[key]);
           })
-          .join(","),
+          .join(",")
       )
       .join("\n");
 
-    downloadTextFile("users-grid.csv", `${header}\n${body}`, "text/csv;charset=utf-8");
+    downloadTextFile(
+      "users-grid.csv",
+      `${header}\n${body}`,
+      "text/csv;charset=utf-8"
+    );
   }
 
   return (
@@ -522,16 +627,19 @@ export default function UsersGridExample({
       <div className="space-y-1">
         <h2 className="text-lg font-semibold">Users-style example</h2>
         <p className="text-sm text-muted-foreground">
-          A fuller integration example with optional columns, export actions, row actions, and mixed string, select,
-          number, and date filters.
+          A fuller integration example with optional columns, export actions,
+          row actions, and mixed string, select, number, and date filters.
         </p>
       </div>
 
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>
-          Filtered users: <span className="font-mono">{filteredRows}</span> / {rows.length}
+          Filtered users: <span className="font-mono">{filteredRows}</span> /{" "}
+          {rows.length}
         </span>
-        <span>Reorder columns directly in the grid to update the toolbar order.</span>
+        <span>
+          Reorder columns directly in the grid to update the toolbar order.
+        </span>
       </div>
 
       <UsersToolbar
@@ -544,27 +652,29 @@ export default function UsersGridExample({
         onExport={handleExport}
       />
 
-      <ReactDataGrid
-        key={filtersActive ? "users-grid-filters-on" : "users-grid-filters-off"}
-        theme={theme}
-        idProperty="csuserid"
-        columns={gridColumns}
-        dataSource={rows}
-        columnOrder={gridColumnOrder}
-        enableColumnFilterContextMenu
-        enableColumnAutosize
-        skipHeaderOnAutoSize={false}
-        resizable={resizable}
-        enableFiltering={filtersActive}
-        defaultFilterValue={defaultFilterValue}
-        filteredRowsCount={setFilteredRows}
-        onColumnOrderChange={setColumnOrder}
-        virtualized
-        columnUserSelect
-        showCellBorders={showCellBorders}
-        i18n={i18n}
-        showColumnMenuTool={false}
-      />
+      <div className="h-[32rem] min-h-0" data-testid="users-grid-viewport">
+        <ReactDataGrid
+          theme={theme}
+          idProperty="csuserid"
+          columns={baseColumns}
+          dataSource={rows}
+          columnOrder={columnOrder}
+          enableColumnFilterContextMenu
+          enableColumnAutosize
+          skipHeaderOnAutoSize={false}
+          resizable={resizable}
+          enableFiltering={filtersActive}
+          defaultFilterValue={defaultFilterValue}
+          filteredRowsCount={setFilteredRows}
+          onColumnOrderChange={setColumnOrder}
+          virtualized
+          columnUserSelect
+          showCellBorders={showCellBorders}
+          i18n={i18n}
+          showColumnMenuTool={false}
+          handle={captureGridApi}
+        />
+      </div>
     </section>
   );
 }

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -596,6 +596,13 @@ const reactDataGridPropSections: ReferenceSection[] = [
           "Turns header drag-resize handles on or off. Mouse, pen, and touch use the same pointer lifecycle. Controlled column.width stays authoritative; uncontrolled defaultWidth can retain a drag result.",
       },
       {
+        name: "liveColumnResize",
+        type: "boolean",
+        defaultValue: "false",
+        description:
+          "the-datagrid extension that updates header and body column geometry while the resize pointer moves. Pointer events are coalesced to animation frames, and onColumnResize remains a single completion callback. When false, the grid keeps the Inovua-compatible resize proxy until drop.",
+      },
+      {
         name: "onColumnResize",
         type: "(info, context) => void",
         defaultValue: "-",
@@ -1218,6 +1225,20 @@ function createInovuaStatusPage(): DocsPage {
               flex columns are reported with flex payloads in the same commit.
             </p>
             <p>
+              <strong className="text-foreground">
+                Live preview extension.
+              </strong>{" "}
+              Inovua Community uses a resize proxy and commits on release.
+              the-datagrid preserves that behavior by default and adds the
+              opt-in <code>liveColumnResize</code> prop. Live mode updates the
+              matching header/body column and table geometry at most once per
+              animation frame without rerendering the row model for every
+              pointer event. <code>onColumnResize</code> remains
+              completion-only, cancellation restores the original geometry, and
+              a controlled width returns to its prop value unless the consumer
+              applies the proposal.
+            </p>
+            <p>
               <strong className="text-foreground">Flex allocation.</strong>{" "}
               Inovua uses <code>flex</code> and <code>defaultFlex</code> to
               distribute remaining viewport width by weight: subject to min/max
@@ -1231,7 +1252,8 @@ function createInovuaStatusPage(): DocsPage {
             <p>
               <strong className="text-foreground">Verified behavior.</strong>{" "}
               Focused tests cover the resize payload, controlled-width
-              authority, proportional flex allocation, and natural-row
+              authority, live header/body geometry, burst coalescing and
+              cleanup, proportional flex allocation, and natural-row
               remeasurement after width changes.
             </p>
             <p>
@@ -3241,6 +3263,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
   enableColumnAutosize: true,
   skipHeaderOnAutoSize: false,
   resizable: true,
+  liveColumnResize: false,
   enableFiltering: true,
   filterTypes: DEFAULT_FILTER_TYPES,
   virtualized: true,
@@ -3381,7 +3404,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "mouse, pen, touch / double-click",
         defaultValue: "enabled",
         description:
-          "Enabled handles use pointer capture, clamp drag widths, and report completion through onColumnResize for mouse, pen, and touch. Cancel, blur, responsive changes, and unmount clean up the session. Controlled width/flex remain prop-owned; defaultWidth/defaultFlex are grid-owned starts. Double-click reruns one-column estimation, and natural rows remeasure after width changes.",
+          "Enabled handles use pointer capture, clamp drag widths, and report completion through onColumnResize for mouse, pen, and touch. liveColumnResize opts into animation-frame-coalesced header/body geometry during the gesture; the default keeps Inovua's resize proxy. Cancel, blur, responsive changes, and unmount clean up the session. Controlled width/flex remain prop-owned; defaultWidth/defaultFlex are grid-owned starts. Double-click reruns one-column estimation, and natural rows remeasure after width changes.",
       },
       {
         name: "Header column menu",

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -110,6 +110,7 @@ type ReactDataGridDefaultPropName =
   | "enableColumnAutosize"
   | "skipHeaderOnAutoSize"
   | "resizable"
+  | "liveColumnResize"
   | "enableFiltering"
   | "filterTypes"
   | "virtualized"
@@ -136,6 +137,7 @@ const REACT_DATA_GRID_DEFAULT_PROPS: ReactDataGridDefaultProps = {
   enableColumnAutosize: true,
   skipHeaderOnAutoSize: false,
   resizable: true,
+  liveColumnResize: false,
   enableFiltering: true,
   filterTypes: DEFAULT_FILTER_TYPES,
   virtualized: true,
@@ -158,6 +160,94 @@ type ReactDataGridComponent = ((
 ) => React.ReactElement) & {
   defaultProps: ReactDataGridDefaultProps;
 };
+
+type LiveColumnResizePreview = {
+  baseColumnWidth: number;
+  columns: {
+    element: HTMLTableColElement;
+    inlineWidth: string;
+  }[];
+  tables: {
+    element: HTMLTableElement;
+    inlineWidth: string;
+    renderedWidth: number;
+  }[];
+};
+
+type ColumnResizeSession = {
+  columnId: string;
+  column: TypeColumn;
+  inputType: "mouse" | "pointer";
+  pointerId: number | null;
+  startX: number;
+  startWidth: number;
+  nextWidth: number;
+  columnLeft: number;
+  minWidth: number;
+  maxWidth: number;
+  liveColumnResize: boolean;
+  appliedPreviewWidth: number | null;
+  preview: LiveColumnResizePreview | null;
+};
+
+function captureLiveColumnResizePreview(
+  surface: HTMLElement,
+  columnId: string,
+  baseColumnWidth: number
+): LiveColumnResizePreview {
+  const columns = Array.from(
+    surface.querySelectorAll<HTMLTableColElement>("col[data-column-id]")
+  )
+    .filter((element) => element.dataset.columnId === columnId)
+    .map((element) => ({
+      element,
+      inlineWidth: element.style.width,
+    }));
+  const owningTables = new Set<HTMLTableElement>();
+
+  for (const { element } of columns) {
+    const table = element.closest("table");
+    if (table instanceof HTMLTableElement) owningTables.add(table);
+  }
+
+  return {
+    baseColumnWidth,
+    columns,
+    tables: Array.from(owningTables, (element) => ({
+      element,
+      inlineWidth: element.style.width,
+      renderedWidth: element.getBoundingClientRect().width,
+    })),
+  };
+}
+
+function applyLiveColumnResizePreview(
+  session: ColumnResizeSession,
+  nextWidth: number
+) {
+  if (!session.preview || session.appliedPreviewWidth === nextWidth) return;
+
+  const widthDelta = nextWidth - session.preview.baseColumnWidth;
+  for (const { element } of session.preview.columns) {
+    element.style.width = `${nextWidth}px`;
+  }
+  for (const { element, renderedWidth } of session.preview.tables) {
+    element.style.width = `${Math.max(1, renderedWidth + widthDelta)}px`;
+  }
+  session.appliedPreviewWidth = nextWidth;
+}
+
+function restoreLiveColumnResizePreview(session: ColumnResizeSession | null) {
+  if (!session?.preview || session.appliedPreviewWidth == null) return;
+
+  for (const { element, inlineWidth } of session.preview.columns) {
+    element.style.width = inlineWidth;
+  }
+  for (const { element, inlineWidth } of session.preview.tables) {
+    element.style.width = inlineWidth;
+  }
+  session.appliedPreviewWidth = null;
+}
 
 type InternalSearchController = {
   value: string;
@@ -358,6 +448,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     enableColumnAutosize = REACT_DATA_GRID_DEFAULT_PROPS.enableColumnAutosize,
     skipHeaderOnAutoSize = REACT_DATA_GRID_DEFAULT_PROPS.skipHeaderOnAutoSize,
     resizable = REACT_DATA_GRID_DEFAULT_PROPS.resizable,
+    liveColumnResize = REACT_DATA_GRID_DEFAULT_PROPS.liveColumnResize,
 
     enableFiltering = REACT_DATA_GRID_DEFAULT_PROPS.enableFiltering,
     onColumnFilterValueChange,
@@ -2811,21 +2902,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const resizeProxyElementRef = React.useRef<HTMLDivElement | null>(null);
   const resizeProxyFrameRef = React.useRef<number | null>(null);
   const resizeProxyNextLeftRef = React.useRef<number | null>(null);
+  const liveColumnResizeFrameRef = React.useRef<number | null>(null);
+  const liveColumnResizeNextWidthRef = React.useRef<number | null>(null);
   const [resizingColumnId, setResizingColumnId] = React.useState<string | null>(
     null
   );
-  const resizeSessionRef = React.useRef<{
-    columnId: string;
-    column: TypeColumn;
-    inputType: "mouse" | "pointer";
-    pointerId: number | null;
-    startX: number;
-    startWidth: number;
-    nextWidth: number;
-    columnLeft: number;
-    minWidth: number;
-    maxWidth: number;
-  } | null>(null);
+  const resizeSessionRef = React.useRef<ColumnResizeSession | null>(null);
   const resizeCleanupRef = React.useRef<(() => void) | null>(null);
 
   const cancelResizeProxyFrame = React.useCallback(() => {
@@ -2849,6 +2931,65 @@ function ReactDataGrid(props: TypeDataGridProps) {
       proxy.style.transform = `translate3d(${left}px, 0, 0)`;
     });
   }, []);
+
+  const cancelLiveColumnResizeFrame = React.useCallback(() => {
+    if (liveColumnResizeFrameRef.current != null) {
+      window.cancelAnimationFrame(liveColumnResizeFrameRef.current);
+      liveColumnResizeFrameRef.current = null;
+    }
+    liveColumnResizeNextWidthRef.current = null;
+  }, []);
+
+  const scheduleLiveColumnResizePreview = React.useCallback(
+    (nextWidth: number) => {
+      liveColumnResizeNextWidthRef.current = nextWidth;
+      if (liveColumnResizeFrameRef.current != null) return;
+
+      liveColumnResizeFrameRef.current = window.requestAnimationFrame(() => {
+        liveColumnResizeFrameRef.current = null;
+        const activeSession = resizeSessionRef.current;
+        const width = liveColumnResizeNextWidthRef.current;
+        liveColumnResizeNextWidthRef.current = null;
+        if (!activeSession?.liveColumnResize || width == null) return;
+
+        applyLiveColumnResizePreview(activeSession, width);
+      });
+    },
+    []
+  );
+
+  React.useLayoutEffect(() => {
+    const activeSession = resizeSessionRef.current;
+    const preview = activeSession?.preview;
+    if (!activeSession?.liveColumnResize || !preview) return;
+
+    const latestColumn = renderedColumnLayout.find(
+      (column) => column.id === activeSession.columnId
+    );
+    if (!latestColumn) return;
+
+    // React can receive a newer controlled width while a pointer gesture is
+    // still active. Keep that latest React-owned geometry as the cancellation
+    // baseline, then place the transient pointer preview back on top before
+    // paint. This prevents cleanup from restoring a stale drag-start width.
+    preview.baseColumnWidth = latestColumn.width;
+    for (const column of preview.columns) {
+      column.inlineWidth = `${latestColumn.width}px`;
+    }
+
+    const latestTableInlineWidth = tableMinWidth ? `${tableMinWidth}px` : "";
+    for (const table of preview.tables) {
+      table.inlineWidth = latestTableInlineWidth;
+      table.renderedWidth =
+        tableMinWidth ?? table.element.getBoundingClientRect().width;
+    }
+
+    const appliedPreviewWidth = activeSession.appliedPreviewWidth;
+    if (appliedPreviewWidth == null) return;
+
+    activeSession.appliedPreviewWidth = null;
+    applyLiveColumnResizePreview(activeSession, appliedPreviewWidth);
+  }, [renderedColumnLayout, tableMinWidth]);
 
   const captureRenderedColumnWidths = React.useCallback(() => {
     const headerCells = Array.from(
@@ -3150,14 +3291,17 @@ function ReactDataGrid(props: TypeDataGridProps) {
   );
 
   const stopColumnResize = React.useCallback(() => {
+    const session = resizeSessionRef.current;
     const cleanup = resizeCleanupRef.current;
     resizeCleanupRef.current = null;
     resizeSessionRef.current = null;
-    cleanup?.();
     cancelResizeProxyFrame();
+    cancelLiveColumnResizeFrame();
+    restoreLiveColumnResizePreview(session);
+    cleanup?.();
     setResizeProxyLeft(null);
     setResizingColumnId(null);
-  }, [cancelResizeProxyFrame]);
+  }, [cancelLiveColumnResizeFrame, cancelResizeProxyFrame]);
 
   const startColumnResize = React.useCallback(
     (
@@ -3223,6 +3367,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
           bodyViewport.scrollLeft <=
           1
       );
+      const preview = liveColumnResize
+        ? captureLiveColumnResizePreview(surfaceElement, columnId, startWidth)
+        : null;
 
       headerCell.draggable = false;
 
@@ -3237,6 +3384,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
         columnLeft,
         minWidth,
         maxWidth,
+        liveColumnResize,
+        appliedPreviewWidth: null,
+        preview,
       };
 
       resizeCleanupRef.current?.();
@@ -3257,15 +3407,26 @@ function ReactDataGrid(props: TypeDataGridProps) {
         );
 
         activeSession.nextWidth = nextWidth;
-        scheduleResizeProxyPosition(activeSession.columnLeft + nextWidth);
+        if (activeSession.liveColumnResize) {
+          scheduleLiveColumnResizePreview(nextWidth);
+        } else {
+          scheduleResizeProxyPosition(activeSession.columnLeft + nextWidth);
+        }
       };
 
       const completeResize = () => {
         const completedSession = resizeSessionRef.current;
-        if (
+        const shouldCommit = Boolean(
           completedSession &&
           completedSession.nextWidth !== completedSession.startWidth
-        ) {
+        );
+        if (completedSession && shouldCommit) {
+          // Settle the imperative preview before entering the existing commit
+          // path. React applies the grid-owned result in the same event turn;
+          // controlled widths therefore return to their prop value unless the
+          // consumer supplies the proposal back from `onColumnResize`.
+          cancelLiveColumnResizeFrame();
+          restoreLiveColumnResizePreview(completedSession);
           commitColumnPixelResize(
             completedSession.column,
             completedSession.nextWidth
@@ -3387,15 +3548,23 @@ function ReactDataGrid(props: TypeDataGridProps) {
       }
       window.addEventListener("blur", handleWindowBlur);
       setResizingColumnId(columnId);
-      const initialProxyLeft = columnLeft + startWidth;
       cancelResizeProxyFrame();
-      resizeProxyNextLeftRef.current = initialProxyLeft;
-      setResizeProxyLeft(initialProxyLeft);
+      cancelLiveColumnResizeFrame();
+      if (liveColumnResize) {
+        setResizeProxyLeft(null);
+      } else {
+        const initialProxyLeft = columnLeft + startWidth;
+        resizeProxyNextLeftRef.current = initialProxyLeft;
+        setResizeProxyLeft(initialProxyLeft);
+      }
     },
     [
+      cancelLiveColumnResizeFrame,
       cancelResizeProxyFrame,
       commitColumnPixelResize,
+      liveColumnResize,
       orderedColumns,
+      scheduleLiveColumnResizePreview,
       scheduleResizeProxyPosition,
       seedManualColumnWidthsFromDom,
       showColumnMenuTool,
@@ -3405,17 +3574,21 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   React.useLayoutEffect(() => {
     return () => {
+      const session = resizeSessionRef.current;
       const cleanup = resizeCleanupRef.current;
       resizeCleanupRef.current = null;
       resizeSessionRef.current = null;
-      cleanup?.();
       cancelResizeProxyFrame();
+      cancelLiveColumnResizeFrame();
+      restoreLiveColumnResizePreview(session);
+      cleanup?.();
     };
-  }, [cancelResizeProxyFrame]);
+  }, [cancelLiveColumnResizeFrame, cancelResizeProxyFrame]);
 
   React.useEffect(() => {
     if (!resizingColumnId) return;
 
+    const activeSession = resizeSessionRef.current;
     const resizingColumnExists = orderedColumns.some(
       (column) => getColumnId(column) === resizingColumnId
     );
@@ -3424,11 +3597,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
       mobileTransformActive ||
       !resizable ||
       !showHeader ||
-      !resizingColumnExists
+      !resizingColumnExists ||
+      activeSession?.liveColumnResize !== liveColumnResize
     ) {
       stopColumnResize();
     }
   }, [
+    liveColumnResize,
     mobileTransformActive,
     orderedColumns,
     resizable,
@@ -4835,7 +5010,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
             tabIndex={-1}
             style={style}
           >
-            {resizeProxyLeft != null ? (
+            {!liveColumnResize && resizeProxyLeft != null ? (
               <div
                 ref={resizeProxyElementRef}
                 className="InovuaReactDataGrid__resize-proxy"
@@ -4889,6 +5064,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           {renderedColumnLayout.map((column) => (
                             <col
                               key={column.id}
+                              data-column-id={column.id}
                               style={{
                                 width: column.width,
                                 minWidth: column.minWidth,
@@ -4949,6 +5125,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                     {renderedColumnLayout.map((column) => (
                       <col
                         key={column.id}
+                        data-column-id={column.id}
                         style={{
                           width: column.width,
                           minWidth: column.minWidth,

--- a/src/types.ts
+++ b/src/types.ts
@@ -851,6 +851,15 @@ export type TypeDataGridProps = {
   reorderColumns?: boolean;
   resizable?: boolean;
 
+  /**
+   * When enabled, the rendered column follows the pointer while its resize
+   * handle is dragged. The default deferred mode keeps the lightweight resize
+   * proxy and applies the proposed width when the gesture completes.
+   *
+   * `onColumnResize` remains a completion callback in both modes.
+   */
+  liveColumnResize?: boolean;
+
   enableColumnFilterContextMenu?: boolean;
 
   enableColumnAutosize?: boolean;

--- a/tests/playwright/default-props-compat.spec.ts
+++ b/tests/playwright/default-props-compat.spec.ts
@@ -22,11 +22,14 @@ test("defaultProps static is available from the ReactDataGrid default export", a
   await expect(page.getByTestId("default-props-keys")).toContainText(
     "virtualizeColumnsThreshold"
   );
+  await expect(page.getByTestId("default-props-keys")).toContainText(
+    "liveColumnResize"
+  );
   await expect(
     page.getByTestId("default-props-string-operators")
   ).toContainText("contains");
   await expect(page.getByTestId("default-props-values")).toHaveText(
-    "theme=default,virtualized=true,virtualizeColumnsThreshold=15,allowMobileTransform=false,rowHeight=44,emptyText=noRecords"
+    "theme=default,virtualized=true,virtualizeColumnsThreshold=15,allowMobileTransform=false,liveColumnResize=false,rowHeight=44,emptyText=noRecords"
   );
   await expect(page.getByTestId("default-props-filtered-count")).toContainText(
     "3"

--- a/tests/playwright/example-row-height.spec.ts
+++ b/tests/playwright/example-row-height.spec.ts
@@ -1,0 +1,315 @@
+import { expect, test, type Locator } from "@playwright/test";
+
+type CellHeightGeometry = {
+  rowIndex: number | null;
+  rowHeight: number;
+  rowInlineHeight: string;
+  cellHeight: number;
+  cellTop: number;
+  cellBottom: number;
+  rowTop: number;
+  rowBottom: number;
+  contentClientHeight: number;
+  contentScrollHeight: number;
+  contentTop: number;
+  contentBottom: number;
+  contentInlineMaxHeight: string;
+  renderedTop: number;
+  renderedBottom: number;
+};
+
+async function readCellHeightGeometry(
+  cells: Locator
+): Promise<CellHeightGeometry[]> {
+  return cells.evaluateAll((cellElements): CellHeightGeometry[] =>
+    cellElements.map((cellElement) => {
+      const cell = cellElement as HTMLElement;
+      const row = cell.closest<HTMLElement>('[data-slot="grid-row"]');
+      const content = cell.querySelector<HTMLElement>(".tdg-cell-content");
+      const rendered = content?.firstElementChild as HTMLElement | null;
+
+      if (!row || !content || !rendered) {
+        throw new Error(
+          "Expected a rendered data row, cell content, and renderer"
+        );
+      }
+
+      const rowRect = row.getBoundingClientRect();
+      const cellRect = cell.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const renderedRect = rendered.getBoundingClientRect();
+      const parsedIndex = Number(row.dataset.rowIndex);
+
+      return {
+        rowIndex: Number.isFinite(parsedIndex) ? parsedIndex : null,
+        rowHeight: rowRect.height,
+        rowInlineHeight: row.style.height,
+        cellHeight: cellRect.height,
+        cellTop: cellRect.top,
+        cellBottom: cellRect.bottom,
+        rowTop: rowRect.top,
+        rowBottom: rowRect.bottom,
+        contentClientHeight: content.clientHeight,
+        contentScrollHeight: content.scrollHeight,
+        contentTop: contentRect.top,
+        contentBottom: contentRect.bottom,
+        contentInlineMaxHeight: content.style.maxHeight,
+        renderedTop: renderedRect.top,
+        renderedBottom: renderedRect.bottom,
+      };
+    })
+  );
+}
+
+function expectContentToFit(geometry: CellHeightGeometry): void {
+  const tolerance = 1;
+
+  expect(geometry.contentScrollHeight).toBeLessThanOrEqual(
+    geometry.contentClientHeight + tolerance
+  );
+  expect(geometry.renderedTop).toBeGreaterThanOrEqual(
+    geometry.contentTop - tolerance
+  );
+  expect(geometry.renderedBottom).toBeLessThanOrEqual(
+    geometry.contentBottom + tolerance
+  );
+  expect(geometry.cellTop).toBeGreaterThanOrEqual(geometry.rowTop - tolerance);
+  expect(geometry.cellBottom).toBeLessThanOrEqual(
+    geometry.rowBottom + tolerance
+  );
+  expect(
+    Math.abs(geometry.cellHeight - geometry.rowHeight)
+  ).toBeLessThanOrEqual(tolerance);
+}
+
+async function expectAdjacentRowsToShareAnEdge(
+  grid: Locator,
+  firstRowIndex: number,
+  secondRowIndex: number
+): Promise<void> {
+  const edgeDelta = await grid.evaluate(
+    (gridElement, { firstIndex, secondIndex }) => {
+      const firstRow = gridElement.querySelector<HTMLElement>(
+        `[data-slot="grid-row"][data-row-index="${firstIndex}"]`
+      );
+      const secondRow = gridElement.querySelector<HTMLElement>(
+        `[data-slot="grid-row"][data-row-index="${secondIndex}"]`
+      );
+
+      if (!firstRow || !secondRow) {
+        throw new Error(
+          `Expected adjacent rendered rows ${firstIndex} and ${secondIndex}`
+        );
+      }
+
+      const firstRect = firstRow.getBoundingClientRect();
+      const secondRect = secondRow.getBoundingClientRect();
+
+      return Math.abs(secondRect.top - firstRect.bottom);
+    },
+    { firstIndex: firstRowIndex, secondIndex: secondRowIndex }
+  );
+
+  expect(edgeDelta).toBeLessThanOrEqual(1);
+}
+
+async function waitForRowsToRemainRendered(
+  grid: Locator,
+  rowIndexes: number[]
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        grid.evaluate(async (gridElement, expectedIndexes) => {
+          const rowsAreRendered = () =>
+            expectedIndexes.every((rowIndex) =>
+              gridElement.querySelector(
+                `[data-slot="grid-row"][data-row-index="${rowIndex}"]`
+              )
+            );
+
+          // The virtualizer can briefly expose its initial range while React
+          // finishes the first post-scroll render. Requiring the requested
+          // range to survive several paints waits for the settled range rather
+          // than accepting that transient DOM.
+          for (let frame = 0; frame < 6; frame += 1) {
+            if (!rowsAreRendered()) return false;
+            await new Promise<void>((resolve) =>
+              window.requestAnimationFrame(() => resolve())
+            );
+          }
+
+          return rowsAreRendered();
+        }, rowIndexes),
+      { message: `rows ${rowIndexes.join(", ")} to remain rendered` }
+    )
+    .toBe(true);
+}
+
+test("selection example uses natural rows without clipping composite Account cells", async ({
+  page,
+}) => {
+  await page.goto("/examples/selection");
+
+  const grid = page
+    .getByTestId("selection-example-shell")
+    .locator(".InovuaReactDataGrid.tdg-root")
+    .first();
+  await expect(grid).toBeVisible();
+
+  const accountCells = grid.locator(
+    '[data-slot="grid-row"] [data-column-id="account"]'
+  );
+  await expect(accountCells).toHaveCount(8);
+
+  const geometry = await readCellHeightGeometry(accountCells);
+  for (const cell of geometry) {
+    expectContentToFit(cell);
+    expect(cell.rowHeight).toBeGreaterThanOrEqual(52);
+    // Natural mode leaves the renderer unconstrained and uses minRowHeight as
+    // a floor; the table may grow by a fractional pixel for its two text lines.
+    expect(cell.contentInlineMaxHeight).toBe("");
+    expect(cell.rowInlineHeight).toBe("52px");
+  }
+
+  await expectAdjacentRowsToShareAnEdge(grid, 0, 1);
+});
+
+test("columns example keeps fixed virtual rows and an offscreen Owner renderer aligned", async ({
+  page,
+}) => {
+  await page.goto("/examples/columns");
+
+  const shell = page.getByTestId("columns-grid-shell");
+  const grid = shell.locator(".InovuaReactDataGrid.tdg-root").first();
+  const viewport = grid.locator('[data-slot="scroll-area-viewport"]');
+  const headerViewport = grid.locator('[data-slot="grid-header-viewport"]');
+  await expect(grid).toBeVisible();
+
+  const initialOwnerCells = grid.locator(
+    '[data-slot="grid-row"] [data-column-id="owner"]'
+  );
+  await expect(initialOwnerCells.first()).toBeVisible();
+  for (const cell of await readCellHeightGeometry(initialOwnerCells)) {
+    expectContentToFit(cell);
+    expect(cell.rowHeight).toBeCloseTo(56, 0);
+    expect(cell.rowInlineHeight).toBe("56px");
+    expect(cell.contentInlineMaxHeight).toBe("40px");
+  }
+
+  const targetIndex = 77;
+  await viewport.evaluate(async (element, targetScrollTop) => {
+    element.scrollTo({ top: targetScrollTop });
+    await new Promise<void>((resolve) =>
+      window.requestAnimationFrame(() => resolve())
+    );
+  }, targetIndex * 56);
+
+  await waitForRowsToRemainRendered(grid, [targetIndex, targetIndex + 1]);
+
+  const targetRow = grid.locator(
+    `[data-slot="grid-row"][data-row-index="${targetIndex}"]`
+  );
+  const nextRow = grid.locator(
+    `[data-slot="grid-row"][data-row-index="${targetIndex + 1}"]`
+  );
+  await expect(targetRow).toBeVisible();
+  await expect(nextRow).toBeVisible();
+
+  const [targetGeometry] = await readCellHeightGeometry(
+    targetRow.locator('[data-column-id="owner"]')
+  );
+  expect(targetGeometry).toBeDefined();
+  expectContentToFit(targetGeometry!);
+  expect(targetGeometry?.rowHeight).toBeCloseTo(56, 0);
+  await expectAdjacentRowsToShareAnEdge(grid, targetIndex, targetIndex + 1);
+
+  const virtualOffset = await grid.evaluate(
+    (gridElement, { targetIndex: index, expectedRowHeight }) => {
+      const row = gridElement.querySelector<HTMLElement>(
+        `[data-slot="grid-row"][data-row-index="${index}"]`
+      );
+      const bodyViewport = gridElement.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-viewport"]'
+      );
+      const header = gridElement.querySelector<HTMLElement>(
+        '[data-slot="grid-header-viewport"]'
+      );
+
+      if (!row || !bodyViewport || !header) {
+        throw new Error(
+          "Expected the target row, grid body, and sticky header viewports"
+        );
+      }
+
+      const rowRect = row.getBoundingClientRect();
+      const viewportRect = bodyViewport.getBoundingClientRect();
+
+      return {
+        actualStart:
+          rowRect.top -
+          viewportRect.top +
+          bodyViewport.scrollTop -
+          header.getBoundingClientRect().height,
+        expectedStart: index * expectedRowHeight,
+      };
+    },
+    { targetIndex, expectedRowHeight: 56 }
+  );
+  expect(
+    Math.abs(virtualOffset.actualStart - virtualOffset.expectedStart)
+  ).toBeLessThanOrEqual(2);
+
+  // Keep the header locator live through the scroll: the row must begin below
+  // the same sticky layer rather than being virtually positioned under it.
+  await expect(headerViewport).toBeVisible();
+});
+
+test("columns natural-height toggle measures its three composite rows without clipping", async ({
+  page,
+}) => {
+  await page.goto("/examples/columns");
+  await page.getByTestId("columns-height-toggle").click();
+  await expect(page.getByTestId("columns-height-toggle")).toHaveText(
+    "Use fixed height"
+  );
+
+  const shell = page.getByTestId("columns-grid-shell");
+  const grid = shell.locator(".InovuaReactDataGrid.tdg-root").first();
+  const ownerCells = grid.locator(
+    '[data-slot="grid-row"] [data-column-id="owner"]'
+  );
+  await expect(ownerCells).toHaveCount(3);
+
+  const geometry = await readCellHeightGeometry(ownerCells);
+  for (const cell of geometry) {
+    expectContentToFit(cell);
+    expect(cell.rowHeight).toBeGreaterThanOrEqual(52);
+    expect(cell.rowInlineHeight).toBe("52px");
+    expect(cell.contentInlineMaxHeight).toBe("");
+  }
+
+  await expectAdjacentRowsToShareAnEdge(grid, 0, 1);
+  await expectAdjacentRowsToShareAnEdge(grid, 1, 2);
+
+  const layout = await shell.evaluate((element) => {
+    const gridElement = element.querySelector<HTMLElement>(".tdg-root");
+    const viewport = element.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+
+    if (!gridElement || !viewport) {
+      throw new Error("Expected the natural-height grid layout");
+    }
+
+    return {
+      shellHeight: element.getBoundingClientRect().height,
+      gridHeight: gridElement.getBoundingClientRect().height,
+      hasVerticalOverflow: viewport.scrollHeight > viewport.clientHeight + 1,
+    };
+  });
+
+  expect(layout.shellHeight).toBeLessThan(400);
+  expect(layout.gridHeight).toBeLessThanOrEqual(layout.shellHeight + 1);
+  expect(layout.hasVerticalOverflow).toBe(false);
+});

--- a/tests/playwright/examples-routing.spec.ts
+++ b/tests/playwright/examples-routing.spec.ts
@@ -286,7 +286,7 @@ test("keeps the compatibility lab source bounded and internally scrollable", asy
     .getByRole("button");
 
   await expect(sourcePanel).toBeVisible();
-  await expect(scenarioButtons).toHaveCount(20);
+  await expect(scenarioButtons).toHaveCount(22);
   await expect
     .poll(async () => sourcePanel.evaluate((element) => element.clientHeight))
     .toBeLessThanOrEqual(640);

--- a/tests/playwright/live-column-resize.spec.ts
+++ b/tests/playwright/live-column-resize.spec.ts
@@ -1,0 +1,673 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const MAX_GEOMETRY_DRIFT_PX = 2;
+const MAX_INTERACTION_DELAY_MS = 250;
+const MAX_LONG_TASK_MS = 250;
+const POINTER_BURST_SIZE = 180;
+
+type ResizePayload = {
+  columnId: string;
+  width: number | null;
+  flex: number | null;
+  reservedViewportWidth: number | null;
+};
+
+type ResizeListenerSnapshot = Record<string, number>;
+
+async function openScenario(
+  page: Page,
+  scenario: "resize-callback" | "live-resize" | "controlled-live-resize"
+) {
+  await page.goto(`/compat/inovua-parity?scenario=${scenario}`);
+
+  const scope = page.getByTestId("inovua-parity-scenario");
+  await expect(scope).toHaveAttribute("data-scenario", scenario);
+
+  const grid = scope.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toBeVisible();
+
+  return { scope, grid };
+}
+
+function header(grid: Locator, columnId: string): Locator {
+  return grid.locator(
+    `[data-slot="grid-header-cell"][data-column-id="${columnId}"]`
+  );
+}
+
+function firstCell(grid: Locator, columnId: string): Locator {
+  return grid
+    .locator(
+      `[data-slot="grid-row"][data-row-id] [data-column-id="${columnId}"]`
+    )
+    .first();
+}
+
+async function readWidth(locator: Locator): Promise<number> {
+  return locator.evaluate((element) => element.getBoundingClientRect().width);
+}
+
+async function readCount(locator: Locator): Promise<number> {
+  return Number((await locator.textContent())?.trim() ?? "0");
+}
+
+async function readPayload(locator: Locator): Promise<ResizePayload> {
+  return JSON.parse(
+    (await locator.textContent())?.trim() ?? "null"
+  ) as ResizePayload;
+}
+
+async function readPayloads(locator: Locator): Promise<ResizePayload[]> {
+  return JSON.parse(
+    (await locator.textContent())?.trim() ?? "[]"
+  ) as ResizePayload[];
+}
+
+async function settleFrames(page: Page, count = 2): Promise<void> {
+  await page.evaluate(async (frameCount) => {
+    for (let index = 0; index < frameCount; index += 1) {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve())
+      );
+    }
+  }, count);
+}
+
+async function dragStartPoint(resizer: Locator) {
+  const box = await resizer.boundingBox();
+  expect(box).not.toBeNull();
+
+  return {
+    x: (box?.x ?? 0) + (box?.width ?? 0) / 2,
+    y: (box?.y ?? 0) + (box?.height ?? 0) / 2,
+  };
+}
+
+async function installResizeListenerAudit(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const eventTypes = [
+      "blur",
+      "mousemove",
+      "mouseup",
+      "pointermove",
+      "pointerup",
+      "pointercancel",
+    ] as const;
+    const active = Object.fromEntries(
+      eventTypes.map((type) => [
+        type,
+        new Set<EventListenerOrEventListenerObject>(),
+      ])
+    ) as Record<string, Set<EventListenerOrEventListenerObject>>;
+    const nativeAdd = window.addEventListener.bind(window);
+    const nativeRemove = window.removeEventListener.bind(window);
+
+    window.addEventListener = ((type, listener, options) => {
+      if (listener && active[type]) active[type].add(listener);
+      nativeAdd(type, listener, options);
+    }) as typeof window.addEventListener;
+    window.removeEventListener = ((type, listener, options) => {
+      if (listener && active[type]) active[type].delete(listener);
+      nativeRemove(type, listener, options);
+    }) as typeof window.removeEventListener;
+
+    Object.defineProperty(window, "__tdgLiveResizeListenerAudit", {
+      configurable: false,
+      value: active,
+    });
+  });
+}
+
+async function readResizeListenerAudit(
+  page: Page
+): Promise<ResizeListenerSnapshot> {
+  return page.evaluate(() => {
+    const active = (
+      window as typeof window & {
+        __tdgLiveResizeListenerAudit: Record<
+          string,
+          Set<EventListenerOrEventListenerObject>
+        >;
+      }
+    ).__tdgLiveResizeListenerAudit;
+
+    return Object.fromEntries(
+      Object.entries(active).map(([type, listeners]) => [type, listeners.size])
+    );
+  });
+}
+
+test.describe("live column resizing", () => {
+  test("updates header and body geometry during drag and commits the latest payload", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "live-resize");
+    const descriptionHeader = header(grid, "description");
+    const descriptionCell = firstCell(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const latestEvent = scope.getByTestId("column-resize-last-event");
+    const initialWidth = await readWidth(descriptionHeader);
+    const start = await dragStartPoint(resizer);
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await expect(grid).toHaveAttribute("data-column-resizing", "true");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+
+    await page.mouse.move(start.x + 100, start.y, { steps: 12 });
+    await expect
+      .poll(() => readWidth(descriptionHeader))
+      .toBeGreaterThan(initialWidth + 75);
+
+    const widthDuringDrag = await readWidth(descriptionHeader);
+    const bodyWidthDuringDrag = await readWidth(descriptionCell);
+    expect(Math.abs(widthDuringDrag - bodyWidthDuringDrag)).toBeLessThanOrEqual(
+      MAX_GEOMETRY_DRIFT_PX
+    );
+    await expect(eventCount).toHaveText("0");
+    await expect(latestEvent).toHaveText("none");
+    await settleFrames(page);
+
+    await page.mouse.up();
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+    await settleFrames(page);
+
+    // Live mode changes only when geometry is painted. The public Inovua-style
+    // callback remains a completion event and fires once with the final size.
+    await expect(eventCount).toHaveText("1");
+    const renderedWidth = await readWidth(descriptionHeader);
+    const finalPayload = await readPayload(latestEvent);
+    expect(finalPayload.columnId).toBe("description");
+    expect(finalPayload.width).not.toBeNull();
+    expect(renderedWidth).toBeGreaterThan(initialWidth + 75);
+    expect(
+      Math.abs(renderedWidth - (finalPayload.width ?? 0))
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX + 1);
+    expect(finalPayload.reservedViewportWidth).not.toBeNull();
+  });
+
+  test("keeps deferred proxy resizing as the default", async ({ page }) => {
+    const { scope, grid } = await openScenario(page, "resize-callback");
+    const descriptionHeader = header(grid, "description");
+    const descriptionCell = firstCell(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const initialWidth = await readWidth(descriptionHeader);
+    const start = await dragStartPoint(resizer);
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 100, start.y, { steps: 12 });
+    await settleFrames(page);
+
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toBeVisible();
+    expect(
+      Math.abs((await readWidth(descriptionHeader)) - initialWidth)
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs((await readWidth(descriptionCell)) - initialWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    await expect(eventCount).toHaveText("0");
+
+    await page.mouse.up();
+    await expect(eventCount).toHaveText("1");
+    await expect
+      .poll(() => readWidth(descriptionHeader))
+      .toBeGreaterThan(initialWidth + 75);
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+  });
+
+  test("previews a controlled width but leaves ownership with the consumer", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "controlled-live-resize");
+    const controlledHeader = header(grid, "controlled");
+    const controlledCell = firstCell(grid, "controlled");
+    const resizer = controlledHeader.locator('[data-slot="column-resizer"]');
+    const proposals = scope.getByTestId("controlled-resize-events");
+    const controlledValue = scope.getByTestId("controlled-width-value");
+    const initialWidth = await readWidth(controlledHeader);
+    const start = await dragStartPoint(resizer);
+
+    await expect(controlledValue).toHaveText("180");
+    expect(await readPayloads(proposals)).toEqual([]);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 100, start.y, { steps: 12 });
+
+    await expect
+      .poll(() => readWidth(controlledHeader))
+      .toBeGreaterThan(initialWidth + 75);
+    expect(
+      Math.abs(
+        (await readWidth(controlledHeader)) - (await readWidth(controlledCell))
+      )
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(await readPayloads(proposals)).toEqual([]);
+    await expect(controlledValue).toHaveText("180");
+
+    await page.mouse.up();
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(async () => (await readPayloads(proposals)).length)
+      .toBe(1);
+    const [proposal] = await readPayloads(proposals);
+    expect(proposal?.columnId).toBe("controlled");
+    expect(proposal?.width ?? 0).toBeGreaterThan(initialWidth + 75);
+    await expect
+      .poll(async () =>
+        Math.abs((await readWidth(controlledHeader)) - initialWidth)
+      )
+      .toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(controlledCell)) - initialWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    await expect(controlledValue).toHaveText("180");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+  });
+
+  test("cancelling restores a controlled width updated during the live drag", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "controlled-live-resize");
+    const controlledHeader = header(grid, "controlled");
+    const controlledCell = firstCell(grid, "controlled");
+    const fillerHeader = header(grid, "filler");
+    const bodyTable = grid.locator(".tdg-body-table");
+    const resizer = controlledHeader.locator('[data-slot="column-resizer"]');
+    const proposals = scope.getByTestId("controlled-resize-events");
+    const controlledValue = scope.getByTestId("controlled-width-value");
+    const setControlledWidth = scope.getByTestId("set-controlled-width");
+    const initialWidth = await readWidth(controlledHeader);
+    const fillerWidth = await readWidth(fillerHeader);
+    const start = await dragStartPoint(resizer);
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 70, start.y, { steps: 10 });
+    await settleFrames(page);
+
+    const previewWidth = await readWidth(controlledHeader);
+    expect(previewWidth).toBeGreaterThan(initialWidth + 50);
+    expect(await readPayloads(proposals)).toEqual([]);
+
+    // Dispatch a consumer action without releasing the held resize pointer.
+    await setControlledWidth.evaluate((element) =>
+      (element as HTMLElement).click()
+    );
+    await expect(controlledValue).toHaveText("300");
+    await settleFrames(page);
+
+    // The active pointer preview remains on top of the new controlled base.
+    expect(
+      Math.abs((await readWidth(controlledHeader)) - previewWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(bodyTable)) - (previewWidth + fillerWidth))
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX + 1);
+    expect(await readPayloads(proposals)).toEqual([]);
+
+    await page.evaluate(() => window.dispatchEvent(new Event("blur")));
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(async () => Math.abs((await readWidth(controlledHeader)) - 300))
+      .toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(controlledCell)) - 300)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(bodyTable)) - (300 + fillerWidth))
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX + 1);
+    await expect(controlledValue).toHaveText("300");
+    expect(await readPayloads(proposals)).toEqual([]);
+
+    // Reset Playwright's mouse state; the grid listener is already gone.
+    await page.mouse.up();
+  });
+
+  test("rolls a cancelled live preview back without emitting completion", async ({
+    page,
+  }) => {
+    const { scope, grid } = await openScenario(page, "live-resize");
+    const descriptionHeader = header(grid, "description");
+    const descriptionCell = firstCell(grid, "description");
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const initialWidth = await readWidth(descriptionHeader);
+    const pointerId = 29;
+
+    const start = await resizer.evaluate((element, id) => {
+      const rect = element.getBoundingClientRect();
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      element.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          button: 0,
+          buttons: 1,
+          pointerId: id,
+          pointerType: "mouse",
+          isPrimary: true,
+        })
+      );
+      return { x, y };
+    }, pointerId);
+
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 90,
+            clientY: y,
+            buttons: 1,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+    await settleFrames(page, 2);
+    await expect
+      .poll(() => readWidth(descriptionHeader))
+      .toBeGreaterThan(initialWidth + 65);
+    await expect(eventCount).toHaveText("0");
+
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointercancel", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 90,
+            clientY: y,
+            buttons: 0,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(async () =>
+        Math.abs((await readWidth(descriptionHeader)) - initialWidth)
+      )
+      .toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(
+      Math.abs((await readWidth(descriptionCell)) - initialWidth)
+    ).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    await expect(eventCount).toHaveText("0");
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toHaveCount(0);
+  });
+
+  test("coalesces pointer bursts and releases every drag listener", async ({
+    page,
+  }) => {
+    await installResizeListenerAudit(page);
+    const { scope, grid } = await openScenario(page, "live-resize");
+    const descriptionHeader = header(grid, "description");
+    const fillerContent = firstCell(grid, "filler").locator(
+      ".tdg-cell-content"
+    );
+    const resizer = descriptionHeader.locator('[data-slot="column-resizer"]');
+    const eventCount = scope.getByTestId("column-resize-event-count");
+    const initialWidth = await readWidth(descriptionHeader);
+    const baselineListeners = await readResizeListenerAudit(page);
+    const mountedRows = grid.locator('[data-slot="grid-row"][data-row-id]');
+    const initialMountedRowCount = await mountedRows.count();
+    expect(initialMountedRowCount).toBeGreaterThan(0);
+    expect(initialMountedRowCount).toBeLessThan(500);
+    const pointerId = 41;
+
+    const start = await resizer.evaluate((element, id) => {
+      const rect = element.getBoundingClientRect();
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      element.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          button: 0,
+          buttons: 1,
+          pointerId: id,
+          pointerType: "mouse",
+          isPrimary: true,
+        })
+      );
+      return { x, y };
+    }, pointerId);
+    await expect(grid).toHaveAttribute("data-column-resizing", "true");
+
+    const burst = await grid.evaluate(
+      async (
+        gridElement,
+        args: {
+          pointerId: number;
+          startX: number;
+          startY: number;
+          moveCount: number;
+        }
+      ) => {
+        const descriptionHeader = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-header-cell"][data-column-id="description"]'
+        );
+        const descriptionCell = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id] [data-column-id="description"]'
+        );
+        const fillerContent = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id] [data-column-id="filler"] .tdg-cell-content'
+        );
+        if (!descriptionHeader || !descriptionCell || !fillerContent) {
+          throw new Error(
+            "Expected resize performance targets were not mounted"
+          );
+        }
+
+        const descriptionColumns = Array.from(
+          gridElement.querySelectorAll<HTMLTableColElement>(
+            'col[data-column-id="description"]'
+          )
+        );
+        const owningTables = Array.from(
+          new Set(
+            descriptionColumns
+              .map((element) => element.closest("table"))
+              .filter(
+                (element): element is HTMLTableElement =>
+                  element instanceof HTMLTableElement
+              )
+          )
+        );
+        if (descriptionColumns.length < 2 || owningTables.length < 2) {
+          throw new Error(
+            "Expected separate header/body column preview targets"
+          );
+        }
+
+        let columnStyleMutations = 0;
+        let tableStyleMutations = 0;
+        const styleObserver = new MutationObserver((records) => {
+          for (const record of records) {
+            if (
+              descriptionColumns.includes(record.target as HTMLTableColElement)
+            ) {
+              columnStyleMutations += 1;
+            }
+            if (owningTables.includes(record.target as HTMLTableElement)) {
+              tableStyleMutations += 1;
+            }
+          }
+        });
+        for (const target of [...descriptionColumns, ...owningTables]) {
+          styleObserver.observe(target, {
+            attributes: true,
+            attributeFilter: ["style"],
+          });
+        }
+
+        const longTasks: number[] = [];
+        const longTaskObserver =
+          typeof PerformanceObserver === "function" &&
+          PerformanceObserver.supportedEntryTypes.includes("longtask")
+            ? new PerformanceObserver((list) => {
+                for (const entry of list.getEntries()) {
+                  longTasks.push(entry.duration);
+                }
+              })
+            : null;
+        longTaskObserver?.observe({ entryTypes: ["longtask"] });
+
+        const preservedFillerContent = fillerContent;
+        const startedAt = performance.now();
+        for (let index = 1; index <= args.moveCount; index += 1) {
+          window.dispatchEvent(
+            new PointerEvent("pointermove", {
+              bubbles: true,
+              cancelable: true,
+              clientX: args.startX + (120 * index) / args.moveCount,
+              clientY: args.startY,
+              button: -1,
+              buttons: 1,
+              pointerId: args.pointerId,
+              pointerType: "mouse",
+              isPrimary: true,
+            })
+          );
+        }
+        const dispatchDuration = performance.now() - startedAt;
+        const firstFrameAt = await new Promise<number>((resolve) =>
+          requestAnimationFrame(resolve)
+        );
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve())
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+        const currentFillerContent = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id] [data-column-id="filler"] .tdg-cell-content'
+        );
+        styleObserver.disconnect();
+        longTaskObserver?.disconnect();
+
+        return {
+          cellWidth: descriptionCell.getBoundingClientRect().width,
+          dispatchDuration,
+          fillerContentPreserved:
+            currentFillerContent === preservedFillerContent,
+          firstFrameDelay: firstFrameAt - startedAt,
+          headerWidth: descriptionHeader.getBoundingClientRect().width,
+          columnStyleMutations,
+          maxLongTask: Math.max(0, ...longTasks),
+          mountedRowCount: gridElement.querySelectorAll(
+            '[data-slot="grid-row"][data-row-id]'
+          ).length,
+          tableStyleMutations,
+        };
+      },
+      {
+        pointerId,
+        startX: start.x,
+        startY: start.y,
+        moveCount: POINTER_BURST_SIZE,
+      }
+    );
+
+    expect(burst.dispatchDuration).toBeLessThan(MAX_INTERACTION_DELAY_MS);
+    expect(burst.firstFrameDelay).toBeLessThan(MAX_INTERACTION_DELAY_MS);
+    expect(burst.maxLongTask).toBeLessThan(MAX_LONG_TASK_MS);
+    expect(burst.headerWidth).toBeGreaterThan(initialWidth + 95);
+    expect(Math.abs(burst.headerWidth - burst.cellWidth)).toBeLessThanOrEqual(
+      MAX_GEOMETRY_DRIFT_PX
+    );
+    expect(burst.fillerContentPreserved).toBe(true);
+    expect(burst.mountedRowCount).toBe(initialMountedRowCount);
+    expect(burst.columnStyleMutations).toBeGreaterThan(0);
+    expect(burst.tableStyleMutations).toBeGreaterThan(0);
+    expect(
+      burst.columnStyleMutations + burst.tableStyleMutations
+    ).toBeLessThanOrEqual(12);
+
+    // A synchronous event burst must be reduced to frame-sized DOM work. The
+    // public callback remains completion-only even though geometry is live.
+    await expect(eventCount).toHaveText("0");
+
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointerup", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 120,
+            clientY: y,
+            button: 0,
+            buttons: 0,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+    await expect(grid).toHaveAttribute("data-column-resizing", "false");
+    await expect
+      .poll(() => readResizeListenerAudit(page))
+      .toEqual(baselineListeners);
+    await settleFrames(page);
+    await expect(eventCount).toHaveText("1");
+
+    const settledWidth = await readWidth(descriptionHeader);
+    const settledCount = await readCount(eventCount);
+    expect(settledCount).toBe(1);
+    expect(await mountedRows.count()).toBe(initialMountedRowCount);
+    expect(await fillerContent.isVisible()).toBe(true);
+
+    // A stale pointer event after completion must not enqueue more width work.
+    await page.evaluate(
+      ({ id, x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x + 180,
+            clientY: y,
+            buttons: 1,
+            pointerId: id,
+            pointerType: "mouse",
+            isPrimary: true,
+          })
+        );
+      },
+      { id: pointerId, x: start.x, y: start.y }
+    );
+    await settleFrames(page, 3);
+    expect(await readWidth(descriptionHeader)).toBeCloseTo(settledWidth, 1);
+    expect(await readCount(eventCount)).toBe(settledCount);
+  });
+});

--- a/tests/playwright/users-column-visibility.spec.ts
+++ b/tests/playwright/users-column-visibility.spec.ts
@@ -1,0 +1,378 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Timing is a secondary guard because CI scheduling can be noisy. DOM identity
+// below is the deterministic signal for the expensive renderer churn.
+const MAX_FRAME_DELAY_MS = 250;
+const MAX_LONG_TASK_MS = 250;
+const MAX_GEOMETRY_DRIFT_PX = 2;
+const MAX_LAYOUT_DRIFT_PX = 1;
+const OPTIONAL_COLUMNS = [
+  { label: "Failed logins", id: "failed_login_attempts" },
+  { label: "Last login", id: "date_last_successful_login" },
+  { label: "Password changed", id: "date_pwdchanged" },
+  { label: "Language", id: "lang" },
+] as const;
+
+function captureRuntimeFailures(page: Page) {
+  const failures: string[] = [];
+  const renderLoopPattern =
+    /too many re-renders|maximum update depth|cannot update a component while rendering/i;
+
+  page.on("pageerror", (error) => failures.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error" && renderLoopPattern.test(message.text())) {
+      failures.push(message.text());
+    }
+  });
+
+  return failures;
+}
+
+test("Visible columns toggles stay responsive and geometrically consistent", async ({
+  page,
+}) => {
+  const runtimeFailures = captureRuntimeFailures(page);
+
+  // This width exposed the old icon-driven wrap: toggling a hidden column
+  // changed the toolbar from one line to two and moved the complete grid.
+  await page.setViewportSize({ width: 940, height: 900 });
+  await page.goto("/users");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const toggleGroup = preview.getByRole("group", {
+    name: "Visible column toggles",
+  });
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const failedLoginsButton = toggleGroup.getByRole("button", {
+    name: "Failed logins",
+    exact: true,
+  });
+  const failedLoginsHeader = grid.locator(
+    '[data-slot="grid-header-cell"][data-column-id="failed_login_attempts"]'
+  );
+
+  await expect(preview).toBeVisible();
+  await expect(grid).toBeVisible();
+  await expect(failedLoginsButton).toBeVisible();
+  await expect(failedLoginsHeader).toHaveCount(0);
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "false");
+
+  const mountedRows = grid.locator('[data-slot="grid-row"][data-row-id]');
+  await expect(mountedRows.first()).toBeVisible();
+  const mountedRowCount = await mountedRows.count();
+  expect(mountedRowCount).toBeGreaterThan(0);
+  expect(mountedRowCount).toBeLessThan(48);
+
+  // Column toggles are text controls. Their state must not add an eye icon or
+  // change the button's accessible name when a column is hidden.
+  const initialIconCount = await toggleGroup.locator("svg").count();
+
+  // Exercise one browser-driven round trip before the in-page probe. This
+  // catches pointer/focus regressions that a synthetic click alone would miss.
+  await failedLoginsButton.click();
+  await expect(failedLoginsHeader).toBeVisible();
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "true");
+  await failedLoginsButton.click();
+  await expect(failedLoginsHeader).toHaveCount(0);
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "false");
+
+  const result = await preview.evaluate(
+    async (previewElement, optionalColumns) => {
+      const gridElement = previewElement.querySelector<HTMLElement>(
+        ".InovuaReactDataGrid.tdg-root"
+      );
+      const group = previewElement.querySelector<HTMLElement>(
+        '[role="group"][aria-label="Visible column toggles"]'
+      );
+      if (!gridElement || !group) {
+        return { error: "Visibility controls or grid were not found" } as const;
+      }
+
+      const longTasks: number[] = [];
+      const observer =
+        typeof PerformanceObserver === "function" &&
+        PerformanceObserver.supportedEntryTypes.includes("longtask")
+          ? new PerformanceObserver((list) => {
+              for (const entry of list.getEntries()) {
+                longTasks.push(entry.duration);
+              }
+            })
+          : null;
+
+      observer?.observe({ entryTypes: ["longtask"] });
+
+      const nextFrame = () =>
+        new Promise<number>((resolve) => requestAnimationFrame(resolve));
+
+      // Do not attribute route initialization or first-paint work to toggles.
+      await nextFrame();
+      await nextFrame();
+
+      const samples: Array<{
+        frameDelay: number;
+        geometryDrift: number;
+        headerIds: string[];
+        bodyIds: string[];
+        expectedVisible: boolean;
+        visibleOnNextFrame: boolean;
+        iconCount: number;
+        label: string;
+        pressedOnNextFrame: boolean;
+        replacedContentNodes: number;
+        buttonWidthDrift: number;
+        groupHeightDrift: number;
+        gridTopDrift: number;
+      }> = [];
+
+      const toggleColumn = async (
+        target: { label: string; id: string },
+        expectedVisible: boolean
+      ) => {
+        const button = Array.from(
+          group.querySelectorAll<HTMLButtonElement>("button")
+        ).find((element) => element.textContent?.trim() === target.label);
+        if (!button) throw new Error(`Missing ${target.label} toggle`);
+
+        // Existing renderers are the strongest deterministic proxy for work:
+        // adding one column must not remount content in every unaffected cell.
+        const preservedContent = new Map<string, Element>();
+        for (const rowElement of gridElement.querySelectorAll<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id]'
+        )) {
+          for (const cellElement of rowElement.querySelectorAll<HTMLElement>(
+            `[data-column-id]:not([data-column-id="${target.id}"])`
+          )) {
+            const content = cellElement.querySelector(".tdg-cell-content > *");
+            if (!content) continue;
+
+            preservedContent.set(
+              `${rowElement.dataset.rowId}\u0000${cellElement.dataset.columnId}`,
+              content
+            );
+          }
+        }
+
+        const buttonWidthBefore = button.getBoundingClientRect().width;
+        const groupHeightBefore = group.getBoundingClientRect().height;
+        const gridTopBefore = gridElement.getBoundingClientRect().top;
+        const clickTime = performance.now();
+        button.click();
+        const frameTime = await nextFrame();
+
+        const header = gridElement.querySelector<HTMLElement>(
+          `[data-slot="grid-header-cell"][data-column-id="${target.id}"]`
+        );
+        const firstRow = gridElement.querySelector<HTMLElement>(
+          '[data-slot="grid-row"][data-row-id]'
+        );
+        const headers = Array.from(
+          gridElement.querySelectorAll<HTMLElement>(
+            '[data-slot="grid-header-cell"][data-column-id]'
+          )
+        );
+        const cells = Array.from(
+          firstRow?.querySelectorAll<HTMLElement>("[data-column-id]") ?? []
+        );
+        const headerIds = headers.map(
+          (element) => element.dataset.columnId ?? ""
+        );
+        const bodyIds = cells.map((element) => element.dataset.columnId ?? "");
+        let replacedContentNodes = 0;
+        for (const [key, previousContent] of preservedContent) {
+          const [rowId, columnId] = key.split("\u0000");
+          const currentContent = gridElement.querySelector(
+            `[data-slot="grid-row"][data-row-id="${rowId}"] ` +
+              `[data-column-id="${columnId}"] .tdg-cell-content > *`
+          );
+
+          if (currentContent !== previousContent) replacedContentNodes += 1;
+        }
+        const geometryDrift = headers.reduce(
+          (maximum, headerElement, index) => {
+            const cellElement = cells[index];
+            if (!cellElement) return Number.POSITIVE_INFINITY;
+
+            const headerRect = headerElement.getBoundingClientRect();
+            const cellRect = cellElement.getBoundingClientRect();
+            return Math.max(
+              maximum,
+              Math.abs(headerRect.left - cellRect.left),
+              Math.abs(headerRect.width - cellRect.width)
+            );
+          },
+          0
+        );
+
+        samples.push({
+          frameDelay: frameTime - clickTime,
+          geometryDrift,
+          headerIds,
+          bodyIds,
+          expectedVisible,
+          visibleOnNextFrame: Boolean(header),
+          iconCount: group.querySelectorAll("svg").length,
+          label: target.label,
+          pressedOnNextFrame:
+            button.getAttribute("aria-pressed") === String(expectedVisible),
+          replacedContentNodes,
+          buttonWidthDrift: Math.abs(
+            button.getBoundingClientRect().width - buttonWidthBefore
+          ),
+          groupHeightDrift: Math.abs(
+            group.getBoundingClientRect().height - groupHeightBefore
+          ),
+          gridTopDrift: Math.abs(
+            gridElement.getBoundingClientRect().top - gridTopBefore
+          ),
+        });
+      };
+
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        for (const target of optionalColumns) {
+          await toggleColumn(target, true);
+        }
+        for (const target of [...optionalColumns].reverse()) {
+          await toggleColumn(target, false);
+        }
+      }
+
+      // Let PerformanceObserver deliver any entry generated by the final
+      // toggle before disconnecting it.
+      await nextFrame();
+      observer?.disconnect();
+
+      return {
+        error: null,
+        longTasks,
+        samples,
+      };
+    },
+    OPTIONAL_COLUMNS
+  );
+
+  expect(result.error).toBeNull();
+  if (result.error) return;
+
+  expect(result.samples).toHaveLength(16);
+  for (const sample of result.samples) {
+    // A click is a discrete React event, so the complete header/body state must
+    // be committed before the next paint rather than settling over many frames.
+    expect(sample.visibleOnNextFrame).toBe(sample.expectedVisible);
+    expect(sample.pressedOnNextFrame).toBe(true);
+    expect(sample.headerIds).toEqual(sample.bodyIds);
+    expect(sample.geometryDrift).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
+    expect(sample.replacedContentNodes).toBe(0);
+    expect(sample.buttonWidthDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
+    expect(sample.groupHeightDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
+    expect(sample.gridTopDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
+    expect(sample.frameDelay).toBeLessThan(MAX_FRAME_DELAY_MS);
+  }
+
+  expect(Math.max(0, ...result.longTasks)).toBeLessThan(MAX_LONG_TASK_MS);
+  await expect(failedLoginsHeader).toHaveCount(0);
+
+  const filterLifecycle = await preview.evaluate(async (previewElement) => {
+    const initialGridRoot = previewElement.querySelector<HTMLElement>(
+      ".InovuaReactDataGrid.tdg-root"
+    );
+    const group = previewElement.querySelector<HTMLElement>(
+      '[role="group"][aria-label="Visible column toggles"]'
+    );
+    const failedLoginsToggle = Array.from(
+      group?.querySelectorAll<HTMLButtonElement>("button") ?? []
+    ).find((element) => element.textContent?.trim() === "Failed logins");
+
+    if (!initialGridRoot || !failedLoginsToggle) {
+      return { error: "Grid root or visibility toggle was not found" } as const;
+    }
+
+    let rootWasDisconnected = false;
+    const rootObserver = new MutationObserver(() => {
+      if (!initialGridRoot.isConnected) rootWasDisconnected = true;
+    });
+    rootObserver.observe(previewElement, { childList: true, subtree: true });
+
+    const nextFrame = () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    const findButton = (label: string) =>
+      Array.from(
+        previewElement.querySelectorAll<HTMLButtonElement>("button")
+      ).find((element) => element.textContent?.trim() === label);
+    const currentGridRoot = () =>
+      previewElement.querySelector<HTMLElement>(
+        ".InovuaReactDataGrid.tdg-root"
+      );
+    const failedLoginsIsVisible = () =>
+      Boolean(
+        currentGridRoot()?.querySelector(
+          '[data-slot="grid-header-cell"][data-column-id="failed_login_attempts"]'
+        )
+      );
+
+    failedLoginsToggle.click();
+    await nextFrame();
+    const afterColumnShow = {
+      sameRoot: currentGridRoot() === initialGridRoot,
+      columnVisible: failedLoginsIsVisible(),
+      pressed: failedLoginsToggle.getAttribute("aria-pressed"),
+    };
+
+    const hideFilters = findButton("Hide filters");
+    hideFilters?.click();
+    await nextFrame();
+    const afterFilterHide = {
+      sameRoot: currentGridRoot() === initialGridRoot,
+      columnVisible: failedLoginsIsVisible(),
+      filterCellCount:
+        currentGridRoot()?.querySelectorAll(".tdg-filter-cell").length ?? -1,
+    };
+
+    const showFilters = findButton("Show filters");
+    showFilters?.click();
+    await nextFrame();
+    const afterFilterShow = {
+      sameRoot: currentGridRoot() === initialGridRoot,
+      columnVisible: failedLoginsIsVisible(),
+      filterCellCount:
+        currentGridRoot()?.querySelectorAll(".tdg-filter-cell").length ?? -1,
+    };
+
+    rootObserver.disconnect();
+
+    return {
+      error: hideFilters && showFilters ? null : "Filter toggle was not found",
+      afterColumnShow,
+      afterFilterHide,
+      afterFilterShow,
+      rootWasDisconnected,
+    };
+  });
+
+  expect(filterLifecycle.error).toBeNull();
+  if (filterLifecycle.error) return;
+
+  expect(filterLifecycle.afterColumnShow).toEqual({
+    sameRoot: true,
+    columnVisible: true,
+    pressed: "true",
+  });
+  expect(filterLifecycle.afterFilterHide).toEqual({
+    sameRoot: true,
+    columnVisible: true,
+    filterCellCount: 0,
+  });
+  expect(filterLifecycle.afterFilterShow.sameRoot).toBe(true);
+  expect(filterLifecycle.afterFilterShow.columnVisible).toBe(true);
+  expect(filterLifecycle.afterFilterShow.filterCellCount).toBeGreaterThan(0);
+  expect(filterLifecycle.rootWasDisconnected).toBe(false);
+  await expect(failedLoginsHeader).toBeVisible();
+  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "true");
+
+  expect(runtimeFailures).toEqual([]);
+  expect(
+    Math.max(
+      initialIconCount,
+      ...result.samples.map((sample) => sample.iconCount)
+    )
+  ).toBe(0);
+});

--- a/tests/types/type-default-props-compat.ts
+++ b/tests/types/type-default-props-compat.ts
@@ -33,6 +33,7 @@ const defaultTheme: string = defaultExportDefaults.theme;
 const defaultVirtualized: boolean = defaultExportDefaults.virtualized;
 const defaultVirtualizeColumnsThreshold: number =
   defaultExportDefaults.virtualizeColumnsThreshold;
+const defaultLiveColumnResize: boolean = defaultExportDefaults.liveColumnResize;
 const defaultEmptyText: TypeDataGridProps["emptyText"] =
   defaultExportDefaults.emptyText;
 
@@ -43,6 +44,7 @@ export const defaultPropsCompat = {
   defaultTheme,
   defaultVirtualized,
   defaultVirtualizeColumnsThreshold,
+  defaultLiveColumnResize,
   defaultEmptyText,
   stringOperatorCount: defaultFilterTypes.string.operators.length,
 };

--- a/tests/types/type-live-column-resize.ts
+++ b/tests/types/type-live-column-resize.ts
@@ -1,0 +1,23 @@
+import type { TypeDataGridProps } from "../../src/main";
+
+const baseProps = {
+  idProperty: "id",
+  columns: [{ name: "name", defaultWidth: 180 }],
+  dataSource: [{ id: 1, name: "Ada Lovelace" }],
+} satisfies TypeDataGridProps;
+
+export const deferredResizeProps = {
+  ...baseProps,
+  liveColumnResize: false,
+} satisfies TypeDataGridProps;
+
+export const interactiveResizeProps = {
+  ...baseProps,
+  liveColumnResize: true,
+  onColumnResize: (info, context) => {
+    void info.column;
+    void info.width;
+    void info.flex;
+    void context.reservedViewportWidth;
+  },
+} satisfies TypeDataGridProps;


### PR DESCRIPTION
## Summary

- removes the icon and render churn from **Visible columns**, preserving unaffected DOM and grid geometry
- adds opt-in `liveColumnResize` with animation-frame-coalesced header/body updates while retaining Inovua's deferred resize behavior by default
- keeps controlled widths authoritative, including prop updates during an active drag and cancellation cleanup
- fixes composite row-height examples and adds stable virtualized geometry coverage
- documents the new sizing contract and adds manual live/controlled resize checkpoints

## Performance and compatibility

Live resizing mutates only the rendered column/table geometry once per animation frame and commits React state once on completion. The performance test sends 180 pointer moves through a 500-row virtualized grid while checking bounded style writes, stable mounted rows and DOM identity, listener cleanup, callback ordering, and stale-event protection.

The default remains `liveColumnResize={false}`, so existing consumers keep the Inovua-compatible resize proxy and completion-only `onColumnResize` contract.

## Validation

- `176 passed` — complete serial Chromium Playwright suite
- focused live-resize suite repeated three times: `18 passed`
- library build, declarations, packed TypeScript consumers, CSS scope, and optional-search boundary
- `npm pack --dry-run`: `@geovi/the-datagrid@0.0.8`
- scoped ESLint, Prettier, and `git diff --check`

## Stack

This PR targets #30's compatibility branch. Merge this PR first, then merge #30 into `main` to produce the complete `0.0.8` release tree.
