### PR TITLE
Release 0.0.9: provider controls and compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ The optional `@geovi/the-datagrid/search` entry exports `RDGSearchProvider`,
 fallbacks are `@geovi/the-datagrid/style.css` and
 `@geovi/the-datagrid/search/style.css`.
 
+The optional `@geovi/the-datagrid/components` entry is the one-import choice for
+mixed contextual controls. It exports `RDGProvider`, `RDGTarget`,
+`RDGSearchBar`, `RDGColumnVisibilityToolbar`, all four stable feature-specific
+provider/target APIs, and their prop types. It reuses the existing search and
+column-visibility singleton contexts and automatically loads both isolated
+stylesheets; there is intentionally no duplicate `components/style.css`.
+
 The optional `@geovi/the-datagrid/column-visibility` entry exports
 `RDGColumnVisibilityProvider`, `RDGColumnVisibilityToolbar`,
 `RDGColumnVisibilityTarget`, and their prop types. Its explicit stylesheet
@@ -362,6 +369,43 @@ export default function App() {
 }
 ```
 
+## Combined contextual controls
+
+Use one `RDGProvider` when search and column visibility control the same grid.
+A direct grid child connects automatically:
+
+```tsx
+import ReactDataGrid from "@geovi/the-datagrid";
+import {
+  RDGColumnVisibilityToolbar,
+  RDGProvider,
+  RDGSearchBar,
+} from "@geovi/the-datagrid/components";
+
+<RDGProvider>
+  <RDGSearchBar />
+  <RDGColumnVisibilityToolbar>
+    <button type="button" onClick={exportRows}>
+      Export CSV
+    </button>
+  </RDGColumnVisibilityToolbar>
+  <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
+</RDGProvider>;
+```
+
+If a `div`, card, Fragment, Suspense boundary, or application component sits
+between the provider and grid, put one `RDGTarget` immediately around the grid.
+`RDGProvider` and `RDGTarget` add no DOM elements and support one grid per
+provider scope. Use `defaultSearchValue` when the shared search query needs a
+non-empty initial value. Do not nest `RDGSearchTarget` and
+`RDGColumnVisibilityTarget`; use the combined target instead.
+
+Controls imported from `@geovi/the-datagrid/search` and
+`@geovi/the-datagrid/column-visibility` also work inside `RDGProvider`. The
+existing `RDGSearchProvider`, `RDGSearchTarget`,
+`RDGColumnVisibilityProvider`, and `RDGColumnVisibilityTarget` exports remain
+supported and are not deprecated.
+
 ## Optional table search
 
 Global search is intentionally separate from the main component entry. A plain
@@ -519,6 +563,17 @@ fallbacks, omits columns with `hideable={false}`, and does not allow the final
 visible column to be hidden. Button state is exposed through `aria-pressed`; no
 eye icon or parallel application visibility state is required.
 
+Set `visible: false` on a column that should start hidden and `hideable: false`
+on one that must not be toggled. `defaultVisible` and `defaultHidden` remain
+ignored compatibility fields. Visibility clicks update grid-owned runtime
+state; a real grid remount discards those overrides and initializes again from
+the current column props.
+
+The default title is a level-two heading that labels the toolbar region. The
+toggle group keeps its `ariaLabel`, and the description is associated with both
+through `aria-describedby`. Passing `title={null}` suppresses the heading while
+preserving the group's accessible name.
+
 Use `RDGColumnVisibilityTarget` around the grid when layout markup separates it
 from the provider. Keep one grid per provider so the column model is
 unambiguous. The JavaScript entry loads its scoped stylesheet automatically; if
@@ -528,6 +583,10 @@ your environment requires manual CSS imports, add
 For the complete direct-child rules, nested layout examples, multiple-grid
 scoping, and the stability contract for all feature-specific providers and
 targets, see [Providers and targets](https://geo-vi.github.io/the-datagrid/docs/reference/providers-and-targets).
+
+When search and visibility share a grid, prefer `RDGProvider`/`RDGTarget` from
+`@geovi/the-datagrid/components`. The feature-specific provider and target
+remain supported for visibility-only screens and existing integrations.
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Documentation and live examples: https://geo-vi.github.io/the-datagrid/
 - Sorting (single + multi-column)
 - Filtering with a built-in filter row and operators
 - Opt-in global table search through a separate, tree-shakeable entry
+- Opt-in contextual column-visibility toolbar with a right-side action slot
 - Column management (reorder, resize, auto-size)
 - Pagination (local + remote)
 - Row selection (checkbox column)
@@ -31,7 +32,8 @@ TypeScript fields: it includes defaults, runtime behavior, callback payloads
 and timing, controlled/uncontrolled state, local and remote data flow, layout,
 keyboard and focus interaction, and accessibility behavior.
 
-The Issue 17 compatibility batch now implements and regression-tests:
+The audited Issue 17 and Issue 48 compatibility batches now implement and
+regression-test:
 
 - natural and per-row height (`rowHeight={null}`, a `rowHeight` function,
   `minRowHeight`/`maxRowHeight`, and width-change remeasurement);
@@ -41,6 +43,12 @@ The Issue 17 compatibility batch now implements and regression-tests:
 - inline editing (`editable`, `editStartEvent`, column editors, lifecycle
   callbacks, cancellation, focus, and keyboard navigation);
 - object- or function-valued whole-row `rowStyle`.
+- the standalone
+  `@geovi/the-datagrid/packages/TextInput` compatibility entry, including its
+  value-first callbacks, clear tool, legacy class hooks, and imperative ref;
+- the `onDidMount` computed-props lifecycle callback; and
+- `getVirtualList().adjustHeights()` for instantiated variable-height rows in
+  virtual and non-virtual layouts.
 
 This closes those audited differences; it does not certify the entire Inovua
 Community API as complete. Remaining mismatches stay in the public status
@@ -51,10 +59,10 @@ technically impossible, document consumer impact and a safe migration path, and
 carry executable coverage. Cost, bundle size, schedule, or architectural
 preference alone do not qualify.
 
-Inovua's internal default editor uses `TextInput`, but a standalone `TextInput`
-was not a documented top-level Community grid API. Matching the observable
-default-editor behavior is in scope; supporting undocumented toolkit deep
-imports is not part of the current public baseline.
+Issue 48 explicitly adopts Inovua's standalone `TextInput` toolkit path. Migrate
+its default import to `@geovi/the-datagrid/packages/TextInput`; the package also
+provides a named root export. The deep entry and its class-instance TypeScript
+shape are now part of the compatibility contract.
 
 Read the public
 [compatibility contract](https://geo-vi.github.io/the-datagrid/docs/migration/inovua-compat)
@@ -122,14 +130,21 @@ method allowlists.
   entry, normalized AND matching, column-scoped queries and aliases, nested or
   derived search values, hidden-column search, a lazy cached local index, static
   Promise search, and `searchValue` forwarding for remote functions.
+- **Optional column visibility:** a separate provider/toolbar/target entry that
+  follows live grid order and visibility, honors non-hideable columns, protects
+  the final visible column, and accepts application actions on the right.
 - **Themes and UI:** packaged CSS, shadcn-aligned controls, `default`, `light`,
   and `dark` token bases, custom `data-theme` hooks, grid-scoped menu portals,
   cell-border modes, i18n overrides, and compatibility class hooks for existing
   Inovua-oriented theme styles.
-- **Imperative compatibility API:** `onReady` and `handle` expose a stable
-  `TypeComputedProps` ref with implemented data, pagination, filtering, sorting,
-  column lookup/order/visibility, selection, DOM lookup, scrolling, loading,
-  header/filter visibility, localization, editing, and virtual-list helpers.
+- **Imperative compatibility API:** `onDidMount`, `handle`, and `onReady`
+  expose the same stable `TypeComputedProps` ref with implemented data,
+  pagination, filtering, sorting, column lookup/order/visibility, selection, DOM
+  lookup, scrolling, loading, header/filter visibility, localization, editing,
+  and virtual-list helpers. `onDidMount` runs first from the passive mount
+  lifecycle; `getVirtualList().adjustHeights()` reads the instantiated
+  variable-height rows' DOM `scrollHeight` without registering extra resize
+  observers.
   The editing subset includes `startEdit`, `tryStartEdit`, `completeEdit`,
   `cancelEdit`, `getCurrentEditInfo`, `isInEdit`, and
   `currentEditCompletePromise`. This is an implemented subset;
@@ -142,7 +157,8 @@ The main entry, `@geovi/the-datagrid`, exports:
 
 - default and named `ReactDataGrid`, plus the compatibility-shaped `plugins`
   empty list;
-- `DateFilter`, `NumberFilter`, `SelectFilter`, and `CheckBox`;
+- `DateFilter`, `NumberFilter`, `SelectFilter`, `CheckBox`, and the named
+  `TextInput`;
 - `DEFAULT_FILTER_TYPES` and its `filterTypes` alias;
 - the public types `CellProps`, `IColumn`, `SortDirection`, `TypeColumn`,
   `TypeColumns`, `TypeColumnEditorProps`, `TypeColumnResizeContext`,
@@ -154,13 +170,24 @@ The main entry, `@geovi/the-datagrid`, exports:
   `TypeGetColumnByParam`, `TypeI18n`, `TypeOnSelectionChangeArg`,
   `TypePaginationMode`, `TypeRowSelection`, `TypeRowStyle`, `TypeRowStyleArgs`,
   `TypeRowStyleProps`, `TypeShowCellBorders`, `TypeSize`, `TypeSingleFilterValue`,
-  `TypeSingleSortInfo`, `TypeSortInfo`, `TypeCheckboxColumn`, and
-  `TypeCheckboxProps`.
+  `TypeSingleSortInfo`, `TypeSortInfo`, `TypeCheckboxColumn`,
+  `TypeCheckboxProps`, `TextInputProps`, `TypeTextInputProps`, and the
+  TextInput callback/input/wrapper/clear-button helper types.
 
 The optional `@geovi/the-datagrid/search` entry exports `RDGSearchProvider`,
 `RDGSearchBar`, `RDGSearchTarget`, and their prop types. The explicit stylesheet
 fallbacks are `@geovi/the-datagrid/style.css` and
 `@geovi/the-datagrid/search/style.css`.
+
+The optional `@geovi/the-datagrid/column-visibility` entry exports
+`RDGColumnVisibilityProvider`, `RDGColumnVisibilityToolbar`,
+`RDGColumnVisibilityTarget`, and their prop types. Its explicit stylesheet
+fallback is `@geovi/the-datagrid/column-visibility/style.css`.
+
+The Inovua-compatible standalone input remains a default class export at
+`@geovi/the-datagrid/packages/TextInput`. That deep entry loads the packaged
+standalone styles, does not load the grid runtime, and preserves `focus()` /
+`setValue()` instance refs.
 
 ### Runtime defaults and filter registry
 
@@ -384,6 +411,10 @@ import {
 </RDGSearchProvider>;
 ```
 
+See [Providers and targets](https://geo-vi.github.io/the-datagrid/docs/reference/providers-and-targets)
+for the exact direct-child rule, Fragment and Suspense boundaries, and
+multiple-grid scoping.
+
 The normal-table bar and transformed-mobile search are two placements of the
 same internal component. They use the same shadcn-style Input and Button,
 column-prefix highlighting, IME handling, Escape behavior, and clear/refocus
@@ -455,6 +486,48 @@ Remote functions own the search operation. The grid does not post-filter one
 remote page and present it as a server-wide result. If the backend does not yet
 support global search, keep that search state application-owned until its
 request contract is defined.
+
+## Optional column visibility toolbar
+
+Column visibility controls are also an opt-in contextual entry. A direct grid
+child connects automatically, and toolbar children form a separate right-side
+action area for consumer-owned export, filter, or navigation controls:
+
+```tsx
+import ReactDataGrid from "@geovi/the-datagrid";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityToolbar,
+} from "@geovi/the-datagrid/column-visibility";
+
+<RDGColumnVisibilityProvider>
+  <RDGColumnVisibilityToolbar>
+    <button type="button" onClick={exportRows}>
+      Export CSV
+    </button>
+    <button type="button" onClick={toggleFilters}>
+      Show filters
+    </button>
+  </RDGColumnVisibilityToolbar>
+  <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
+</RDGColumnVisibilityProvider>;
+```
+
+The toolbar renders columns in the grid's current order and reflects the live
+visibility map. It uses string or numeric headers with stable `id`/`name`
+fallbacks, omits columns with `hideable={false}`, and does not allow the final
+visible column to be hidden. Button state is exposed through `aria-pressed`; no
+eye icon or parallel application visibility state is required.
+
+Use `RDGColumnVisibilityTarget` around the grid when layout markup separates it
+from the provider. Keep one grid per provider so the column model is
+unambiguous. The JavaScript entry loads its scoped stylesheet automatically; if
+your environment requires manual CSS imports, add
+`import "@geovi/the-datagrid/column-visibility/style.css"`.
+
+For the complete direct-child rules, nested layout examples, multiple-grid
+scoping, and the stability contract for all feature-specific providers and
+targets, see [Providers and targets](https://geo-vi.github.io/the-datagrid/docs/reference/providers-and-targets).
 
 ## Advanced usage
 
@@ -685,14 +758,20 @@ source-compatible.
 
 ### Misc
 
-| Prop        | Type                       | Default | Description                                         |
-| ----------- | -------------------------- | ------- | --------------------------------------------------- |
-| `i18n`      | `TypeI18n`                 | -       | Text overrides (labels, operators, etc.)            |
-| `loading`   | `boolean`                  | -       | Loading state                                       |
-| `onReady`   | `(ref: RefObject) => void` | -       | Called with an Inovua-compatible computed-props ref |
-| `handle`    | `(ref: RefObject) => void` | -       | Alias for `onReady`                                 |
-| `className` | `string`                   | -       | Extra CSS classes                                   |
-| `style`     | `CSSProperties`            | -       | Inline styles                                       |
+| Prop         | Type                                                 | Default | Description                                                       |
+| ------------ | ---------------------------------------------------- | ------- | ----------------------------------------------------------------- |
+| `i18n`       | `TypeI18n`                                           | -       | Text overrides (labels, operators, etc.)                          |
+| `loading`    | `boolean`                                            | -       | Loading state                                                     |
+| `onDidMount` | `(ref: MutableRefObject<TypeComputedProps \| null>)` | -       | Passive mount callback after API hydration, before handle/onReady |
+| `handle`     | `(ref: MutableRefObject<TypeComputedProps \| null>)` | -       | Receives the same stable ref after onDidMount                     |
+| `onReady`    | `(ref: MutableRefObject<TypeComputedProps \| null>)` | -       | Receives the same stable ref after handle                         |
+| `className`  | `string`                                             | -       | Extra CSS classes                                                 |
+| `style`      | `CSSProperties`                                      | -       | Inline styles                                                     |
+
+Issue 48 certifies the `onDidMount` mount contract. The existing `handle` and
+`onReady` adapters are usable, but Inovua's callback-identity cleanup and
+nonzero-width readiness details remain explicitly listed as a known gap in the
+public compatibility ledger.
 
 ## TypeScript
 

--- a/examples/src/ColumnVisibilityCompatPage.tsx
+++ b/examples/src/ColumnVisibilityCompatPage.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState } from "react";
+
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+} from "../../src/column-visibility";
+import ReactDataGrid, { type TypeColumns } from "../../src/main";
+
+const rows = [
+  { id: 1, name: "Ada Lovelace", city: "London" },
+  { id: 2, name: "Grace Hopper", city: "New York" },
+];
+
+const directRows = [{ id: 1, locked: "Always present", optional: "Optional" }];
+
+const directColumns: TypeColumns = [
+  {
+    name: "locked",
+    header: "Locked",
+    hideable: false,
+    defaultWidth: 180,
+  },
+  {
+    name: "optional",
+    header: "Optional",
+    visible: false,
+    defaultWidth: 180,
+  },
+];
+
+export default function ColumnVisibilityCompatPage() {
+  const columns = useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 100 },
+      { name: "name", header: "Name", defaultWidth: 220 },
+      { name: "city", header: "City", defaultWidth: 180, visible: false },
+    ],
+    []
+  );
+  const [columnOrder, setColumnOrder] = useState(["id", "name", "city"]);
+  const [gridKey, setGridKey] = useState(0);
+
+  return (
+    <main
+      className="flex min-h-screen flex-col gap-4 bg-background p-6 text-foreground"
+      data-testid="column-visibility-compat"
+    >
+      <div className="flex gap-2">
+        <button
+          type="button"
+          data-testid="column-visibility-reverse-order"
+          onClick={() => setColumnOrder((current) => [...current].reverse())}
+        >
+          Reverse order
+        </button>
+        <button
+          type="button"
+          data-testid="column-visibility-remount-grid"
+          onClick={() => setGridKey((current) => current + 1)}
+        >
+          Remount grid
+        </button>
+      </div>
+
+      <section data-testid="column-visibility-nested-target">
+        <RDGColumnVisibilityProvider>
+          <RDGColumnVisibilityToolbar title="Fixture columns" />
+
+          <div className="h-80 min-h-0">
+            <RDGColumnVisibilityTarget>
+              <ReactDataGrid
+                key={gridKey}
+                idProperty="id"
+                columns={columns}
+                dataSource={rows}
+                columnOrder={columnOrder}
+                onColumnOrderChange={setColumnOrder}
+                virtualized={false}
+                showColumnMenuTool={false}
+              />
+            </RDGColumnVisibilityTarget>
+          </div>
+        </RDGColumnVisibilityProvider>
+      </section>
+
+      <section data-testid="column-visibility-direct-target">
+        <RDGColumnVisibilityProvider>
+          <RDGColumnVisibilityToolbar title="Direct target columns" />
+          <ReactDataGrid
+            idProperty="id"
+            columns={directColumns}
+            dataSource={directRows}
+            virtualized={false}
+            showColumnMenuTool={false}
+            style={{ height: 240 }}
+          />
+        </RDGColumnVisibilityProvider>
+      </section>
+    </main>
+  );
+}

--- a/examples/src/ColumnVisibilityCompatPage.tsx
+++ b/examples/src/ColumnVisibilityCompatPage.tsx
@@ -6,6 +6,13 @@ import {
   RDGColumnVisibilityToolbar,
 } from "../../src/column-visibility";
 import ReactDataGrid, { type TypeColumns } from "../../src/main";
+import {
+  RDGColumnVisibilityToolbar as CombinedColumnVisibilityToolbar,
+  RDGProvider,
+  RDGSearchBar as CombinedSearchBar,
+  RDGTarget,
+} from "../../src/providers";
+import { RDGSearchBar as LegacySearchBar } from "../../src/search";
 
 const rows = [
   { id: 1, name: "Ada Lovelace", city: "London" },
@@ -27,6 +34,33 @@ const directColumns: TypeColumns = [
     visible: false,
     defaultWidth: 180,
   },
+];
+
+const combinedRows = [
+  {
+    id: "combined-1",
+    name: "Ada Lovelace",
+    city: "London",
+    role: "Mathematician",
+  },
+  {
+    id: "combined-2",
+    name: "Grace Hopper",
+    city: "New York",
+    role: "Rear admiral",
+  },
+  {
+    id: "combined-3",
+    name: "Katherine Johnson",
+    city: "Paris",
+    role: "Research mathematician",
+  },
+];
+
+const combinedColumns: TypeColumns = [
+  { name: "name", header: "Name", defaultWidth: 220 },
+  { name: "city", header: "City", defaultWidth: 180 },
+  { name: "role", header: "Role", defaultWidth: 220 },
 ];
 
 export default function ColumnVisibilityCompatPage() {
@@ -96,6 +130,52 @@ export default function ColumnVisibilityCompatPage() {
             style={{ height: 240 }}
           />
         </RDGColumnVisibilityProvider>
+      </section>
+
+      <section
+        className="flex flex-col gap-3"
+        data-testid="combined-provider-direct-target"
+      >
+        <RDGProvider>
+          <CombinedSearchBar
+            ariaLabel="Search direct combined grid"
+            debounceMs={0}
+          />
+          <CombinedColumnVisibilityToolbar title="Direct combined columns" />
+          <ReactDataGrid
+            idProperty="id"
+            columns={combinedColumns}
+            dataSource={combinedRows}
+            allowMobileTransform
+            virtualized={false}
+            showColumnMenuTool={false}
+            style={{ height: 320 }}
+          />
+        </RDGProvider>
+      </section>
+
+      <section
+        className="flex flex-col gap-3"
+        data-testid="combined-provider-nested-target"
+      >
+        <RDGProvider defaultSearchValue="London">
+          <LegacySearchBar
+            ariaLabel="Search nested combined grid"
+            debounceMs={0}
+          />
+          <RDGColumnVisibilityToolbar title="Nested mixed-import columns" />
+          <div className="h-80 min-h-0">
+            <RDGTarget>
+              <ReactDataGrid
+                idProperty="id"
+                columns={combinedColumns}
+                dataSource={combinedRows}
+                virtualized={false}
+                showColumnMenuTool={false}
+              />
+            </RDGTarget>
+          </div>
+        </RDGProvider>
       </section>
     </main>
   );

--- a/examples/src/ComputedPropsCompatPage.tsx
+++ b/examples/src/ComputedPropsCompatPage.tsx
@@ -46,6 +46,7 @@ const virtualListCompatKeys = [
   "getRows",
   "scrollToIndex",
   "smoothScrollTo",
+  "adjustHeights",
 ];
 
 type CompatStatus = {

--- a/examples/src/Issue48CompatPage.tsx
+++ b/examples/src/Issue48CompatPage.tsx
@@ -1,0 +1,881 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  type CellProps,
+  type TypeColumns,
+  type TypeComputedProps,
+  type TypeDataGridProps,
+} from "../../src/main";
+import { Button } from "../../src/components/ui/button";
+
+type Issue48Scenario =
+  | "text-input"
+  | "did-mount"
+  | "did-mount-zero-width"
+  | "did-mount-async"
+  | "adjust-natural"
+  | "adjust-fixed"
+  | "adjust-function"
+  | "adjust-nonvirtual"
+  | "adjust-safe";
+
+type TextInputHandle = {
+  focus: () => void;
+  renderClearButton: (
+    config: TextInputClearButtonCompatConfig
+  ) => React.ReactNode;
+  setValue: (value: unknown, event?: unknown) => void;
+};
+
+type TextInputCompatProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "onChange"
+> & {
+  value?: unknown;
+  defaultValue?: unknown;
+  type?: string;
+  theme?: string;
+  name?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  maxLength?: number;
+  minLength?: number;
+  required?: boolean;
+  readOnly?: boolean;
+  disabled?: boolean;
+  hidden?: boolean;
+  stopChangePropagation?: boolean | null;
+  enableClearButton?: boolean;
+  acceptClearToolFocus?: boolean;
+  rtl?: boolean;
+  rootClassName?: string;
+  clearButtonSize?: number | [number, number];
+  clearButtonColor?: string;
+  clearButtonStyle?: React.CSSProperties;
+  clearButtonClassName?: string;
+  inputProps?:
+    | (Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> & {
+        "data-testid"?: string;
+        onChange?: (value: unknown, event?: unknown) => void;
+      })
+    | null;
+  wrapperProps?: React.HTMLAttributes<HTMLDivElement>;
+  onChange?: (value: unknown, event?: unknown) => void;
+};
+
+type TextInputCompatComponent = React.ComponentType<
+  TextInputCompatProps & React.RefAttributes<TextInputHandle>
+>;
+
+type TextInputClearButtonCompatConfig = {
+  clearButtonClassName?: string;
+  clearButtonColor?: string;
+  clearButtonSize?: number | readonly [number, number] | null;
+  clearButtonStyle?: React.CSSProperties;
+};
+
+type Issue48GridProps = TypeDataGridProps & {
+  onDidMount?: (
+    computedPropsRef: React.MutableRefObject<TypeComputedProps | null>
+  ) => void;
+};
+
+type MountEvent = {
+  type: "didMount" | "handle" | "ready";
+  refId: number;
+  callbackVersion: number;
+  apiLive: boolean;
+  domConnected: boolean;
+  rowCount: number | null;
+};
+
+type HeightSnapshot = {
+  height: number | null;
+  start: number | null;
+  end: number | null;
+  nextStart: number | null;
+  total: number | null;
+};
+
+type AdjustReport = {
+  methodExists: boolean;
+  returnedUndefined: boolean;
+  error: string | null;
+  mode: string;
+  before: HeightSnapshot;
+  stale: HeightSnapshot;
+  after: HeightSnapshot;
+  domHeight: number | null;
+  totalRows: number;
+  mountedIndexes: number[];
+  measuredIndexes: number[];
+};
+
+const CompatGrid = ReactDataGrid as React.ComponentType<Issue48GridProps>;
+
+// Keep this fixture runnable before the missing compatibility entry point is
+// implemented. Vite eagerly discovers the source module once it exists; until
+// then the visible marker makes every TextInput assertion fail for that exact
+// product gap instead of failing the fixture build.
+const packageModules = import.meta.glob("../../src/packages/**/*.{ts,tsx}", {
+  eager: true,
+}) as Record<string, { default?: unknown }>;
+const textInputModule = Object.entries(packageModules).find(([path]) =>
+  /\/TextInput(?:\/index)?\.(?:ts|tsx)$/.test(path)
+)?.[1];
+const TextInput = textInputModule?.default as
+  | TextInputCompatComponent
+  | undefined;
+const TextInputClass = TextInput as
+  | React.ComponentClass<TextInputCompatProps>
+  | undefined;
+const SubclassTextInput = TextInputClass
+  ? class extends TextInputClass {
+      renderClearButton(config: TextInputClearButtonCompatConfig) {
+        return (
+          <button
+            type="button"
+            className={config.clearButtonClassName}
+            data-testid="subclass-clear-button"
+            data-clear-color={config.clearButtonColor}
+            data-clear-size={JSON.stringify(config.clearButtonSize)}
+            data-clear-style={JSON.stringify(config.clearButtonStyle)}
+          >
+            Subclass clear
+          </button>
+        );
+      }
+    }
+  : undefined;
+
+const columns: TypeColumns = [
+  { name: "id", header: "ID", width: 88 },
+  { name: "name", header: "Name", width: 220 },
+];
+const columnOrder = ["id", "name"];
+const rows = [
+  { id: 1, name: "Ada Lovelace" },
+  { id: 2, name: "Grace Hopper" },
+];
+
+function readScenario(): Issue48Scenario {
+  if (typeof window === "undefined") return "text-input";
+
+  const value = new URLSearchParams(window.location.search).get("scenario");
+  switch (value) {
+    case "did-mount":
+    case "did-mount-zero-width":
+    case "did-mount-async":
+    case "adjust-natural":
+    case "adjust-fixed":
+    case "adjust-function":
+    case "adjust-nonvirtual":
+    case "adjust-safe":
+    case "text-input":
+      return value;
+    default:
+      return "text-input";
+  }
+}
+
+function ScenarioShell(props: {
+  scenario: Issue48Scenario;
+  children: React.ReactNode;
+}) {
+  return (
+    <main
+      data-testid="issue-48-scenario"
+      data-scenario={props.scenario}
+      className="mx-auto flex w-full max-w-5xl flex-col gap-4"
+    >
+      <header className="space-y-1">
+        <p className="text-sm font-medium text-muted-foreground">
+          Issue #48 compatibility fixture
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {props.scenario}
+        </h1>
+      </header>
+      {props.children}
+    </main>
+  );
+}
+
+function Report(props: { testId: string; children: React.ReactNode }) {
+  return (
+    <output
+      data-testid={props.testId}
+      className="block overflow-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs"
+    >
+      {props.children}
+    </output>
+  );
+}
+
+function TextInputScenario() {
+  const inputRef = React.useRef<TextInputHandle | null>(null);
+  const [events, setEvents] = React.useState<string[]>([]);
+  const [outerChanges, setOuterChanges] = React.useState(0);
+  const [controlledValue, setControlledValue] = React.useState("locked");
+  const [controlledCandidate, setControlledCandidate] = React.useState("");
+  const [detachedRenderStatus, setDetachedRenderStatus] =
+    React.useState("idle");
+
+  const log = React.useCallback((event: string) => {
+    setEvents((current) => [...current, event]);
+  }, []);
+
+  if (!TextInput) {
+    return (
+      <section
+        data-testid="text-input-availability"
+        data-available="false"
+        className="rounded-lg border border-dashed p-4"
+      >
+        The TextInput compatibility entry point is missing.
+      </section>
+    );
+  }
+
+  return (
+    <section
+      data-testid="text-input-availability"
+      data-available="true"
+      className="space-y-4 rounded-lg border bg-card p-4"
+      onChange={() => setOuterChanges((current) => current + 1)}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-2">
+          <span>Uncontrolled</span>
+          <TextInput
+            ref={inputRef}
+            data-testid="uncontrolled-root"
+            defaultValue="seed"
+            inputProps={{
+              "data-testid": "uncontrolled-input",
+              onChange: (value) => log(`input:${String(value)}`),
+            }}
+            clearButtonClassName="issue48-uncontrolled-clear"
+            onChange={(value) => log(`root:${String(value)}`)}
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Controlled</span>
+          <TextInput
+            data-testid="controlled-root"
+            value={controlledValue}
+            inputProps={{ "data-testid": "controlled-input" }}
+            clearButtonClassName="issue48-controlled-clear"
+            onChange={(value) => {
+              setControlledCandidate(String(value));
+              log(`controlled:${String(value)}`);
+            }}
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Disabled</span>
+          <TextInput
+            data-testid="disabled-root"
+            defaultValue="disabled value"
+            disabled
+            inputProps={{ "data-testid": "disabled-input" }}
+            clearButtonClassName="issue48-disabled-clear"
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Read only</span>
+          <TextInput
+            data-testid="readonly-root"
+            defaultValue="read only value"
+            readOnly
+            inputProps={{ "data-testid": "readonly-input" }}
+            clearButtonClassName="issue48-readonly-clear"
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Propagation enabled</span>
+          <TextInput
+            data-testid="propagating-root"
+            defaultValue="propagates"
+            stopChangePropagation={false}
+            inputProps={{ "data-testid": "propagating-input" }}
+            clearButtonClassName="issue48-propagating-clear"
+            onChange={(value) => log(`propagating:${String(value)}`)}
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Focusable clear tool</span>
+          <TextInput
+            data-testid="focusable-clear-root"
+            defaultValue="tab stop"
+            acceptClearToolFocus
+            inputProps={{
+              "data-testid": "focusable-clear-input",
+              stopChangePropagation: false,
+            }}
+            clearButtonClassName="issue48-focusable-clear"
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Null input props</span>
+          <TextInput
+            data-testid="null-input-props-root"
+            defaultValue="null-safe"
+            inputProps={null}
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Legacy numeric empty value</span>
+          <TextInput
+            data-testid="numeric-zero-root"
+            value={0}
+            clearButtonClassName="issue48-numeric-zero-clear"
+            inputProps={{ "data-testid": "numeric-zero-input" }}
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Falsey clear size</span>
+          <TextInput
+            defaultValue="size fallback"
+            clearButtonSize={0}
+            clearButtonClassName="issue48-zero-size-clear"
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Null propagation flag</span>
+          <TextInput
+            data-testid="null-propagation-root"
+            defaultValue="bubbles"
+            stopChangePropagation={null}
+            inputProps={{ "data-testid": "null-propagation-input" }}
+          />
+        </label>
+
+        <label className="space-y-2">
+          <span>Custom RTL theme</span>
+          <TextInput
+            data-testid="custom-theme-root"
+            defaultValue="rtl value"
+            rootClassName="issue48-custom-text-input"
+            theme="midnight"
+            rtl
+            data-theme="consumer-theme-hook"
+            data-disabled="consumer-disabled-hook"
+            data-focused="consumer-focused-hook"
+            dir="auto"
+            inputProps={{ "data-testid": "custom-theme-input" }}
+            clearButtonClassName="issue48-custom-clear"
+          />
+        </label>
+
+        {SubclassTextInput ? (
+          <label className="space-y-2">
+            <span>Subclass clear renderer</span>
+            <SubclassTextInput
+              defaultValue="subclass value"
+              clearButtonClassName="issue48-subclass-clear"
+              clearButtonColor="rgb(10, 20, 30)"
+              clearButtonSize={[13, 17]}
+              clearButtonStyle={{ opacity: 0.75 }}
+            />
+          </label>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          data-testid="imperative-focus"
+          onClick={() => inputRef.current?.focus()}
+        >
+          Focus uncontrolled
+        </Button>
+        <Button
+          type="button"
+          data-testid="imperative-set-value"
+          onClick={() => inputRef.current?.setValue("imperative")}
+        >
+          Set uncontrolled
+        </Button>
+        <Button
+          type="button"
+          data-testid="apply-controlled"
+          onClick={() => setControlledValue(controlledCandidate)}
+        >
+          Apply controlled candidate
+        </Button>
+        <Button
+          type="button"
+          data-testid="call-detached-clear-renderer"
+          onClick={() => {
+            try {
+              const renderClearButton = inputRef.current?.renderClearButton;
+              const result = renderClearButton?.({
+                clearButtonClassName: "detached-clear",
+                clearButtonColor: "purple",
+                clearButtonSize: 9,
+              });
+              setDetachedRenderStatus(
+                React.isValidElement(result) ? "rendered" : "missing"
+              );
+            } catch (error) {
+              setDetachedRenderStatus(
+                error instanceof Error ? `error:${error.message}` : "error"
+              );
+            }
+          }}
+        >
+          Call detached clear renderer
+        </Button>
+      </div>
+
+      <Report testId="text-input-events">{JSON.stringify(events)}</Report>
+      <Report testId="text-input-outer-changes">{outerChanges}</Report>
+      <Report testId="controlled-candidate">{controlledCandidate}</Report>
+      <Report testId="detached-render-status">{detachedRenderStatus}</Report>
+    </section>
+  );
+}
+
+function refIdFor(
+  refs: WeakMap<object, number>,
+  nextId: React.MutableRefObject<number>,
+  ref: React.MutableRefObject<TypeComputedProps | null>
+) {
+  const existing = refs.get(ref);
+  if (existing != null) return existing;
+
+  const id = nextId.current;
+  nextId.current += 1;
+  refs.set(ref, id);
+  return id;
+}
+
+function DidMountScenario() {
+  const [mountKey, setMountKey] = React.useState(0);
+  const [callbackVersion, setCallbackVersion] = React.useState(0);
+  const [events, setEvents] = React.useState<MountEvent[]>([]);
+  const refs = React.useRef(new WeakMap<object, number>());
+  const nextRefId = React.useRef(1);
+
+  const record = React.useCallback(
+    (
+      type: MountEvent["type"],
+      ref: React.MutableRefObject<TypeComputedProps | null>,
+      version: number
+    ) => {
+      const api = ref.current;
+      setEvents((current) => [
+        ...current,
+        {
+          type,
+          refId: refIdFor(refs.current, nextRefId, ref),
+          callbackVersion: version,
+          apiLive: Boolean(api && typeof api.getVirtualList === "function"),
+          domConnected: Boolean(api?.getDOMNode?.()?.isConnected),
+          rowCount:
+            typeof api?.getCount?.() === "number" ? api.getCount() : null,
+        },
+      ]);
+    },
+    []
+  );
+
+  const didMountCallback = React.useMemo(
+    () => (ref: React.MutableRefObject<TypeComputedProps | null>) =>
+      record("didMount", ref, callbackVersion),
+    [callbackVersion, record]
+  );
+  const handleCallback = React.useCallback(
+    (ref: React.MutableRefObject<TypeComputedProps | null> | null) => {
+      if (ref) record("handle", ref, callbackVersion);
+    },
+    [callbackVersion, record]
+  );
+  const readyCallback = React.useCallback(
+    (ref: React.MutableRefObject<TypeComputedProps | null>) =>
+      record("ready", ref, callbackVersion),
+    [callbackVersion, record]
+  );
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          data-testid="did-mount-rerender"
+          onClick={() => setCallbackVersion((current) => current + 1)}
+        >
+          Replace callback and rerender
+        </Button>
+        <Button
+          type="button"
+          data-testid="did-mount-remount"
+          onClick={() => setMountKey((current) => current + 1)}
+        >
+          Remount grid
+        </Button>
+      </div>
+
+      <Report testId="did-mount-events">{JSON.stringify(events)}</Report>
+
+      <div className="h-[260px] min-h-0 rounded-lg border">
+        <CompatGrid
+          key={mountKey}
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          columnOrder={columnOrder}
+          virtualized
+          onDidMount={didMountCallback}
+          handle={handleCallback}
+          onReady={readyCallback}
+        />
+      </div>
+    </section>
+  );
+}
+
+function DidMountZeroWidthScenario() {
+  const [events, setEvents] = React.useState<MountEvent[]>([]);
+  const refs = React.useRef(new WeakMap<object, number>());
+  const nextRefId = React.useRef(1);
+
+  return (
+    <section className="space-y-4">
+      <Report testId="did-mount-zero-events">{JSON.stringify(events)}</Report>
+      <div
+        data-testid="zero-width-host"
+        className="h-[180px] w-0 overflow-hidden"
+      >
+        <CompatGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          columnOrder={columnOrder}
+          virtualized
+          onDidMount={(ref) => {
+            const api = ref.current;
+            setEvents((current) => [
+              ...current,
+              {
+                type: "didMount",
+                refId: refIdFor(refs.current, nextRefId, ref),
+                callbackVersion: 0,
+                apiLive: Boolean(
+                  api && typeof api.getVirtualList === "function"
+                ),
+                domConnected: Boolean(api?.getDOMNode?.()?.isConnected),
+                rowCount:
+                  typeof api?.getCount?.() === "number" ? api.getCount() : null,
+              },
+            ]);
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
+function DidMountAsyncScenario() {
+  const [deferred] = React.useState(() => {
+    let resolvePromise: (value: typeof rows) => void = () => undefined;
+    const promise = new Promise<typeof rows>((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    return { promise, resolve: resolvePromise };
+  });
+  const [calls, setCalls] = React.useState(0);
+
+  const dataSource = React.useCallback(() => deferred.promise, [deferred]);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          data-testid="resolve-async-data"
+          onClick={() => deferred.resolve(rows)}
+        >
+          Resolve data
+        </Button>
+        <Report testId="did-mount-async-calls">{calls}</Report>
+      </div>
+      <div className="h-[260px] min-h-0 rounded-lg border">
+        <CompatGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={dataSource}
+          columnOrder={columnOrder}
+          virtualized
+          onDidMount={() => setCalls((current) => current + 1)}
+        />
+      </div>
+    </section>
+  );
+}
+
+function snapshotHeight(api: TypeComputedProps | null): HeightSnapshot {
+  const virtualList = api?.getVirtualList?.();
+  const first = virtualList?.getRowAt?.(0);
+  const next = virtualList?.getRowAt?.(1);
+  const total = virtualList?.getTotalRowHeight?.();
+
+  return {
+    height: typeof first?.height === "number" ? Math.round(first.height) : null,
+    start: typeof first?.start === "number" ? Math.round(first.start) : null,
+    end: typeof first?.end === "number" ? Math.round(first.end) : null,
+    nextStart: typeof next?.start === "number" ? Math.round(next.start) : null,
+    total: typeof total === "number" ? Math.round(total) : null,
+  };
+}
+
+function AdjustHeightScenario(props: {
+  mode: "natural" | "fixed" | "function" | "nonvirtual";
+}) {
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const scopeRef = React.useRef<HTMLDivElement | null>(null);
+  const [report, setReport] = React.useState<AdjustReport | null>(null);
+  const data = React.useMemo(
+    () =>
+      Array.from(
+        { length: props.mode === "nonvirtual" ? 12 : 400 },
+        (_, index) => ({
+          id: `height-${index}`,
+          label: `Measured row ${index + 1}`,
+        })
+      ),
+    [props.mode]
+  );
+  const heightColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 110 },
+      {
+        name: "label",
+        header: "Measured content",
+        width: 360,
+        render: ({ value, rowIndex }: CellProps) => (
+          <div data-testid={`height-content-${rowIndex}`}>{String(value)}</div>
+        ),
+      },
+    ],
+    []
+  );
+  const rowHeight =
+    props.mode === "natural" || props.mode === "nonvirtual"
+      ? null
+      : props.mode === "fixed"
+        ? 48
+        : () => 48;
+  const virtualized = props.mode !== "nonvirtual";
+
+  const runAdjustment = React.useCallback(() => {
+    const api = apiRef.current;
+    const virtualList = api?.getVirtualList?.() as
+      | (ReturnType<TypeComputedProps["getVirtualList"]> & {
+          adjustHeights?: () => void;
+        })
+      | undefined;
+    const adjustHeights = virtualList?.adjustHeights;
+    const target = scopeRef.current?.querySelector<HTMLElement>(
+      '[data-slot="grid-row"][data-row-index="0"]'
+    );
+    const mountedRows = Array.from(
+      scopeRef.current?.querySelectorAll<HTMLElement>(
+        '[data-slot="grid-row"][data-row-index]'
+      ) ?? []
+    );
+    const mountedIndexes = mountedRows
+      .map((row) => Number(row.dataset.rowIndex))
+      .filter(Number.isFinite);
+    const before = snapshotHeight(api);
+
+    if (target) {
+      target.style.height = "168px";
+      // Force layout before calling adjustHeights. Inovua reads scrollHeight
+      // synchronously, then lets its row-height manager rebuild offsets on the
+      // next animation frame.
+      void target.scrollHeight;
+    }
+
+    const domHeight = target ? Math.round(target.scrollHeight) : null;
+    const stale = snapshotHeight(api);
+    const measuredIndexes: number[] = [];
+    const measuredHeights = mountedRows.map((row) => row.scrollHeight);
+
+    mountedRows.forEach((row, index) => {
+      Object.defineProperty(row, "scrollHeight", {
+        configurable: true,
+        get() {
+          measuredIndexes.push(Number(row.dataset.rowIndex));
+          return measuredHeights[index];
+        },
+      });
+    });
+
+    let returnedUndefined = false;
+    let error: string | null = null;
+    try {
+      const result = adjustHeights?.call(virtualList);
+      returnedUndefined = result === undefined;
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught);
+    } finally {
+      mountedRows.forEach((row) => {
+        Reflect.deleteProperty(row, "scrollHeight");
+      });
+    }
+
+    const nextReport: AdjustReport = {
+      methodExists: typeof adjustHeights === "function",
+      returnedUndefined,
+      error,
+      mode: props.mode,
+      before,
+      stale,
+      // Offset reindexing is allowed to settle on the next frame, as it does
+      // in the upstream row-height manager.
+      after: stale,
+      domHeight,
+      totalRows: data.length,
+      mountedIndexes,
+      measuredIndexes,
+    };
+    setReport(nextReport);
+    window.requestAnimationFrame(() => {
+      setReport((current) =>
+        current === nextReport
+          ? { ...current, after: snapshotHeight(apiRef.current) }
+          : current
+      );
+    });
+  }, [data.length, props.mode]);
+
+  return (
+    <section ref={scopeRef} className="space-y-4">
+      <Button
+        type="button"
+        data-testid="run-adjust-heights"
+        onClick={runAdjustment}
+      >
+        Mutate row and adjust heights
+      </Button>
+      <Report testId="adjust-heights-report">{JSON.stringify(report)}</Report>
+      <div className="h-[300px] w-[560px] max-w-full min-h-0 rounded-lg border">
+        <ReactDataGrid
+          idProperty="id"
+          columns={heightColumns}
+          dataSource={data}
+          columnOrder={["id", "label"]}
+          virtualized={virtualized}
+          rowHeight={rowHeight}
+          minRowHeight={40}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
+function AdjustSafeScenario() {
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [report, setReport] = React.useState<{
+    methodExists: boolean;
+    returnedUndefined: boolean;
+    error: string | null;
+  } | null>(null);
+
+  return (
+    <section className="space-y-4">
+      <Button
+        type="button"
+        data-testid="run-safe-adjust-heights"
+        onClick={() => {
+          const virtualList = apiRef.current?.getVirtualList?.() as
+            | (ReturnType<TypeComputedProps["getVirtualList"]> & {
+                adjustHeights?: () => void;
+              })
+            | undefined;
+          let error: string | null = null;
+          let returnedUndefined = false;
+          try {
+            const result = virtualList?.adjustHeights?.();
+            returnedUndefined = result === undefined;
+          } catch (caught) {
+            error = caught instanceof Error ? caught.message : String(caught);
+          }
+          setReport({
+            methodExists: typeof virtualList?.adjustHeights === "function",
+            returnedUndefined,
+            error,
+          });
+        }}
+      >
+        Adjust empty non-virtual grid
+      </Button>
+      <Report testId="adjust-safe-report">{JSON.stringify(report)}</Report>
+      <div className="h-[220px] min-h-0 rounded-lg border">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={[]}
+          columnOrder={columnOrder}
+          virtualized={false}
+          rowHeight={null}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default function Issue48CompatPage() {
+  const scenario = readScenario();
+
+  let content: React.ReactNode;
+  switch (scenario) {
+    case "did-mount":
+      content = <DidMountScenario />;
+      break;
+    case "did-mount-zero-width":
+      content = <DidMountZeroWidthScenario />;
+      break;
+    case "did-mount-async":
+      content = <DidMountAsyncScenario />;
+      break;
+    case "adjust-natural":
+      content = <AdjustHeightScenario mode="natural" />;
+      break;
+    case "adjust-fixed":
+      content = <AdjustHeightScenario mode="fixed" />;
+      break;
+    case "adjust-function":
+      content = <AdjustHeightScenario mode="function" />;
+      break;
+    case "adjust-nonvirtual":
+      content = <AdjustHeightScenario mode="nonvirtual" />;
+      break;
+    case "adjust-safe":
+      content = <AdjustSafeScenario />;
+      break;
+    default:
+      content = <TextInputScenario />;
+      break;
+  }
+
+  return <ScenarioShell scenario={scenario}>{content}</ScenarioShell>;
+}

--- a/examples/src/UsersGridExample.tsx
+++ b/examples/src/UsersGridExample.tsx
@@ -12,8 +12,12 @@ import ReactDataGrid, {
   type TypeI18n,
   type TypeShowCellBorders,
 } from "../../src/main";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+} from "../../src/column-visibility";
 import { Button } from "../../src/components/ui/button";
-import { ButtonGroup } from "../../src/components/ui/button-group";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -23,8 +27,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../../src/components/ui/dropdown-menu";
-
-const FILTER_RESERVED_COLNAME = "_filterColActive";
 
 const roleOptions = [
   "Administrator",
@@ -61,16 +63,6 @@ type UsersGridExampleProps = {
   i18n: TypeI18n;
   resizable: boolean;
   showCellBorders: TypeShowCellBorders;
-};
-
-type UsersToolbarProps = {
-  columns: TypeColumns;
-  selectedColumns: string[];
-  order: string[];
-  filtersActive: boolean;
-  onSelectedColumnsChange: (columns: string[]) => void;
-  onToggleFilters: () => void;
-  onExport: (format: ExportFormat) => void;
 };
 
 function getColumnId(column: TypeColumn): string {
@@ -194,118 +186,6 @@ function orderColumns(columns: TypeColumns, order: string[]) {
     (column) => !order.includes(getColumnId(column))
   );
   return [...ordered, ...remaining];
-}
-
-function UsersToolbar({
-  columns,
-  selectedColumns,
-  order,
-  filtersActive,
-  onSelectedColumnsChange,
-  onToggleFilters,
-  onExport,
-}: UsersToolbarProps) {
-  const orderedColumns = useMemo(
-    () => orderColumns(columns, order),
-    [columns, order]
-  );
-
-  const visibleColumnNames = selectedColumns.filter(
-    (name) => name !== FILTER_RESERVED_COLNAME
-  );
-  const visibleSet = new Set(visibleColumnNames);
-
-  function toggleColumn(columnName: string) {
-    const isVisible = visibleSet.has(columnName);
-
-    if (isVisible && visibleColumnNames.length === 1) {
-      return;
-    }
-
-    if (isVisible) {
-      onSelectedColumnsChange(
-        visibleColumnNames.filter((name) => name !== columnName)
-      );
-      return;
-    }
-
-    onSelectedColumnsChange([...visibleColumnNames, columnName]);
-  }
-
-  return (
-    <div className="flex flex-col gap-3 rounded-xl border bg-card/60 p-3 shadow-sm">
-      <div className="flex flex-col gap-1">
-        <div className="text-sm font-medium">Visible columns</div>
-        <div className="text-xs text-muted-foreground">
-          Toggle columns, export the current dataset shape, and show or hide the
-          filter row.
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-        <ButtonGroup
-          aria-label="Visible column toggles"
-          className="flex max-w-full flex-wrap gap-2"
-        >
-          {orderedColumns.map((column) => {
-            const columnId = getColumnId(column);
-            const isVisible = visibleSet.has(columnId);
-
-            return (
-              <Button
-                key={columnId}
-                type="button"
-                variant={isVisible ? "secondary" : "outline"}
-                size="sm"
-                className="rounded-md"
-                aria-pressed={isVisible}
-                onClick={() => toggleColumn(columnId)}
-              >
-                {getColumnLabel(column)}
-              </Button>
-            );
-          })}
-        </ButtonGroup>
-
-        <div className="flex items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button type="button" variant="outline" size="sm">
-                <Download className="size-4" />
-                Export
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuLabel>Download example data</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                <DropdownMenuItem onSelect={() => onExport("csv")}>
-                  Export CSV
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => onExport("json")}>
-                  Export JSON
-                </DropdownMenuItem>
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <Button
-            type="button"
-            variant={filtersActive ? "secondary" : "outline"}
-            size="sm"
-            onClick={onToggleFilters}
-          >
-            {filtersActive ? (
-              <FilterX className="size-4" />
-            ) : (
-              <Filter className="size-4" />
-            )}
-            {filtersActive ? "Hide filters" : "Show filters"}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export default function UsersGridExample({
@@ -508,19 +388,8 @@ export default function UsersGridExample({
   const [columnOrder, setColumnOrder] = useState<string[]>(() =>
     baseColumns.map(getColumnId)
   );
-  const [selectedColumns, setSelectedColumns] = useState<string[]>(() => [
-    ...baseColumns
-      .filter((column) => column.defaultHidden !== true)
-      .map(getColumnId),
-    FILTER_RESERVED_COLNAME,
-  ]);
+  const [filtersActive, setFiltersActive] = useState(true);
   const [filteredRows, setFilteredRows] = useState(rows.length);
-
-  const filtersActive = selectedColumns.includes(FILTER_RESERVED_COLNAME);
-  const visibleColumnNames = useMemo(
-    () => selectedColumns.filter((name) => name !== FILTER_RESERVED_COLNAME),
-    [selectedColumns]
-  );
   const gridApiRef = useRef<TypeComputedProps | null>(null);
 
   const captureGridApi = useCallback(
@@ -530,32 +399,8 @@ export default function UsersGridExample({
     []
   );
 
-  function handleSelectedColumnsChange(nextColumns: string[]) {
-    const currentVisible = new Set(visibleColumnNames);
-    const nextVisible = new Set(nextColumns);
-
-    // Visibility is presentation state. Keep the complete column model stable
-    // so toggling one button does not recreate TanStack definitions, rerun the
-    // local data pipeline, or remount every filter editor.
-    for (const column of baseColumns) {
-      const columnId = getColumnId(column);
-      const wasVisible = currentVisible.has(columnId);
-      const willBeVisible = nextVisible.has(columnId);
-      if (wasVisible !== willBeVisible) {
-        gridApiRef.current?.setColumnVisible?.(columnId, willBeVisible);
-      }
-    }
-
-    const filtersMarker = filtersActive ? [FILTER_RESERVED_COLNAME] : [];
-    setSelectedColumns([...nextColumns, ...filtersMarker]);
-  }
-
   function handleToggleFilters() {
-    setSelectedColumns((current) =>
-      current.includes(FILTER_RESERVED_COLNAME)
-        ? current.filter((name) => name !== FILTER_RESERVED_COLNAME)
-        : [...current, FILTER_RESERVED_COLNAME]
-    );
+    setFiltersActive((current) => !current);
     setFilteredRows(rows.length);
   }
 
@@ -563,7 +408,11 @@ export default function UsersGridExample({
     const exportColumns = orderColumns(baseColumns, columnOrder).filter(
       (column) => {
         const columnId = getColumnId(column);
-        return selectedColumns.includes(columnId) && columnId !== "actions";
+        return (
+          columnId !== "actions" &&
+          (gridApiRef.current?.isColumnVisible?.(columnId) ??
+            column.visible !== false)
+        );
       }
     );
 
@@ -642,39 +491,73 @@ export default function UsersGridExample({
         </span>
       </div>
 
-      <UsersToolbar
-        columns={baseColumns}
-        selectedColumns={selectedColumns}
-        order={columnOrder}
-        filtersActive={filtersActive}
-        onSelectedColumnsChange={handleSelectedColumnsChange}
-        onToggleFilters={handleToggleFilters}
-        onExport={handleExport}
-      />
+      <RDGColumnVisibilityProvider>
+        <RDGColumnVisibilityToolbar
+          title="Visible columns"
+          description="Toggle columns, export the current dataset shape, and show or hide the filter row."
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button type="button" variant="outline" size="sm">
+                <Download className="size-4" />
+                Export
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuLabel>Download example data</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
+                <DropdownMenuItem onSelect={() => handleExport("csv")}>
+                  Export CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => handleExport("json")}>
+                  Export JSON
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
-      <div className="h-[32rem] min-h-0" data-testid="users-grid-viewport">
-        <ReactDataGrid
-          theme={theme}
-          idProperty="csuserid"
-          columns={baseColumns}
-          dataSource={rows}
-          columnOrder={columnOrder}
-          enableColumnFilterContextMenu
-          enableColumnAutosize
-          skipHeaderOnAutoSize={false}
-          resizable={resizable}
-          enableFiltering={filtersActive}
-          defaultFilterValue={defaultFilterValue}
-          filteredRowsCount={setFilteredRows}
-          onColumnOrderChange={setColumnOrder}
-          virtualized
-          columnUserSelect
-          showCellBorders={showCellBorders}
-          i18n={i18n}
-          showColumnMenuTool={false}
-          handle={captureGridApi}
-        />
-      </div>
+          <Button
+            type="button"
+            variant={filtersActive ? "secondary" : "outline"}
+            size="sm"
+            onClick={handleToggleFilters}
+          >
+            {filtersActive ? (
+              <FilterX className="size-4" />
+            ) : (
+              <Filter className="size-4" />
+            )}
+            {filtersActive ? "Hide filters" : "Show filters"}
+          </Button>
+        </RDGColumnVisibilityToolbar>
+
+        <div className="h-[32rem] min-h-0" data-testid="users-grid-viewport">
+          <RDGColumnVisibilityTarget>
+            <ReactDataGrid
+              theme={theme}
+              idProperty="csuserid"
+              columns={baseColumns}
+              dataSource={rows}
+              columnOrder={columnOrder}
+              enableColumnFilterContextMenu
+              enableColumnAutosize
+              skipHeaderOnAutoSize={false}
+              resizable={resizable}
+              enableFiltering={filtersActive}
+              defaultFilterValue={defaultFilterValue}
+              filteredRowsCount={setFilteredRows}
+              onColumnOrderChange={setColumnOrder}
+              virtualized
+              columnUserSelect
+              showCellBorders={showCellBorders}
+              i18n={i18n}
+              showColumnMenuTool={false}
+              handle={captureGridApi}
+            />
+          </RDGColumnVisibilityTarget>
+        </div>
+      </RDGColumnVisibilityProvider>
     </section>
   );
 }

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -192,6 +192,146 @@ const searchColumnsSnippet = `const columns: TypeColumns = [
   { name: "internalNote", searchable: false },
 ];`;
 
+const columnVisibilityToolbarSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityToolbar,
+} from "@geovi/the-datagrid/column-visibility";
+
+export function AccountsGrid() {
+  return (
+    <RDGColumnVisibilityProvider>
+      <RDGColumnVisibilityToolbar>
+        <button type="button" onClick={exportRows}>Export CSV</button>
+        <button type="button" onClick={toggleFilters}>Show filters</button>
+      </RDGColumnVisibilityToolbar>
+
+      <ReactDataGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={rows}
+        columnOrder={columnOrder}
+      />
+    </RDGColumnVisibilityProvider>
+  );
+}`;
+
+const nestedColumnVisibilityToolbarSnippet = `import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+} from "@geovi/the-datagrid/column-visibility";
+
+<RDGColumnVisibilityProvider>
+  <RDGColumnVisibilityToolbar />
+  <section className="min-h-0 flex-1">
+    <RDGColumnVisibilityTarget>
+      <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
+    </RDGColumnVisibilityTarget>
+  </section>
+</RDGColumnVisibilityProvider>;`;
+
+const directProviderChildrenSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
+import {
+  RDGSearchBar,
+  RDGSearchProvider,
+} from "@geovi/the-datagrid/search";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityToolbar,
+} from "@geovi/the-datagrid/column-visibility";
+
+export function SearchableAccountsGrid() {
+  return (
+    <RDGSearchProvider>
+      <RDGSearchBar />
+      {/* Direct provider child: RDGSearchTarget is not required. */}
+      <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
+    </RDGSearchProvider>
+  );
+}
+
+export function ConfigurableAccountsGrid() {
+  return (
+    <RDGColumnVisibilityProvider>
+      <RDGColumnVisibilityToolbar />
+      {/* Direct provider child: RDGColumnVisibilityTarget is not required. */}
+      <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
+    </RDGColumnVisibilityProvider>
+  );
+}`;
+
+const requiredSearchTargetSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
+import {
+  RDGSearchBar,
+  RDGSearchProvider,
+  RDGSearchTarget,
+} from "@geovi/the-datagrid/search";
+
+<RDGSearchProvider>
+  <RDGSearchBar />
+
+  {/* The section is an intervening child, so the target is required. */}
+  <section className="min-h-0 flex-1">
+    <RDGSearchTarget>
+      <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
+    </RDGSearchTarget>
+  </section>
+</RDGSearchProvider>;`;
+
+const requiredColumnVisibilityTargetSnippet = `import type { ReactNode } from "react";
+import ReactDataGrid from "@geovi/the-datagrid";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+} from "@geovi/the-datagrid/column-visibility";
+
+function GridCard({ children }: { children: ReactNode }) {
+  return <section className="min-h-0 rounded-xl border">{children}</section>;
+}
+
+<RDGColumnVisibilityProvider>
+  <RDGColumnVisibilityToolbar />
+
+  {/* GridCard hides the grid from the provider's direct child list. */}
+  <GridCard>
+    <RDGColumnVisibilityTarget>
+      <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
+    </RDGColumnVisibilityTarget>
+  </GridCard>
+</RDGColumnVisibilityProvider>;`;
+
+const independentProviderScopesSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityToolbar,
+} from "@geovi/the-datagrid/column-visibility";
+
+function AccountsAndInvoices() {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <RDGColumnVisibilityProvider>
+        <RDGColumnVisibilityToolbar title="Account columns" />
+        <ReactDataGrid
+          idProperty="id"
+          columns={accountColumns}
+          dataSource={accounts}
+        />
+      </RDGColumnVisibilityProvider>
+
+      <RDGColumnVisibilityProvider>
+        <RDGColumnVisibilityToolbar title="Invoice columns" />
+        <ReactDataGrid
+          idProperty="id"
+          columns={invoiceColumns}
+          dataSource={invoices}
+        />
+      </RDGColumnVisibilityProvider>
+    </div>
+  );
+}`;
+
 const remoteSearchSnippet = `import type { TypeDataSourceArgs } from "@geovi/the-datagrid";
 
 const dataSource = async (args: TypeDataSourceArgs) => {
@@ -1032,18 +1172,25 @@ const reactDataGridPropSections: ReferenceSection[] = [
         description: "Shows the header menu trigger for per-column actions.",
       },
       {
+        name: "onDidMount",
+        type: "(apiRef) => void",
+        defaultValue: "-",
+        description:
+          "Runs from the passive mount effect after the stable MutableRefObject has been hydrated, before handle and onReady. It does not repeat for grid updates or async data resolution; a real remount receives a new ref. React StrictMode can replay the mount effect in development, matching React and Inovua behavior.",
+      },
+      {
         name: "onReady",
         type: "(apiRef) => void",
         defaultValue: "-",
         description:
-          "Receives one stable MutableRefObject after mount; its TypeComputedProps target is refreshed in place as grid state changes.",
+          "Receives the hydrated stable MutableRefObject after onDidMount; its TypeComputedProps target is refreshed in place as grid state changes.",
       },
       {
         name: "handle",
         type: "(apiRef) => void",
         defaultValue: "-",
         description:
-          "Compatibility alias for onReady with the same stable-ref lifecycle.",
+          "Receives the same stable ref after onDidMount and before onReady. It is retained as a compatibility lifecycle hook rather than an alias with different timing.",
       },
     ],
   },
@@ -1079,7 +1226,7 @@ function createInovuaStatusPage(): DocsPage {
     summary:
       "A living, evidence-backed ledger of verified compatibility, remaining gaps, and behavior still being audited.",
     description:
-      "The status page is deliberately scoped: Issue 17 behaviors proven by executable tests are marked compatible, while the remaining Community surface is still audited independently.",
+      "The status page is deliberately evidence-based: verified Issue 17 and Issue 48 behaviors are marked compatible, while the remaining Community surface is still audited independently.",
     tags: ["Migration", "Inovua", "Parity status"],
     sections: [
       {
@@ -1099,10 +1246,10 @@ function createInovuaStatusPage(): DocsPage {
               </p>
             </Callout>
             <p>
-              This ledger covers the differences audited from Issue 17 and the
-              linked compatibility analysis. It is not exhaustive. The remaining
-              public Community surface is still being verified, and absence from
-              this table is not proof of compatibility.
+              This ledger covers the differences audited from Issue 17, Issue
+              48, and the linked compatibility analysis. It is not exhaustive.
+              The remaining public Community surface is still being verified,
+              and absence from this table is not proof of compatibility.
             </p>
             <p>
               The matching{" "}
@@ -1115,8 +1262,8 @@ function createInovuaStatusPage(): DocsPage {
                 executable parity specifications
               </a>{" "}
               become permanent green regression coverage as each behavior is
-              implemented. The Issue 17 rows marked compatible below are backed
-              by that focused suite.
+              implemented. The Issue 17 and Issue 48 rows marked compatible
+              below are backed by focused local suites.
             </p>
           </div>
         ),
@@ -1420,20 +1567,25 @@ function createInovuaStatusPage(): DocsPage {
       },
       {
         id: "text-input-boundary",
-        title: "TextInput boundary",
+        title: "Standalone TextInput compatibility",
         body: (
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
-              Inovua's default cell editor is internally backed by a TextInput.
-              The observable editor behavior belongs to the compatibility
-              baseline; the internal component choice does not.
+              Issue 48 explicitly adopts Inovua&apos;s standalone toolkit input
+              as part of the migration surface. The compatible path is the
+              legacy default import{" "}
+              <code>@geovi/the-datagrid/packages/TextInput</code>; a named root
+              export is also available for discoverability.
             </p>
             <p>
-              Standalone <code>TextInput</code> was not documented as a
-              top-level Community grid API. It is therefore outside the public
-              baseline, not an approved technical-impossibility exception. A
-              compatible standalone export would become required only if this
-              project explicitly adopts support for Inovua toolkit deep imports.
+              Compatibility includes controlled and uncontrolled values,
+              value-first change callbacks, nested input-callback ordering,
+              stopped change propagation by default, the clear tool, and the
+              class-instance <code>focus()</code> and <code>setValue()</code>{" "}
+              methods. The public clear renderer keeps its original config shape
+              and remains subclassable. The legacy BEM hooks remain available
+              while the shipped visual treatment uses the library&apos;s
+              shadcn-compatible tokens.
             </p>
           </div>
         ),
@@ -1893,10 +2045,17 @@ const columnSections: ReferenceSection[] = [
 const computedPropsRows: ReferenceRow[] = [
   {
     name: "Lifecycle",
-    type: "onReady / handle",
-    defaultValue: "once after mount",
+    type: "onDidMount",
+    defaultValue: "passive mount effect",
     description:
-      "Both callbacks receive the same stable MutableRefObject<TypeComputedProps | null>. Its target refreshes in place and exposes initialProps/publicAPI; retain the ref rather than a state snapshot.",
+      "Receives the hydrated MutableRefObject<TypeComputedProps | null> before the currently implemented handle/onReady notifications. It follows React's passive mount-effect semantics, including StrictMode development replay; ordinary grid updates do not retrigger it. The ref target refreshes in place and exposes initialProps/publicAPI, so retain the ref rather than a state snapshot.",
+  },
+  {
+    name: "Existing lifecycle adapters",
+    type: "handle / onReady",
+    defaultValue: "once when present",
+    description:
+      "Both currently receive the same stable ref after onDidMount. Issue 48 certifies onDidMount only: Inovua's handle identity cleanup and onReady nonzero-width gate remain a separately recorded compatibility gap.",
   },
   {
     name: "Data and loading",
@@ -1973,7 +2132,7 @@ const computedPropsRows: ReferenceRow[] = [
     type: "getVirtualList()",
     defaultValue: "implemented subset",
     description:
-      "getVirtualList exposes getContainerNode/getScrollerNode/getScrollingElement, height/scroll/client-size reads, getRows/forEachRow/getRowAt, visible count/range, setRowIndex, scrollToIndex/smoothScrollTo, refresh/update, visibility/rendered-index checks, and max render count. Inovua's smoothScrollTo(value, config, callback) pixel contract is preserved, including vertical/horizontal orientation, duration, and completion value. Ranges include overscan and measured natural rows report zero-based offsets and their current sizes.",
+      "getVirtualList exposes getContainerNode/getScrollerNode/getScrollingElement, height/scroll/client-size reads, getRows/forEachRow/getRowAt, visible count/range, setRowIndex, scrollToIndex/smoothScrollTo, adjustHeights, refresh/update, visibility/rendered-index checks, and max render count. adjustHeights() synchronously reads scrollHeight from the currently instantiated variable-height rows, updates virtual or non-virtual measurements, and returns void; fixed numeric rowHeight is deliberately a no-op. Offset reindexing may settle on the next animation frame, matching the upstream manager. Inovua's smoothScrollTo(value, config, callback) pixel contract is preserved, including vertical/horizontal orientation, duration, and completion value. Ranges include overscan and measured natural rows report zero-based offsets and their current sizes.",
   },
   {
     name: "Editing",
@@ -2706,6 +2865,79 @@ const selectFilterRows: ReferenceRow[] = [
   },
 ];
 
+const textInputRows: ReferenceRow[] = [
+  {
+    name: "value / defaultValue",
+    type: "any",
+    defaultValue: 'undefined / ""',
+    description:
+      "value makes the input controlled; otherwise defaultValue seeds its owned value. A nullish default becomes an empty string.",
+  },
+  {
+    name: "onChange",
+    type: "(value: any, event?: any) => void",
+    defaultValue: "-",
+    description:
+      "Receives the proposed value first. inputProps.onChange runs before this callback with the same event; clearing reports an undefined event, matching Inovua.",
+  },
+  {
+    name: "inputProps / wrapperProps",
+    type: "input attributes | null / div attributes",
+    defaultValue: "-",
+    description:
+      "Routes native input attributes and outer-wrapper attributes without replacing the compatibility callback, focus, or class behavior. Explicit null inputProps is treated like omission for legacy spread-based callers.",
+  },
+  {
+    name: "stopChangePropagation",
+    type: "boolean | null",
+    defaultValue: "true",
+    description:
+      "Stops native input change propagation before the value-first callbacks when truthy. Set false or null when an ancestor intentionally observes change events.",
+  },
+  {
+    name: "enableClearButton / acceptClearToolFocus",
+    type: "boolean / boolean",
+    defaultValue: "true / false",
+    description:
+      "Controls the built-in clear tool and whether it participates in tab order. Legacy falsey-empty values (including empty string, 0, false, and null), disabled fields, and read-only fields keep its wrapper hidden.",
+  },
+  {
+    name: "clearButtonSize / clearButtonColor / renderClearIcon",
+    type: "number | [number, number] / string / function",
+    defaultValue: "10 / currentColor / built-in icon",
+    description:
+      "Configures the clear icon. renderClearIcon receives its resolved dimensions and color; undefined uses the default while null suppresses the icon.",
+  },
+  {
+    name: "focus() / setValue(value, event?)",
+    type: "instance methods",
+    defaultValue: "-",
+    description:
+      "A class-component ref exposes the legacy imperative methods. setValue updates uncontrolled state and always follows the nested-then-root callback order.",
+  },
+  {
+    name: "renderClearButton(config) / renderClearButtonWrapper(fieldProps)",
+    type: "bound instance/subclass hooks",
+    defaultValue: "built-in clear tool",
+    description:
+      "Preserves the public class hooks. renderClearButton receives clearButtonClassName, clearButtonColor, clearButtonSize, and clearButtonStyle, and can be detached from the ref or overridden by a subclass.",
+  },
+  {
+    name: "theme / rtl / rootClassName",
+    type: "string / boolean / string",
+    defaultValue: '"default-light" / false / "inovua-react-toolkit-text-input"',
+    description:
+      "Preserves the legacy theme, direction, and BEM hooks while using the packaged shadcn-compatible visual tokens.",
+  },
+  {
+    name: "standard input fields",
+    type: "type, name, placeholder, lengths, required, readOnly, disabled…",
+    defaultValue: 'type="text"',
+    description:
+      "Forwards the supported native input state. Clicking the wrapper focuses the input; focus and blur update the compatibility modifier and callbacks.",
+  },
+];
+
 const checkboxRows: ReferenceRow[] = [
   {
     name: "checked",
@@ -3074,23 +3306,116 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
     feature: "Standalone TextInput export",
     upstreamContract: (
       <>
-        Inovua uses TextInput internally for its default editor, but does not
-        document it as a top-level Community grid export.
+        Inovua exposes a default class component from the toolkit deep path{" "}
+        <code>@inovua/reactdatagrid-community/packages/TextInput</code>. It owns
+        uncontrolled state, keeps controlled values prop-owned, reports{" "}
+        <code>(value, event)</code>, exposes <code>focus()</code> and{" "}
+        <code>setValue()</code>, and supplies a clear tool.
       </>
     ),
     currentBehavior: (
       <>
-        the-datagrid does not promise an Inovua-compatible standalone{" "}
-        <code>TextInput</code> or toolkit deep import.
+        The compatible default deep import is published and the root also
+        provides a named <code>TextInput</code>. Runtime behavior, callback
+        ordering, propagation, imperative methods, clear visibility, disabled
+        and read-only states, RTL/theme hooks, and standalone styling are
+        covered by executable tests.
       </>
     ),
     requiredOutcome: (
       <>
-        Match the observable default-editor behavior; no separate public export
-        is required unless deep-import compatibility is explicitly adopted.
+        Preserve the deep-import entry, class-instance TypeScript shape, and
+        observable interaction semantics as semver-sensitive compatibility
+        behavior.
       </>
     ),
-    status: "outside-public-baseline",
+    status: "compatible",
+  },
+  {
+    id: "on-did-mount",
+    feature: "onDidMount lifecycle callback",
+    upstreamContract: (
+      <>
+        <code>onDidMount</code> runs from a passive mount effect with the live{" "}
+        <code>MutableRefObject&lt;TypeComputedProps | null&gt;</code>. It
+        precedes the other imperative lifecycle notifications and is not tied to
+        grid width, data resolution, or subsequent rerenders.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        The API ref is hydrated first, then callbacks run in{" "}
+        <code>onDidMount → handle → onReady</code> order. Ordinary updates
+        retain and refresh the same ref without repeating onDidMount; a real
+        remount creates another lifecycle. React StrictMode development replay
+        is preserved instead of hidden.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Keep the callback mount-scoped, hydrated, width-independent, ordered,
+        and typed with the same mutable computed-props ref.
+      </>
+    ),
+    status: "compatible",
+  },
+  {
+    id: "handle-on-ready-lifecycle-details",
+    feature: "handle/onReady lifecycle details",
+    upstreamContract: (
+      <>
+        Inovua reruns <code>handle</code> when its callback identity changes and
+        invokes the previous callback with <code>null</code> during cleanup. Its{" "}
+        <code>onReady</code> callback waits until the measured grid width is
+        nonzero.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        The current feedback-safe adapters notify each callback once with the
+        live ref. They do not send the runtime <code>handle(null)</code>{" "}
+        cleanup, and <code>onReady</code> is not width-gated. These pre-existing
+        details are outside Issue 48&apos;s newly certified{" "}
+        <code>onDidMount</code> contract.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Reconcile callback replacement, cleanup, and zero-width readiness with
+        the upstream runtime without reintroducing callback-identity feedback
+        loops.
+      </>
+    ),
+    status: "known-gap",
+  },
+  {
+    id: "virtual-list-adjust-heights",
+    feature: "Virtual-list adjustHeights()",
+    upstreamContract: (
+      <>
+        <code>getVirtualList().adjustHeights()</code> is an argument-free,
+        synchronous command that asks currently instantiated variable-height
+        rows to remeasure themselves and returns <code>void</code>. Fixed
+        numeric row heights are unaffected.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        The adapter reads <code>scrollHeight</code> from every instantiated row
+        for natural and function-valued heights, updates virtual and non-virtual
+        measurements, and leaves fixed numeric heights untouched. Virtual rows
+        use explicit cache updates instead of registering extra observers, so
+        scrolled-out function-height nodes are not retained.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Preserve the no-argument void signature, mounted-row scope, and fixed
+        row-height no-op while keeping offsets and total virtual height
+        contiguous after DOM content changes.
+      </>
+    ),
+    status: "compatible",
   },
   {
     id: "typed-column-fields",
@@ -3154,8 +3479,8 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
     ),
     currentBehavior: (
       <>
-        The rows above are the audited Issue 17 differences, not a certificate
-        that every other API has already been verified.
+        The rows above are the audited Issue 17 and Issue 48 differences, not a
+        certificate that every other API has already been verified.
       </>
     ),
     requiredOutcome: (
@@ -3216,20 +3541,41 @@ const implementedSurfaceSections: ReferenceSection[] = [
   {
     id: "package-exports",
     title: "Package entry points and exports",
+    body: (
+      <p className="text-sm text-muted-foreground">
+        For provider requirements, direct-child auto-connection, and explicit
+        target rules, read{" "}
+        <DocsRouteLink
+          group="reference"
+          slug="providers-and-targets"
+          className="font-medium text-foreground underline underline-offset-4"
+        >
+          Providers and targets
+        </DocsRouteLink>
+        .
+      </p>
+    ),
     rows: [
       {
         name: "@geovi/the-datagrid",
         type: "value exports",
         defaultValue: "main entry",
         description:
-          "Default and named ReactDataGrid, the readonly empty plugins compatibility list, DateFilter, NumberFilter, SelectFilter, CheckBox, DEFAULT_FILTER_TYPES, and filterTypes (the same registry object).",
+          "Default and named ReactDataGrid, the readonly empty plugins compatibility list, DateFilter, NumberFilter, SelectFilter, CheckBox, the discoverable named TextInput, DEFAULT_FILTER_TYPES, and filterTypes (the same registry object).",
       },
       {
         name: "Root type exports",
         type: "TypeScript",
         defaultValue: "main entry",
         description:
-          "CellProps, TypeCellProps, IColumn, SortDirection, TypeColumn, TypeColumns, TypeColumnEditorProps/Cell, TypeColumnFilterValueChangeArg, TypeColumnResizeInfo/Context, TypeComputedColumn, TypeComputedColumnsMap, TypeComputedProps, TypeDataGridProps, TypeDataSourceArgs, TypeDataSource, TypeEditInfo, TypeStartEditArgs, TypeTryStartEditArgs, TypeCompleteEditArgs, TypeCancelEditArgs, TypeFilterOperator, TypeFilterType, TypeFilterTypes, TypeFilterValue, TypeGetColumnByParam, TypeI18n, TypeOnSelectionChangeArg, TypePaginationMode, TypeRowStyle/Args/Props, TypeShowCellBorders, TypeRowSelection, TypeSize, TypeSingleFilterValue, TypeSingleSortInfo, TypeSortInfo, TypeCheckboxColumn, and TypeCheckboxProps.",
+          "The grid's Inovua-aligned CellProps, column, data-source, filter, sort, selection, row-style, editing, computed-props, and checkbox types, plus TextInputProps, TypeTextInputProps, and the TextInput callback/input/wrapper/clear-button helper types.",
+      },
+      {
+        name: "@geovi/the-datagrid/packages/TextInput",
+        type: "compatibility entry",
+        defaultValue: "default export",
+        description:
+          "The Inovua-compatible standalone TextInput path. It resolves as a default class component with TypeTextInputProps and automatically loads its small standalone stylesheet without loading the grid runtime.",
       },
       {
         name: "@geovi/the-datagrid/search",
@@ -3239,11 +3585,18 @@ const implementedSurfaceSections: ReferenceSection[] = [
           "RDGSearchProvider, RDGSearchBar, RDGSearchTarget, and their three prop types. Importing this entry also loads its isolated search stylesheet.",
       },
       {
+        name: "@geovi/the-datagrid/column-visibility",
+        type: "optional entry",
+        defaultValue: "opt in",
+        description:
+          "RDGColumnVisibilityProvider, RDGColumnVisibilityToolbar, RDGColumnVisibilityTarget, and their three prop types. Toolbar children form the independent right-side action area.",
+      },
+      {
         name: "CSS subpaths",
-        type: "./style.css / ./search/style.css",
+        type: "core / search / column visibility",
         defaultValue: "public",
         description:
-          "Both JavaScript entries import their own compiled CSS automatically; the explicit stylesheet subpaths remain available for build systems that require manual CSS imports.",
+          "Every JavaScript entry imports its own compiled CSS automatically; explicit ./style.css, ./search/style.css, and ./column-visibility/style.css subpaths remain available for build systems that require manual CSS imports.",
       },
     ],
   },
@@ -3369,7 +3722,14 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "column.visible",
         defaultValue: "visible",
         description:
-          "visible=false removes a column. defaultVisible/defaultHidden are currently ignored, and hideable is enforced only by the transformed-mobile column picker.",
+          "visible=false removes a column. defaultVisible/defaultHidden are currently ignored; hideable is enforced by the transformed-mobile picker and optional external visibility toolbar.",
+      },
+      {
+        name: "External visibility toolbar",
+        type: "optional provider / toolbar / target",
+        defaultValue: "opt in",
+        description:
+          "Renders buttons in current grid order, reflects the live visibility map, honors hideable=false, and prevents hiding the final visible hideable column. Toolbar children render in a separate right-side actions region.",
       },
       {
         name: "Order normalization",
@@ -3971,15 +4331,20 @@ pnpm add @geovi/the-datagrid`}
             <p>
               Importing <code>@geovi/the-datagrid</code> loads the compiled core
               stylesheet. Importing <code>@geovi/the-datagrid/search</code>
-              loads the isolated optional-search stylesheet. The public{" "}
+              loads the isolated optional-search stylesheet, and importing{" "}
+              <code>@geovi/the-datagrid/column-visibility</code> loads the
+              isolated toolbar stylesheet. The public{" "}
               <code>@geovi/the-datagrid/style.css</code> and{" "}
-              <code>@geovi/the-datagrid/search/style.css</code> subpaths are
-              available when a bundler requires explicit CSS imports.
+              <code>@geovi/the-datagrid/search/style.css</code> and{" "}
+              <code>@geovi/the-datagrid/column-visibility/style.css</code>
+              subpaths are available when a bundler requires explicit CSS
+              imports.
             </p>
             <p>
               Main grid styling is scoped to grid-owned roots, and search styles
-              are scoped to the search bar. This avoids leaking generic shadcn
-              token aliases into the host application.
+              and column-visibility styles are scoped to their respective
+              component roots. This avoids leaking generic shadcn token aliases
+              into the host application.
             </p>
           </div>
         ),
@@ -4109,6 +4474,18 @@ pnpm add @geovi/the-datagrid`}
               explicit without moving search state into the grid props.
             </p>
             <CodeBlock code={nestedTableSearchSnippet} language="tsx" />
+            <p>
+              See{" "}
+              <DocsRouteLink
+                group="reference"
+                slug="providers-and-targets"
+                className="font-medium text-foreground underline underline-offset-4"
+              >
+                Providers and targets
+              </DocsRouteLink>{" "}
+              for the complete direct-child decision table, Fragment and
+              Suspense rules, and multiple-grid scoping guidance.
+            </p>
             <Callout title="Provider scope">
               <p>
                 A search bar updates targets in its nearest provider. Use
@@ -4761,6 +5138,376 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
   },
   {
     group: "reference",
+    slug: "providers-and-targets",
+    title: "Providers and targets",
+    summary:
+      "Understand which external grid controls require provider context, when a direct grid connects automatically, and when an explicit target is mandatory.",
+    description:
+      "Search and column-visibility controls live outside ReactDataGrid so the core remains lightweight. Their providers own the feature scope; targets connect an exact nested grid without adding public grid props.",
+    tags: ["Reference", "Providers", "Targets", "Composition"],
+    sections: [
+      {
+        id: "provider-contract",
+        title: "The provider contract",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              External contextual controls do not own a second copy of grid
+              state. They communicate with a grid through the nearest matching
+              provider. The provider establishes the state and lifecycle scope;
+              the control consumes that scope; and, when necessary, a target
+              identifies the exact <code>ReactDataGrid</code> that participates.
+            </p>
+            <ReferenceTable
+              rows={[
+                {
+                  name: "Provider",
+                  type: "required context",
+                  defaultValue: "feature-specific",
+                  description:
+                    "Owns the optional feature scope. RDGSearchBar requires RDGSearchProvider; RDGColumnVisibilityToolbar requires RDGColumnVisibilityProvider.",
+                },
+                {
+                  name: "Control",
+                  type: "context consumer",
+                  defaultValue: "optional",
+                  description:
+                    "Renders the external UI and reads the nearest provider. Rendering it outside its provider is a configuration error.",
+                },
+                {
+                  name: "Target",
+                  type: "grid connection",
+                  defaultValue: "conditional",
+                  description:
+                    "Wraps exactly one nested ReactDataGrid when that grid is not an immediate provider child. It renders no extra DOM element.",
+                },
+              ]}
+            />
+            <Callout title="Provider required; target conditional">
+              <p>
+                A matching provider is required whenever you render{" "}
+                <code>RDGSearchBar</code> or{" "}
+                <code>RDGColumnVisibilityToolbar</code>. A target is required
+                only when an element, Fragment, Suspense or error boundary, or
+                custom component sits between that provider and the grid.
+              </p>
+              <p>
+                If a screen uses none of these external controls, render{" "}
+                <code>ReactDataGrid</code> normally with no provider or target.
+              </p>
+            </Callout>
+          </div>
+        ),
+      },
+      {
+        id: "direct-grid-child",
+        title: "Direct grid children connect automatically",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              In the common layout, the grid element itself appears directly in
+              the provider&apos;s <code>children</code> list. Controls may be
+              siblings. The provider recognizes the marked grid and installs the
+              feature connection automatically, so adding a target would be
+              redundant.
+            </p>
+            <CodeBlock code={directProviderChildrenSnippet} language="tsx" />
+            <Callout title="What direct means">
+              <p>
+                “Direct” describes the React element tree, not visual proximity
+                in the browser. The grid must be the provider&apos;s immediate
+                React child. A wrapping <code>div</code>, <code>section</code>,{" "}
+                <code>Fragment</code>, <code>Suspense</code>, error boundary, or
+                application component makes it nested even if no extra box is
+                visible.
+              </p>
+            </Callout>
+          </div>
+        ),
+      },
+      {
+        id: "target-decision-table",
+        title: "When a target is required",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              Use the feature-specific target as an explicit marker whenever
+              automatic direct-child detection cannot reach the grid.
+            </p>
+            <ReferenceTable
+              rows={[
+                {
+                  name: "Grid is an immediate provider child",
+                  type: "target?",
+                  defaultValue: "No",
+                  description:
+                    "The provider connects the marked ReactDataGrid automatically.",
+                },
+                {
+                  name: "Grid is inside a div, section, card, or panel",
+                  type: "target?",
+                  defaultValue: "Required",
+                  description:
+                    "Put the target inside the layout wrapper and wrap the grid directly.",
+                },
+                {
+                  name: "Grid is inside Fragment, Suspense, or an error boundary",
+                  type: "target?",
+                  defaultValue: "Required",
+                  description:
+                    "Those React elements are still boundaries in the provider's direct child list.",
+                },
+                {
+                  name: "A custom component renders the grid",
+                  type: "target?",
+                  defaultValue: "Required",
+                  description:
+                    "Place the target where the concrete ReactDataGrid element is created, while it remains under the provider context.",
+                },
+                {
+                  name: "No external contextual control is rendered",
+                  type: "provider / target?",
+                  defaultValue: "Neither",
+                  description:
+                    "ReactDataGrid remains a standalone component; optional providers are never global setup requirements.",
+                },
+              ]}
+            />
+            <Callout title="A target must wrap the grid itself" tone="warning">
+              <p>
+                Do not wrap a card, Fragment, or another target with a target.
+                Both <code>RDGSearchTarget</code> and{" "}
+                <code>RDGColumnVisibilityTarget</code> expect exactly one{" "}
+                <code>ReactDataGrid</code> child.
+              </p>
+            </Callout>
+          </div>
+        ),
+      },
+      {
+        id: "nested-search-example",
+        title: "Required target: nested search layout",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              Here the <code>section</code> is the provider&apos;s direct child,
+              not the grid. Without <code>RDGSearchTarget</code>, the search bar
+              would have context but the nested grid would not receive its
+              committed query.
+            </p>
+            <CodeBlock code={requiredSearchTargetSnippet} language="tsx" />
+          </div>
+        ),
+      },
+      {
+        id: "nested-visibility-example",
+        title: "Required target: custom visibility layout",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              Application components are also boundaries. Put{" "}
+              <code>RDGColumnVisibilityTarget</code> at the point where the real
+              grid element is available. The toolbar may remain outside the card
+              as long as both stay inside the same provider.
+            </p>
+            <CodeBlock
+              code={requiredColumnVisibilityTargetSnippet}
+              language="tsx"
+            />
+          </div>
+        ),
+      },
+      {
+        id: "why-targets-exist",
+        title: "Why targets exist",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              A provider can inspect its immediate React children, but it cannot
+              safely crawl through arbitrary components before React renders
+              them. Querying the DOM would be too late, would fail during server
+              rendering, and would make portals and multiple grids ambiguous.
+            </p>
+            <p>
+              The target solves that boundary explicitly. It clones the exact
+              grid element with an internal feature controller. That controller
+              is removed from consumer-facing prop mirrors and remote
+              data-source arguments, so targets do not expand{" "}
+              <code>TypeDataGridProps</code> or leak implementation details into
+              application business logic.
+            </p>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>The target renders no layout wrapper or DOM node.</li>
+              <li>It does not replace or duplicate grid state.</li>
+              <li>It does not require an id selector or global registry.</li>
+              <li>
+                It keeps the main package independent from optional provider UI
+                and styles.
+              </li>
+            </ul>
+          </div>
+        ),
+      },
+      {
+        id: "provider-scopes",
+        title: "Scope providers deliberately",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              Controls always use their nearest matching provider. Use separate
+              providers when grids need independent state. Column visibility is
+              intentionally one grid per provider because one toolbar must have
+              one unambiguous column model.
+            </p>
+            <CodeBlock code={independentProviderScopesSnippet} language="tsx" />
+            <Callout title="Search can intentionally share a query">
+              <p>
+                One <code>RDGSearchProvider</code> may connect multiple search
+                targets when all of those grids should receive the same query.
+                Use separate search providers when each grid needs an
+                independent search value. In contrast, use a separate{" "}
+                <code>RDGColumnVisibilityProvider</code> for every grid.
+              </p>
+            </Callout>
+          </div>
+        ),
+      },
+      {
+        id: "provider-troubleshooting",
+        title: "Troubleshooting provider connections",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <ReferenceTable
+              rows={[
+                {
+                  name: "Control reports that its provider is missing",
+                  type: "configuration error",
+                  defaultValue: "wrap the scope",
+                  description:
+                    "Move RDGSearchBar inside RDGSearchProvider or RDGColumnVisibilityToolbar inside RDGColumnVisibilityProvider.",
+                },
+                {
+                  name: "Control renders but the nested grid does not react",
+                  type: "missing connection",
+                  defaultValue: "add a target",
+                  description:
+                    "An intervening React element is preventing direct-child discovery. Put the matching Target immediately around ReactDataGrid.",
+                },
+                {
+                  name: "Target rejects its child",
+                  type: "invalid nesting",
+                  defaultValue: "wrap only the grid",
+                  description:
+                    "A target accepts exactly one ReactDataGrid, not a div, Fragment, custom card, or another target.",
+                },
+                {
+                  name: "Second visibility grid reports an ambiguous target",
+                  type: "scope error",
+                  defaultValue: "split providers",
+                  description:
+                    "Give each grid its own RDGColumnVisibilityProvider and toolbar.",
+                },
+                {
+                  name: "Remote search receives a query but rows do not change",
+                  type: "remote ownership",
+                  defaultValue: "apply searchValue",
+                  description:
+                    "The provider connection is working; a function dataSource remains responsible for applying args.searchValue on the server.",
+                },
+              ]}
+            />
+            <Callout title="Do not nest feature targets">
+              <p>
+                The current feature-specific targets each require the grid as
+                their direct child. Do not wrap <code>RDGSearchTarget</code>{" "}
+                around <code>RDGColumnVisibilityTarget</code>, or the reverse. A
+                future combined provider must supply its own shared bridge
+                before that composition can be documented as supported.
+              </p>
+            </Callout>
+          </div>
+        ),
+      },
+      {
+        id: "stable-feature-specific-api",
+        title: "Stable feature-specific APIs",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              The current release uses feature-specific providers and targets.
+              These exports are supported public API and are not deprecated:
+            </p>
+            <ReferenceTable
+              rows={[
+                {
+                  name: "RDGSearchProvider",
+                  type: "@geovi/the-datagrid/search",
+                  defaultValue: "supported",
+                  description:
+                    "Owns search draft and committed state for its search controls and target grids.",
+                },
+                {
+                  name: "RDGSearchTarget",
+                  type: "@geovi/the-datagrid/search",
+                  defaultValue: "supported",
+                  description:
+                    "Explicitly connects one nested ReactDataGrid to the nearest search provider.",
+                },
+                {
+                  name: "RDGColumnVisibilityProvider",
+                  type: "@geovi/the-datagrid/column-visibility",
+                  defaultValue: "supported",
+                  description:
+                    "Owns the one-grid column visibility toolbar scope.",
+                },
+                {
+                  name: "RDGColumnVisibilityTarget",
+                  type: "@geovi/the-datagrid/column-visibility",
+                  defaultValue: "supported",
+                  description:
+                    "Explicitly connects one nested ReactDataGrid to the nearest visibility provider.",
+                },
+              ]}
+            />
+            <Callout title="Compatibility decision">
+              <p>
+                If a convenience provider that combines multiple contextual
+                controls is added later, it will be additive. The four
+                feature-specific APIs above will remain available so existing
+                applications and granular optional imports keep working.
+              </p>
+              <p>
+                A combined <code>RDGProvider</code>/<code>RDGTarget</code> is
+                not exported by the current release, so do not import or
+                document it as shipped behavior yet.
+              </p>
+            </Callout>
+            <p>
+              Continue with the{" "}
+              <DocsRouteLink
+                group="guides"
+                slug="table-search"
+                className="font-medium text-foreground underline underline-offset-4"
+              >
+                table search guide
+              </DocsRouteLink>{" "}
+              or the{" "}
+              <DocsRouteLink
+                group="reference"
+                slug="column-visibility-toolbar"
+                className="font-medium text-foreground underline underline-offset-4"
+              >
+                column visibility toolbar reference
+              </DocsRouteLink>{" "}
+              for feature-specific behavior and props.
+            </p>
+          </div>
+        ),
+      },
+    ],
+  },
+  {
+    group: "reference",
     slug: "date-filter",
     title: "DateFilter component",
     summary: "Date-oriented filter editor for single-date and range operators.",
@@ -4809,6 +5556,45 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
   },
   {
     group: "reference",
+    slug: "text-input",
+    title: "TextInput component",
+    summary:
+      "Inovua-compatible standalone text input with value-first callbacks, a clear tool, and imperative instance methods.",
+    description:
+      "Import the default class component from @geovi/the-datagrid/packages/TextInput when migrating a legacy toolkit deep import. A named root export is also available.",
+    tags: ["Reference", "Component", "TextInput", "Compatibility"],
+    sections: [
+      {
+        id: "textinput-import",
+        title: "Import",
+        body: (
+          <CodeBlock
+            code={
+              'import TextInput from "@geovi/the-datagrid/packages/TextInput";\n\n' +
+              "const inputRef = React.createRef<TextInput>();\n\n" +
+              "<TextInput\n" +
+              "  ref={inputRef}\n" +
+              '  defaultValue="Ada"\n' +
+              "  onChange={(value, event) => {\n" +
+              "    console.log(value, event);\n" +
+              "  }}\n" +
+              "/>;\n\n" +
+              "inputRef.current?.focus();\n" +
+              'inputRef.current?.setValue("Grace");'
+            }
+            language="tsx"
+          />
+        ),
+      },
+      {
+        id: "textinput-props",
+        title: "Props and instance API",
+        rows: textInputRows,
+      },
+    ],
+  },
+  {
+    group: "reference",
     slug: "checkbox",
     title: "CheckBox component",
     summary:
@@ -4821,6 +5607,148 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
         id: "checkbox-props",
         title: "Props",
         rows: checkboxRows,
+      },
+    ],
+  },
+  {
+    group: "reference",
+    slug: "column-visibility-toolbar",
+    title: "Column visibility toolbar",
+    summary:
+      "Optional contextual controls for showing and hiding grid columns, with a right-side slot for application actions.",
+    description:
+      "Import the provider, toolbar, and optional nested target from @geovi/the-datagrid/column-visibility without adding visibility-control props to ReactDataGrid.",
+    tags: ["Reference", "Component", "Columns", "Visibility"],
+    sections: [
+      {
+        id: "column-visibility-composition",
+        title: "Compose the toolbar with a grid",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              A direct <code>ReactDataGrid</code> child connects automatically.
+              The toolbar reads the grid&apos;s current order and visibility;
+              its children render separately on the right, so export, filter,
+              and other application controls remain application-owned.
+            </p>
+            <CodeBlock code={columnVisibilityToolbarSnippet} language="tsx" />
+            <p>
+              Read{" "}
+              <DocsRouteLink
+                group="reference"
+                slug="providers-and-targets"
+                className="font-medium text-foreground underline underline-offset-4"
+              >
+                Providers and targets
+              </DocsRouteLink>{" "}
+              before introducing layout wrappers or scoping controls for more
+              than one grid.
+            </p>
+          </div>
+        ),
+      },
+      {
+        id: "column-visibility-nested-target",
+        title: "Target a nested grid",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              Wrap a grid in <code>RDGColumnVisibilityTarget</code> when layout
+              markup sits between it and the provider. Keep one grid per
+              provider so one toolbar always has an unambiguous column model.
+            </p>
+            <CodeBlock
+              code={nestedColumnVisibilityToolbarSnippet}
+              language="tsx"
+            />
+            <p>
+              The dedicated{" "}
+              <DocsRouteLink
+                group="reference"
+                slug="providers-and-targets"
+                className="font-medium text-foreground underline underline-offset-4"
+              >
+                Providers and targets
+              </DocsRouteLink>{" "}
+              page explains every layout boundary that requires an explicit
+              target and how to scope multiple grids.
+            </p>
+          </div>
+        ),
+      },
+      {
+        id: "column-visibility-behavior",
+        title: "Behavior and public props",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <ul className="list-disc space-y-2 pl-5">
+              <li>
+                Toggle labels use a string or numeric header, then the stable
+                column <code>id</code> or <code>name</code>.
+              </li>
+              <li>
+                Columns with <code>{"hideable={false}"}</code> are omitted, and
+                the last visible column cannot be hidden because its toggle is
+                disabled.
+              </li>
+              <li>
+                Button <code>aria-pressed</code> state follows the live grid; no
+                eye icon or separate consumer visibility state is required.
+              </li>
+              <li>
+                The optional entry follows the target grid theme and loads only
+                its scoped toolbar stylesheet.
+              </li>
+            </ul>
+            <ReferenceTable
+              rows={[
+                {
+                  name: "RDGColumnVisibilityProvider.children",
+                  type: "ReactNode",
+                  defaultValue: "required",
+                  description:
+                    "Contains the toolbar and one direct grid or explicit target.",
+                },
+                {
+                  name: "RDGColumnVisibilityToolbar.ariaLabel",
+                  type: "string",
+                  defaultValue: '"Visible column toggles"',
+                  description:
+                    "Accessible name for the group of visibility buttons.",
+                },
+                {
+                  name: "RDGColumnVisibilityToolbar.title",
+                  type: "ReactNode",
+                  defaultValue: '"Visible columns"',
+                  description:
+                    "Heading above the controls; null suppresses the heading.",
+                },
+                {
+                  name: "RDGColumnVisibilityToolbar.description",
+                  type: "ReactNode",
+                  defaultValue:
+                    '"Choose which columns are visible in the grid."',
+                  description:
+                    "Supporting copy below the title; null suppresses it.",
+                },
+                {
+                  name: "RDGColumnVisibilityToolbar.children",
+                  type: "ReactNode",
+                  defaultValue: "none",
+                  description:
+                    "Application controls rendered in the right-side actions region.",
+                },
+                {
+                  name: "RDGColumnVisibilityTarget.children",
+                  type: "ReactElement<TypeDataGridProps>",
+                  defaultValue: "required",
+                  description:
+                    "The single nested ReactDataGrid connected to the nearest provider.",
+                },
+              ]}
+            />
+          </div>
+        ),
       },
     ],
   },
@@ -5002,10 +5930,12 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
               The Issue 17 batch now verifies natural and functional row
               heights, resize remeasurement and <code>onColumnResize</code>,
               controlled/default widths and flex, zebra behavior, inline
-              editing, and data-dependent <code>rowStyle</code>. Other ledger
-              entries remain gaps or under verification, and the inventory is
-              not exhaustive until the remaining Community API has been audited
-              surface by surface.
+              editing, and data-dependent <code>rowStyle</code>. Issue 48 adds
+              the standalone TextInput deep entry, the <code>onDidMount</code>{" "}
+              lifecycle, and virtual-list <code>adjustHeights()</code>. Other
+              ledger entries remain gaps or under verification, and the
+              inventory is not exhaustive until the remaining Community API has
+              been audited surface by surface.
             </p>
           </div>
         ),

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -233,74 +233,62 @@ const nestedColumnVisibilityToolbarSnippet = `import {
 
 const directProviderChildrenSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
 import {
-  RDGSearchBar,
-  RDGSearchProvider,
-} from "@geovi/the-datagrid/search";
-import {
-  RDGColumnVisibilityProvider,
   RDGColumnVisibilityToolbar,
-} from "@geovi/the-datagrid/column-visibility";
+  RDGProvider,
+  RDGSearchBar,
+} from "@geovi/the-datagrid/components";
 
-export function SearchableAccountsGrid() {
+export function SearchableConfigurableAccountsGrid() {
   return (
-    <RDGSearchProvider>
+    <RDGProvider>
       <RDGSearchBar />
-      {/* Direct provider child: RDGSearchTarget is not required. */}
-      <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
-    </RDGSearchProvider>
-  );
-}
+      <RDGColumnVisibilityToolbar>
+        <button type="button" onClick={exportRows}>Export CSV</button>
+      </RDGColumnVisibilityToolbar>
 
-export function ConfigurableAccountsGrid() {
-  return (
-    <RDGColumnVisibilityProvider>
-      <RDGColumnVisibilityToolbar />
-      {/* Direct provider child: RDGColumnVisibilityTarget is not required. */}
+      {/* Direct provider child: RDGTarget is not required. */}
       <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
-    </RDGColumnVisibilityProvider>
+    </RDGProvider>
   );
 }`;
 
-const requiredSearchTargetSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
+const requiredCombinedTargetSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
 import {
+  RDGColumnVisibilityToolbar,
+  RDGProvider,
   RDGSearchBar,
-  RDGSearchProvider,
-  RDGSearchTarget,
-} from "@geovi/the-datagrid/search";
+  RDGTarget,
+} from "@geovi/the-datagrid/components";
 
-<RDGSearchProvider>
+<RDGProvider>
   <RDGSearchBar />
+  <RDGColumnVisibilityToolbar />
 
-  {/* The section is an intervening child, so the target is required. */}
+  {/* The section is an intervening child, so RDGTarget is required. */}
   <section className="min-h-0 flex-1">
-    <RDGSearchTarget>
+    <RDGTarget>
       <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
-    </RDGSearchTarget>
+    </RDGTarget>
   </section>
-</RDGSearchProvider>;`;
+</RDGProvider>;`;
 
-const requiredColumnVisibilityTargetSnippet = `import type { ReactNode } from "react";
-import ReactDataGrid from "@geovi/the-datagrid";
+const mixedProviderImportsSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
+import { RDGProvider, RDGTarget } from "@geovi/the-datagrid/components";
+import { RDGSearchBar } from "@geovi/the-datagrid/search";
 import {
-  RDGColumnVisibilityProvider,
-  RDGColumnVisibilityTarget,
   RDGColumnVisibilityToolbar,
 } from "@geovi/the-datagrid/column-visibility";
 
-function GridCard({ children }: { children: ReactNode }) {
-  return <section className="min-h-0 rounded-xl border">{children}</section>;
-}
-
-<RDGColumnVisibilityProvider>
+<RDGProvider>
+  {/* Existing feature-entry controls consume the combined provider. */}
+  <RDGSearchBar />
   <RDGColumnVisibilityToolbar />
-
-  {/* GridCard hides the grid from the provider's direct child list. */}
-  <GridCard>
-    <RDGColumnVisibilityTarget>
+  <div className="min-h-0 flex-1">
+    <RDGTarget>
       <ReactDataGrid idProperty="id" columns={columns} dataSource={rows} />
-    </RDGColumnVisibilityTarget>
-  </GridCard>
-</RDGColumnVisibilityProvider>;`;
+    </RDGTarget>
+  </div>
+</RDGProvider>;`;
 
 const independentProviderScopesSnippet = `import ReactDataGrid from "@geovi/the-datagrid";
 import {
@@ -311,26 +299,37 @@ import {
 function AccountsAndInvoices() {
   return (
     <div className="grid gap-6 lg:grid-cols-2">
-      <RDGColumnVisibilityProvider>
-        <RDGColumnVisibilityToolbar title="Account columns" />
-        <ReactDataGrid
-          idProperty="id"
-          columns={accountColumns}
-          dataSource={accounts}
-        />
-      </RDGColumnVisibilityProvider>
+      {/* Providers add no DOM, so each scope gets a real layout wrapper. */}
+      <section className="flex min-h-0 flex-col gap-3">
+        <RDGColumnVisibilityProvider>
+          <RDGColumnVisibilityToolbar title="Account columns" />
+          <ReactDataGrid
+            idProperty="id"
+            columns={accountColumns}
+            dataSource={accounts}
+          />
+        </RDGColumnVisibilityProvider>
+      </section>
 
-      <RDGColumnVisibilityProvider>
-        <RDGColumnVisibilityToolbar title="Invoice columns" />
-        <ReactDataGrid
-          idProperty="id"
-          columns={invoiceColumns}
-          dataSource={invoices}
-        />
-      </RDGColumnVisibilityProvider>
+      <section className="flex min-h-0 flex-col gap-3">
+        <RDGColumnVisibilityProvider>
+          <RDGColumnVisibilityToolbar title="Invoice columns" />
+          <ReactDataGrid
+            idProperty="id"
+            columns={invoiceColumns}
+            dataSource={invoices}
+          />
+        </RDGColumnVisibilityProvider>
+      </section>
     </div>
   );
 }`;
+
+const columnVisibilityColumnsSnippet = `const columns: TypeColumns = [
+  { name: "id", header: "ID", hideable: false },
+  { name: "name", header: "Name" },
+  { name: "city", header: "City", visible: false },
+];`;
 
 const remoteSearchSnippet = `import type { TypeDataSourceArgs } from "@geovi/the-datagrid";
 
@@ -3578,6 +3577,13 @@ const implementedSurfaceSections: ReferenceSection[] = [
           "The Inovua-compatible standalone TextInput path. It resolves as a default class component with TypeTextInputProps and automatically loads its small standalone stylesheet without loading the grid runtime.",
       },
       {
+        name: "@geovi/the-datagrid/components",
+        type: "optional combined entry",
+        defaultValue: "recommended for mixed controls",
+        description:
+          "RDGProvider, RDGTarget, RDGSearchBar, RDGColumnVisibilityToolbar, the four stable feature-specific provider/target APIs, and all corresponding prop types.",
+      },
+      {
         name: "@geovi/the-datagrid/search",
         type: "optional entry",
         defaultValue: "opt in",
@@ -3596,7 +3602,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "core / search / column visibility",
         defaultValue: "public",
         description:
-          "Every JavaScript entry imports its own compiled CSS automatically; explicit ./style.css, ./search/style.css, and ./column-visibility/style.css subpaths remain available for build systems that require manual CSS imports.",
+          "Every JavaScript entry imports its required compiled CSS automatically; the combined components entry reuses search and column-visibility CSS without duplicating it. Explicit ./style.css, ./search/style.css, and ./column-visibility/style.css subpaths remain available for build systems that require manual CSS imports.",
       },
     ],
   },
@@ -4333,7 +4339,10 @@ pnpm add @geovi/the-datagrid`}
               stylesheet. Importing <code>@geovi/the-datagrid/search</code>
               loads the isolated optional-search stylesheet, and importing{" "}
               <code>@geovi/the-datagrid/column-visibility</code> loads the
-              isolated toolbar stylesheet. The public{" "}
+              isolated toolbar stylesheet. The combined{" "}
+              <code>@geovi/the-datagrid/components</code> entry reuses both
+              optional entries and their singleton contexts, so it loads both
+              isolated styles without duplicating their rules. The public{" "}
               <code>@geovi/the-datagrid/style.css</code> and{" "}
               <code>@geovi/the-datagrid/search/style.css</code> and{" "}
               <code>@geovi/the-datagrid/column-visibility/style.css</code>
@@ -5141,9 +5150,9 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
     slug: "providers-and-targets",
     title: "Providers and targets",
     summary:
-      "Understand which external grid controls require provider context, when a direct grid connects automatically, and when an explicit target is mandatory.",
+      "Use one RDGProvider for search and column visibility, understand direct-grid auto-connection, and add RDGTarget only across a React layout boundary.",
     description:
-      "Search and column-visibility controls live outside ReactDataGrid so the core remains lightweight. Their providers own the feature scope; targets connect an exact nested grid without adding public grid props.",
+      "The optional components entry coordinates search and column visibility through one provider and one grid target. The original feature-specific providers and targets remain supported for granular imports and existing applications.",
     tags: ["Reference", "Providers", "Targets", "Composition"],
     sections: [
       {
@@ -5153,19 +5162,20 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
               External contextual controls do not own a second copy of grid
-              state. They communicate with a grid through the nearest matching
-              provider. The provider establishes the state and lifecycle scope;
-              the control consumes that scope; and, when necessary, a target
-              identifies the exact <code>ReactDataGrid</code> that participates.
+              state. They communicate with a grid through the nearest provider.
+              Use <code>RDGProvider</code> when a grid has search, column
+              visibility, or both. It owns the shared connection scope while the
+              grid remains authoritative for column visibility and the provider
+              owns the search draft and committed query.
             </p>
             <ReferenceTable
               rows={[
                 {
                   name: "Provider",
                   type: "required context",
-                  defaultValue: "feature-specific",
+                  defaultValue: "RDGProvider",
                   description:
-                    "Owns the optional feature scope. RDGSearchBar requires RDGSearchProvider; RDGColumnVisibilityToolbar requires RDGColumnVisibilityProvider.",
+                    "RDGProvider from @geovi/the-datagrid/components is the recommended one-grid scope for one or both controls. Feature-specific providers remain supported.",
                 },
                 {
                   name: "Control",
@@ -5179,23 +5189,32 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                   type: "grid connection",
                   defaultValue: "conditional",
                   description:
-                    "Wraps exactly one nested ReactDataGrid when that grid is not an immediate provider child. It renders no extra DOM element.",
+                    "RDGTarget wraps exactly one nested ReactDataGrid when that grid is not an immediate RDGProvider child. Providers and targets render no extra DOM element.",
                 },
               ]}
             />
             <Callout title="Provider required; target conditional">
               <p>
-                A matching provider is required whenever you render{" "}
+                A provider is required whenever you render{" "}
                 <code>RDGSearchBar</code> or{" "}
-                <code>RDGColumnVisibilityToolbar</code>. A target is required
-                only when an element, Fragment, Suspense or error boundary, or
-                custom component sits between that provider and the grid.
+                <code>RDGColumnVisibilityToolbar</code>. Prefer one{" "}
+                <code>RDGProvider</code> for mixed controls. A target is
+                required only when an element, Fragment, Suspense or error
+                boundary, or custom component sits between that provider and the
+                grid.
               </p>
               <p>
                 If a screen uses none of these external controls, render{" "}
                 <code>ReactDataGrid</code> normally with no provider or target.
               </p>
             </Callout>
+            <p>
+              <code>RDGProvider</code> requires <code>children</code> and
+              accepts <code>defaultSearchValue</code> to initialize its search
+              query.
+              <code>RDGTarget</code> requires exactly one grid element as its{" "}
+              <code>children</code> value.
+            </p>
           </div>
         ),
       },
@@ -5206,10 +5225,11 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
               In the common layout, the grid element itself appears directly in
-              the provider&apos;s <code>children</code> list. Controls may be
-              siblings. The provider recognizes the marked grid and installs the
-              feature connection automatically, so adding a target would be
-              redundant.
+              <code>RDGProvider</code>&apos;s <code>children</code> list.
+              Search, column visibility, and application actions may be
+              siblings. The provider recognizes the marked grid and installs
+              both feature connections automatically, so adding{" "}
+              <code>RDGTarget</code> would be redundant.
             </p>
             <CodeBlock code={directProviderChildrenSnippet} language="tsx" />
             <Callout title="What direct means">
@@ -5231,8 +5251,10 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
         body: (
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
-              Use the feature-specific target as an explicit marker whenever
-              automatic direct-child detection cannot reach the grid.
+              Use <code>RDGTarget</code> as an explicit marker whenever
+              automatic direct-child detection cannot reach a grid under{" "}
+              <code>RDGProvider</code>. The same direct-child rule applies to
+              the stable feature-specific targets.
             </p>
             <ReferenceTable
               rows={[
@@ -5241,7 +5263,7 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                   type: "target?",
                   defaultValue: "No",
                   description:
-                    "The provider connects the marked ReactDataGrid automatically.",
+                    "RDGProvider connects the marked ReactDataGrid automatically.",
                 },
                 {
                   name: "Grid is inside a div, section, card, or panel",
@@ -5275,45 +5297,43 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
             />
             <Callout title="A target must wrap the grid itself" tone="warning">
               <p>
-                Do not wrap a card, Fragment, or another target with a target.
-                Both <code>RDGSearchTarget</code> and{" "}
-                <code>RDGColumnVisibilityTarget</code> expect exactly one{" "}
-                <code>ReactDataGrid</code> child.
+                In application code, pass exactly one concrete{" "}
+                <code>ReactDataGrid</code> to <code>RDGTarget</code>,{" "}
+                <code>RDGSearchTarget</code>, or{" "}
+                <code>RDGColumnVisibilityTarget</code>. Put the target inside a
+                card or Fragment rather than wrapping that layout element.
               </p>
             </Callout>
           </div>
         ),
       },
       {
-        id: "nested-search-example",
-        title: "Required target: nested search layout",
+        id: "nested-combined-example",
+        title: "Required target: nested mixed-controls layout",
         body: (
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
               Here the <code>section</code> is the provider&apos;s direct child,
-              not the grid. Without <code>RDGSearchTarget</code>, the search bar
-              would have context but the nested grid would not receive its
-              committed query.
+              not the grid. <code>RDGTarget</code> connects search and
+              visibility together, so both controls operate on the same nested
+              grid.
             </p>
-            <CodeBlock code={requiredSearchTargetSnippet} language="tsx" />
+            <CodeBlock code={requiredCombinedTargetSnippet} language="tsx" />
           </div>
         ),
       },
       {
-        id: "nested-visibility-example",
-        title: "Required target: custom visibility layout",
+        id: "mixed-provider-imports",
+        title: "Combined provider with existing control imports",
         body: (
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
-              Application components are also boundaries. Put{" "}
-              <code>RDGColumnVisibilityTarget</code> at the point where the real
-              grid element is available. The toolbar may remain outside the card
-              as long as both stay inside the same provider.
+              Controls imported from the original <code>/search</code> and{" "}
+              <code>/column-visibility</code> entries consume the same singleton
+              contexts as <code>RDGProvider</code>. This lets applications adopt
+              the combined provider without rewriting every control import.
             </p>
-            <CodeBlock
-              code={requiredColumnVisibilityTargetSnippet}
-              language="tsx"
-            />
+            <CodeBlock code={mixedProviderImportsSnippet} language="tsx" />
           </div>
         ),
       },
@@ -5338,6 +5358,7 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
             </p>
             <ul className="list-disc space-y-2 pl-5">
               <li>The target renders no layout wrapper or DOM node.</li>
+              <li>The provider also renders no DOM layout wrapper.</li>
               <li>It does not replace or duplicate grid state.</li>
               <li>It does not require an id selector or global registry.</li>
               <li>
@@ -5355,18 +5376,20 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
               Controls always use their nearest matching provider. Use separate
-              providers when grids need independent state. Column visibility is
-              intentionally one grid per provider because one toolbar must have
-              one unambiguous column model.
+              providers when grids need independent state.{" "}
+              <code>RDGProvider</code>
+              is intentionally one grid per provider because its visibility
+              toolbar must have one unambiguous column model.
             </p>
             <CodeBlock code={independentProviderScopesSnippet} language="tsx" />
             <Callout title="Search can intentionally share a query">
               <p>
-                One <code>RDGSearchProvider</code> may connect multiple search
-                targets when all of those grids should receive the same query.
-                Use separate search providers when each grid needs an
-                independent search value. In contrast, use a separate{" "}
-                <code>RDGColumnVisibilityProvider</code> for every grid.
+                The legacy search-only <code>RDGSearchProvider</code> may
+                connect multiple search targets when all grids should receive
+                the same query. Use separate <code>RDGProvider</code> scopes for
+                mixed controls, and a separate{" "}
+                <code>RDGColumnVisibilityProvider</code> for every visibility
+                grid.
               </p>
             </Callout>
           </div>
@@ -5384,7 +5407,7 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                   type: "configuration error",
                   defaultValue: "wrap the scope",
                   description:
-                    "Move RDGSearchBar inside RDGSearchProvider or RDGColumnVisibilityToolbar inside RDGColumnVisibilityProvider.",
+                    "Move the controls inside RDGProvider, or inside their matching stable feature-specific provider.",
                 },
                 {
                   name: "Control renders but the nested grid does not react",
@@ -5394,18 +5417,18 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                     "An intervening React element is preventing direct-child discovery. Put the matching Target immediately around ReactDataGrid.",
                 },
                 {
-                  name: "Target rejects its child",
+                  name: "Target rejects or cannot connect its child",
                   type: "invalid nesting",
                   defaultValue: "wrap only the grid",
                   description:
-                    "A target accepts exactly one ReactDataGrid, not a div, Fragment, custom card, or another target.",
+                    "Pass exactly one concrete ReactDataGrid in application code, not a div, Fragment, custom card, or a consumer-assembled target stack. RDGTarget owns the internal mixed-feature composition.",
                 },
                 {
                   name: "Second visibility grid reports an ambiguous target",
                   type: "scope error",
                   defaultValue: "split providers",
                   description:
-                    "Give each grid its own RDGColumnVisibilityProvider and toolbar.",
+                    "Give each grid its own RDGProvider, or its own RDGColumnVisibilityProvider when only visibility is needed.",
                 },
                 {
                   name: "Remote search receives a query but rows do not change",
@@ -5416,29 +5439,45 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                 },
               ]}
             />
-            <Callout title="Do not nest feature targets">
+            <Callout title="Use the combined target for mixed controls">
               <p>
-                The current feature-specific targets each require the grid as
-                their direct child. Do not wrap <code>RDGSearchTarget</code>{" "}
-                around <code>RDGColumnVisibilityTarget</code>, or the reverse. A
-                future combined provider must supply its own shared bridge
-                before that composition can be documented as supported.
+                Do not assemble your own nested stack of{" "}
+                <code>RDGSearchTarget</code> and{" "}
+                <code>RDGColumnVisibilityTarget</code>. That bridge composition
+                is an implementation detail of <code>RDGTarget</code>. Use one{" "}
+                <code>RDGProvider</code> and one <code>RDGTarget</code> when
+                both controls share a grid.
               </p>
             </Callout>
           </div>
         ),
       },
       {
-        id: "stable-feature-specific-api",
-        title: "Stable feature-specific APIs",
+        id: "stable-provider-apis",
+        title: "Combined and stable feature-specific APIs",
         body: (
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
-              The current release uses feature-specific providers and targets.
-              These exports are supported public API and are not deprecated:
+              The components entry is the concise default for new mixed-control
+              integrations. The four original provider/target exports remain
+              supported public API and are not deprecated.
             </p>
             <ReferenceTable
               rows={[
+                {
+                  name: "RDGProvider",
+                  type: "@geovi/the-datagrid/components",
+                  defaultValue: "recommended",
+                  description:
+                    "Owns one grid scope shared by RDGSearchBar and RDGColumnVisibilityToolbar.",
+                },
+                {
+                  name: "RDGTarget",
+                  type: "@geovi/the-datagrid/components",
+                  defaultValue: "conditional",
+                  description:
+                    "Connects both contextual feature bridges to one nested ReactDataGrid.",
+                },
                 {
                   name: "RDGSearchProvider",
                   type: "@geovi/the-datagrid/search",
@@ -5471,15 +5510,15 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
             />
             <Callout title="Compatibility decision">
               <p>
-                If a convenience provider that combines multiple contextual
-                controls is added later, it will be additive. The four
-                feature-specific APIs above will remain available so existing
-                applications and granular optional imports keep working.
+                <code>RDGProvider</code> and <code>RDGTarget</code> are
+                additive. The four feature-specific APIs above remain available
+                so existing applications and granular optional imports keep
+                working.
               </p>
               <p>
-                A combined <code>RDGProvider</code>/<code>RDGTarget</code> is
-                not exported by the current release, so do not import or
-                document it as shipped behavior yet.
+                The <code>/components</code> entry also re-exports both
+                controls, all four feature-specific provider/target APIs, and
+                their prop types for one-import convenience.
               </p>
             </Callout>
             <p>
@@ -5632,6 +5671,16 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
               and other application controls remain application-owned.
             </p>
             <CodeBlock code={columnVisibilityToolbarSnippet} language="tsx" />
+            <Callout title="Using search and visibility together">
+              <p>
+                Prefer <code>RDGProvider</code> from{" "}
+                <code>@geovi/the-datagrid/components</code> when this toolbar
+                and
+                <code>RDGSearchBar</code> control the same grid. The
+                feature-specific provider above remains supported for
+                visibility-only screens.
+              </p>
+            </Callout>
             <p>
               Read{" "}
               <DocsRouteLink
@@ -5700,6 +5749,32 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                 its scoped toolbar stylesheet.
               </li>
             </ul>
+            <CodeBlock code={columnVisibilityColumnsSnippet} language="tsx" />
+            <Callout title="Initialization and remounts">
+              <p>
+                Set <code>{"visible: false"}</code> for a column that starts
+                hidden and <code>{"hideable: false"}</code> for a column that
+                must not appear as a toggle. The compatibility fields{" "}
+                <code>defaultVisible</code> and <code>defaultHidden</code> are
+                currently ignored; they do not initialize this toolbar.
+              </p>
+              <p>
+                Visibility button clicks update grid-owned imperative state. A
+                real grid remount discards those runtime overrides and
+                initializes visibility again from the current column props.
+              </p>
+            </Callout>
+            <Callout title="Accessible title and description">
+              <p>
+                When <code>title</code> is present, the toolbar exposes it as a
+                level-two heading and labels the toolbar region with{" "}
+                <code>aria-labelledby</code>. The toggle group always keeps the
+                public <code>ariaLabel</code>, and the description is connected
+                to both region and group through <code>aria-describedby</code>.
+                Set <code>{"title={null}"}</code> to suppress the heading and
+                region label without changing the group&apos;s accessible name.
+              </p>
+            </Callout>
             <ReferenceTable
               rows={[
                 {
@@ -5721,7 +5796,7 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                   type: "ReactNode",
                   defaultValue: '"Visible columns"',
                   description:
-                    "Heading above the controls; null suppresses the heading.",
+                    "Level-two heading that labels the toolbar region; null suppresses the heading while the toggle group keeps ariaLabel.",
                 },
                 {
                   name: "RDGColumnVisibilityToolbar.description",
@@ -5729,7 +5804,7 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
                   defaultValue:
                     '"Choose which columns are visible in the grid."',
                   description:
-                    "Supporting copy below the title; null suppresses it.",
+                    "Supporting copy associated with the toolbar region and toggle group through aria-describedby; null suppresses it.",
                 },
                 {
                   name: "RDGColumnVisibilityToolbar.children",

--- a/examples/src/docs/docsNavigation.ts
+++ b/examples/src/docs/docsNavigation.ts
@@ -90,9 +90,20 @@ export const docsNavigationSections: DocsNavigationSection[] = [
     id: "components",
     label: "Components",
     items: [
+      navigationItem(
+        "reference",
+        "providers-and-targets",
+        "Providers & targets"
+      ),
       navigationItem("reference", "date-filter", "Date filter"),
       navigationItem("reference", "number-filter", "Number filter"),
       navigationItem("reference", "select-filter", "Select filter"),
+      navigationItem("reference", "text-input", "Text input"),
+      navigationItem(
+        "reference",
+        "column-visibility-toolbar",
+        "Column visibility toolbar"
+      ),
       navigationItem("reference", "checkbox", "Checkbox"),
     ],
   },

--- a/examples/src/router.tsx
+++ b/examples/src/router.tsx
@@ -9,6 +9,7 @@ import App, { useExamplesUi } from "./App";
 import ActionsGridExample from "./ActionsGridExample";
 import BasicGridExample from "./BasicGridExample";
 import ColumnsGridExample from "./ColumnsGridExample";
+import ColumnVisibilityCompatPage from "./ColumnVisibilityCompatPage";
 import ComputedPropsCompatPage from "./ComputedPropsCompatPage";
 import DefaultPropsCompatPage from "./DefaultPropsCompatPage";
 import ExampleDetailPage from "./ExampleDetailPage";
@@ -17,6 +18,7 @@ import FilteredRowsCountCompatPage from "./FilteredRowsCountCompatPage";
 import InovuaParityCompatPage from "./InovuaParityCompatPage";
 import InovuaParityExamplePage from "./InovuaParityExamplePage";
 import InovuaPendingParityCompatPage from "./InovuaPendingParityCompatPage";
+import Issue48CompatPage from "./Issue48CompatPage";
 import MemorySafetyCompatPage from "./MemorySafetyCompatPage";
 import MobileTransformExample from "./MobileTransformExample";
 import SearchDataSourceCompatPage from "./SearchDataSourceCompatPage";
@@ -292,6 +294,12 @@ const compatComputedPropsRoute = createRoute({
   component: ComputedPropsCompatPage,
 });
 
+const compatColumnVisibilityRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/column-visibility",
+  component: ColumnVisibilityCompatPage,
+});
+
 const compatDefaultPropsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "compat/default-props",
@@ -322,6 +330,12 @@ const compatInovuaPendingParityRoute = createRoute({
   component: InovuaPendingParityCompatPage,
 });
 
+const compatIssue48Route = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/issue-48",
+  component: Issue48CompatPage,
+});
+
 const compatSearchDataSourceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "compat/search-data-source",
@@ -331,11 +345,13 @@ const compatSearchDataSourceRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   homeRoute,
   docsRoute.addChildren([docsIndexRoute, docsPageRoute]),
+  compatColumnVisibilityRoute,
   compatComputedPropsRoute,
   compatDefaultPropsRoute,
   compatFilteredRowsCountRoute,
   compatInovuaParityRoute,
   compatInovuaPendingParityRoute,
+  compatIssue48Route,
   compatMemorySafetyRoute,
   compatSearchDataSourceRoute,
   examplesOverviewRoute,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovi/the-datagrid",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A modern, feature-rich React data grid component built with shadcn/ui and TanStack Table",
   "type": "module",
   "main": "./dist/index.js",
@@ -8,6 +8,12 @@
   "types": "./dist/main.d.ts",
   "typesVersions": {
     "*": {
+      "column-visibility": [
+        "./dist/column-visibility/index.d.ts"
+      ],
+      "packages/TextInput": [
+        "./dist/packages/TextInput/index.d.ts"
+      ],
       "search": [
         "./dist/search/index.d.ts"
       ]
@@ -22,6 +28,15 @@
       "types": "./dist/search/index.d.ts",
       "import": "./dist/search.js"
     },
+    "./column-visibility": {
+      "types": "./dist/column-visibility/index.d.ts",
+      "import": "./dist/column-visibility.js"
+    },
+    "./packages/TextInput": {
+      "types": "./dist/packages/TextInput/index.d.ts",
+      "import": "./dist/packages/TextInput/index.js"
+    },
+    "./column-visibility/style.css": "./dist/column-visibility.css",
     "./search/style.css": "./dist/search.css",
     "./style.css": "./dist/index.css"
   },
@@ -52,7 +67,7 @@
   "scripts": {
     "build:search-index": "tsx scripts/build-docfind-index.ts",
     "dev": "yarn build:search-index && vite",
-    "build": "yarn test:types && tsc -p ./tsconfig-build.json && vite build --mode library-core && vite build --mode library-search && node scripts/fix-dts-specifiers.mjs && node scripts/test-published-types.mjs && node scripts/assert-css-scope.mjs && node scripts/assert-search-boundary.mjs",
+    "build": "yarn test:types && tsc -p ./tsconfig-build.json && vite build --mode library-core && vite build --mode library-search && vite build --mode library-column-visibility && vite build --mode library-text-input && node scripts/fix-dts-specifiers.mjs && node scripts/test-published-types.mjs && node scripts/assert-css-scope.mjs && node scripts/assert-search-boundary.mjs && node scripts/assert-column-visibility-boundary.mjs && node scripts/assert-text-input-boundary.mjs",
     "build:site": "yarn build:search-index && vite build --mode site",
     "lint": "eslint .",
     "test:types": "tsc -p ./tests/types/tsconfig.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
       "column-visibility": [
         "./dist/column-visibility/index.d.ts"
       ],
+      "components": [
+        "./dist/providers/index.d.ts"
+      ],
       "packages/TextInput": [
         "./dist/packages/TextInput/index.d.ts"
       ],
@@ -31,6 +34,10 @@
     "./column-visibility": {
       "types": "./dist/column-visibility/index.d.ts",
       "import": "./dist/column-visibility.js"
+    },
+    "./components": {
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/components.js"
     },
     "./packages/TextInput": {
       "types": "./dist/packages/TextInput/index.d.ts",
@@ -67,7 +74,7 @@
   "scripts": {
     "build:search-index": "tsx scripts/build-docfind-index.ts",
     "dev": "yarn build:search-index && vite",
-    "build": "yarn test:types && tsc -p ./tsconfig-build.json && vite build --mode library-core && vite build --mode library-search && vite build --mode library-column-visibility && vite build --mode library-text-input && node scripts/fix-dts-specifiers.mjs && node scripts/test-published-types.mjs && node scripts/assert-css-scope.mjs && node scripts/assert-search-boundary.mjs && node scripts/assert-column-visibility-boundary.mjs && node scripts/assert-text-input-boundary.mjs",
+    "build": "yarn test:types && tsc -p ./tsconfig-build.json && vite build --mode library-core && vite build --mode library-search && vite build --mode library-column-visibility && vite build --mode library-components && vite build --mode library-text-input && node scripts/fix-dts-specifiers.mjs && node scripts/test-published-types.mjs && node scripts/assert-css-scope.mjs && node scripts/assert-search-boundary.mjs && node scripts/assert-column-visibility-boundary.mjs && node scripts/assert-components-boundary.mjs && node scripts/assert-text-input-boundary.mjs",
     "build:site": "yarn build:search-index && vite build --mode site",
     "lint": "eslint .",
     "test:types": "tsc -p ./tests/types/tsconfig.json --noEmit",

--- a/scripts/assert-column-visibility-boundary.mjs
+++ b/scripts/assert-column-visibility-boundary.mjs
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const distDirectory = path.resolve(process.cwd(), "dist");
+const coreRuntimePath = path.join(distDirectory, "index.js");
+const coreStylesheetPath = path.join(distDirectory, "index.css");
+const runtimePath = path.join(distDirectory, "column-visibility.js");
+const stylesheetPath = path.join(distDirectory, "column-visibility.css");
+const declarationPath = path.join(
+  distDirectory,
+  "column-visibility",
+  "index.d.ts"
+);
+const requiredFiles = [
+  coreRuntimePath,
+  coreStylesheetPath,
+  runtimePath,
+  stylesheetPath,
+  declarationPath,
+];
+const missingFiles = requiredFiles.filter(
+  (filePath) => !fs.existsSync(filePath)
+);
+
+if (missingFiles.length > 0) {
+  console.error(
+    `Missing column-visibility build output:\n${missingFiles
+      .map((filePath) => `- ${path.relative(process.cwd(), filePath)}`)
+      .join("\n")}`
+  );
+  process.exit(1);
+}
+
+const coreRuntime = fs.readFileSync(coreRuntimePath, "utf8");
+const coreStylesheet = fs.readFileSync(coreStylesheetPath, "utf8");
+const runtime = fs.readFileSync(runtimePath, "utf8");
+const stylesheet = fs.readFileSync(stylesheetPath, "utf8");
+const expectedPrefix = '"use client";\nimport "./column-visibility.css";';
+
+if (!runtime.startsWith(expectedPrefix)) {
+  console.error(
+    'The optional column-visibility entry must preserve "use client" before importing ./column-visibility.css.'
+  );
+  process.exit(1);
+}
+
+const relativeJavaScriptImportPatterns = [
+  /\bimport\s+(?:[^"']+?\s+from\s+)?["'](\.\.?\/[^"']+\.js)["']/g,
+  /\bexport\s+[^"']+?\s+from\s+["'](\.\.?\/[^"']+\.js)["']/g,
+  /\bimport\(\s*["'](\.\.?\/[^"']+\.js)["']\s*\)/g,
+];
+const relativeJavaScriptImports = new Set();
+
+for (const pattern of relativeJavaScriptImportPatterns) {
+  for (const match of runtime.matchAll(pattern)) {
+    if (match[1]) relativeJavaScriptImports.add(match[1]);
+  }
+}
+
+if (
+  relativeJavaScriptImports.size !== 1 ||
+  !relativeJavaScriptImports.has("./index.js")
+) {
+  console.error(
+    `The optional column-visibility entry must depend only on ./index.js; found:\n${Array.from(
+      relativeJavaScriptImports
+    )
+      .map((specifier) => `- ${specifier}`)
+      .join("\n")}`
+  );
+  process.exit(1);
+}
+
+const publicRuntimeExports = [
+  "RDGColumnVisibilityProvider",
+  "RDGColumnVisibilityToolbar",
+  "RDGColumnVisibilityTarget",
+];
+const missingRuntimeExports = publicRuntimeExports.filter(
+  (name) => !runtime.includes(name)
+);
+if (missingRuntimeExports.length > 0) {
+  console.error(
+    `The optional column-visibility entry is missing runtime exports: ${missingRuntimeExports.join(
+      ", "
+    )}`
+  );
+  process.exit(1);
+}
+
+const leakedCoreExports = publicRuntimeExports.filter((name) =>
+  coreRuntime.includes(name)
+);
+if (leakedCoreExports.length > 0) {
+  console.error(
+    `Optional column-visibility exports leaked into dist/index.js: ${leakedCoreExports.join(
+      ", "
+    )}`
+  );
+  process.exit(1);
+}
+
+if (coreStylesheet.includes(".tdg-column-visibility-root")) {
+  console.error(
+    "Optional column-visibility styles leaked into dist/index.css."
+  );
+  process.exit(1);
+}
+
+if (
+  !stylesheet.includes(".tdg-column-visibility-root") ||
+  stylesheet.includes(".tdg-root") ||
+  stylesheet.includes(".tdg-search-root")
+) {
+  console.error(
+    "The column-visibility stylesheet is missing its scope or contains another entry's root selector."
+  );
+  process.exit(1);
+}
+
+const runtimeBytes = Buffer.byteLength(runtime);
+const stylesheetBytes = Buffer.byteLength(stylesheet);
+if (runtimeBytes > 96 * 1024 || stylesheetBytes > 48 * 1024) {
+  console.error(
+    `Column-visibility optional bundle exceeded its boundary: ${runtimeBytes} B JS, ${stylesheetBytes} B CSS.`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Optional column-visibility boundary verified: ${runtimeBytes} B JS, ${stylesheetBytes} B CSS.`
+);

--- a/scripts/assert-components-boundary.mjs
+++ b/scripts/assert-components-boundary.mjs
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const distDirectory = path.resolve(process.cwd(), "dist");
+const runtimePath = path.join(distDirectory, "components.js");
+const unexpectedStylesheetPath = path.join(distDirectory, "components.css");
+const declarationPath = path.join(distDirectory, "providers", "index.d.ts");
+const coreRuntimePath = path.join(distDirectory, "index.js");
+const searchRuntimePath = path.join(distDirectory, "search.js");
+const columnVisibilityRuntimePath = path.join(
+  distDirectory,
+  "column-visibility.js"
+);
+const requiredFiles = [
+  runtimePath,
+  declarationPath,
+  coreRuntimePath,
+  searchRuntimePath,
+  columnVisibilityRuntimePath,
+];
+const missingFiles = requiredFiles.filter(
+  (filePath) => !fs.existsSync(filePath)
+);
+
+if (missingFiles.length > 0) {
+  console.error(
+    `Missing components build output:\n${missingFiles
+      .map((filePath) => `- ${path.relative(process.cwd(), filePath)}`)
+      .join("\n")}`
+  );
+  process.exit(1);
+}
+
+const runtime = fs.readFileSync(runtimePath, "utf8");
+const coreRuntime = fs.readFileSync(coreRuntimePath, "utf8");
+const searchRuntime = fs.readFileSync(searchRuntimePath, "utf8");
+const columnVisibilityRuntime = fs.readFileSync(
+  columnVisibilityRuntimePath,
+  "utf8"
+);
+const expectedPrefix = '"use client";\n';
+
+if (!runtime.startsWith(expectedPrefix)) {
+  console.error(
+    'The optional components entry must preserve its leading "use client" directive.'
+  );
+  process.exit(1);
+}
+
+if (fs.existsSync(unexpectedStylesheetPath)) {
+  console.error(
+    "The components entry must reuse search.css and column-visibility.css through their existing JavaScript entries, not emit duplicate components.css rules."
+  );
+  process.exit(1);
+}
+
+const relativeJavaScriptImportPatterns = [
+  /\bimport\s+(?:[^"']+?\s+from\s+)?["'](\.\.?\/[^"']+\.js)["']/g,
+  /\bexport\s+[^"']+?\s+from\s+["'](\.\.?\/[^"']+\.js)["']/g,
+  /\bimport\(\s*["'](\.\.?\/[^"']+\.js)["']\s*\)/g,
+];
+const relativeJavaScriptImports = new Set();
+
+for (const pattern of relativeJavaScriptImportPatterns) {
+  for (const match of runtime.matchAll(pattern)) {
+    if (match[1]) relativeJavaScriptImports.add(match[1]);
+  }
+}
+
+const expectedRuntimeImports = new Set([
+  "./column-visibility.js",
+  "./search.js",
+]);
+if (
+  relativeJavaScriptImports.size !== expectedRuntimeImports.size ||
+  Array.from(expectedRuntimeImports).some(
+    (specifier) => !relativeJavaScriptImports.has(specifier)
+  )
+) {
+  console.error(
+    `The optional components entry must compose only the existing search and column-visibility entries; found:\n${Array.from(
+      relativeJavaScriptImports
+    )
+      .map((specifier) => `- ${specifier}`)
+      .join("\n")}`
+  );
+  process.exit(1);
+}
+
+const publicRuntimeExports = [
+  "RDGProvider",
+  "RDGTarget",
+  "RDGSearchBar",
+  "RDGSearchProvider",
+  "RDGSearchTarget",
+  "RDGColumnVisibilityProvider",
+  "RDGColumnVisibilityTarget",
+  "RDGColumnVisibilityToolbar",
+];
+const missingRuntimeExports = publicRuntimeExports.filter(
+  (name) => !runtime.includes(name)
+);
+if (missingRuntimeExports.length > 0) {
+  console.error(
+    `The optional components entry is missing runtime exports: ${missingRuntimeExports.join(
+      ", "
+    )}`
+  );
+  process.exit(1);
+}
+
+for (const [entryName, entryRuntime] of [
+  ["core", coreRuntime],
+  ["search", searchRuntime],
+  ["column visibility", columnVisibilityRuntime],
+]) {
+  const leakedUnifiedExports = ["RDGProvider", "RDGTarget"].filter((name) =>
+    entryRuntime.includes(name)
+  );
+  if (leakedUnifiedExports.length > 0) {
+    console.error(
+      `Unified components exports leaked into the ${entryName} entry: ${leakedUnifiedExports.join(
+        ", "
+      )}`
+    );
+    process.exit(1);
+  }
+}
+
+const runtimeBytes = Buffer.byteLength(runtime);
+if (runtimeBytes > 48 * 1024) {
+  console.error(
+    `Components optional bundle exceeded its boundary: ${runtimeBytes} B JS.`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Optional components boundary verified: ${runtimeBytes} B JS with shared optional styles.`
+);

--- a/scripts/assert-css-scope.mjs
+++ b/scripts/assert-css-scope.mjs
@@ -6,6 +6,8 @@ import postcss from "postcss";
 const cssPaths = [
   path.resolve(process.cwd(), "dist/index.css"),
   path.resolve(process.cwd(), "dist/search.css"),
+  path.resolve(process.cwd(), "dist/column-visibility.css"),
+  path.resolve(process.cwd(), "dist/packages/TextInput/style.css"),
 ];
 const datagridOwnedMarkers = [
   ".tdg-",

--- a/scripts/assert-search-boundary.mjs
+++ b/scripts/assert-search-boundary.mjs
@@ -95,7 +95,12 @@ const topLevelJavaScript = fs
   .sort();
 if (
   JSON.stringify(topLevelJavaScript) !==
-  JSON.stringify(["column-visibility.js", "index.js", "search.js"])
+  JSON.stringify([
+    "column-visibility.js",
+    "components.js",
+    "index.js",
+    "search.js",
+  ])
 ) {
   console.error(
     `Unexpected JavaScript chunks in dist: ${topLevelJavaScript.join(", ")}`

--- a/scripts/assert-search-boundary.mjs
+++ b/scripts/assert-search-boundary.mjs
@@ -95,7 +95,7 @@ const topLevelJavaScript = fs
   .sort();
 if (
   JSON.stringify(topLevelJavaScript) !==
-  JSON.stringify(["index.js", "search.js"])
+  JSON.stringify(["column-visibility.js", "index.js", "search.js"])
 ) {
   console.error(
     `Unexpected JavaScript chunks in dist: ${topLevelJavaScript.join(", ")}`

--- a/scripts/assert-text-input-boundary.mjs
+++ b/scripts/assert-text-input-boundary.mjs
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const distDirectory = path.resolve(
+  process.cwd(),
+  "dist",
+  "packages",
+  "TextInput"
+);
+const runtimePath = path.join(distDirectory, "index.js");
+const stylesheetPath = path.join(distDirectory, "style.css");
+const declarationPath = path.join(distDirectory, "index.d.ts");
+const requiredFiles = [runtimePath, stylesheetPath, declarationPath];
+const missingFiles = requiredFiles.filter(
+  (filePath) => !fs.existsSync(filePath)
+);
+
+if (missingFiles.length > 0) {
+  console.error(
+    `Missing TextInput build output:\n${missingFiles
+      .map((filePath) => `- ${path.relative(process.cwd(), filePath)}`)
+      .join("\n")}`
+  );
+  process.exit(1);
+}
+
+const runtime = fs.readFileSync(runtimePath, "utf8");
+const stylesheet = fs.readFileSync(stylesheetPath, "utf8");
+const expectedPrefix = '"use client";\nimport "./style.css";';
+
+if (!runtime.startsWith(expectedPrefix)) {
+  console.error(
+    'The standalone TextInput entry must preserve "use client" before importing ./style.css.'
+  );
+  process.exit(1);
+}
+
+const relativeJavaScriptImportPatterns = [
+  /\bimport\s+(?:[^"']+?\s+from\s+)?["'](\.\.?\/[^"']+\.js)["']/g,
+  /\bexport\s+[^"']+?\s+from\s+["'](\.\.?\/[^"']+\.js)["']/g,
+  /\bimport\(\s*["'](\.\.?\/[^"']+\.js)["']\s*\)/g,
+];
+const relativeJavaScriptImports = new Set();
+
+for (const pattern of relativeJavaScriptImportPatterns) {
+  for (const match of runtime.matchAll(pattern)) {
+    if (match[1]) relativeJavaScriptImports.add(match[1]);
+  }
+}
+
+if (relativeJavaScriptImports.size > 0) {
+  console.error(
+    `The standalone TextInput entry imports local JavaScript chunks:\n${Array.from(
+      relativeJavaScriptImports
+    )
+      .map((specifier) => `- ${specifier}`)
+      .join("\n")}`
+  );
+  process.exit(1);
+}
+
+const staticImportPatterns = [
+  /\bimport\s+["']([^"']+)["']/g,
+  /\bimport\s+[^;]+?\s+from\s+["']([^"']+)["']/g,
+];
+const staticImports = new Set();
+for (const pattern of staticImportPatterns) {
+  for (const match of runtime.matchAll(pattern)) {
+    if (match[1]) staticImports.add(match[1]);
+  }
+}
+
+const allowedImports = new Set(["./style.css", "react", "react/jsx-runtime"]);
+const unexpectedImports = Array.from(staticImports).filter(
+  (specifier) => !allowedImports.has(specifier)
+);
+if (unexpectedImports.length > 0) {
+  console.error(
+    `The standalone TextInput entry has unexpected runtime imports:\n${unexpectedImports
+      .map((specifier) => `- ${specifier}`)
+      .join("\n")}`
+  );
+  process.exit(1);
+}
+
+if (runtime.includes("../../index.js") || runtime.includes("ReactDataGrid")) {
+  console.error("The standalone TextInput entry leaked the core grid runtime.");
+  process.exit(1);
+}
+
+const runtimeBytes = Buffer.byteLength(runtime);
+const stylesheetBytes = Buffer.byteLength(stylesheet);
+if (runtimeBytes > 64 * 1024 || stylesheetBytes > 16 * 1024) {
+  console.error(
+    `TextInput standalone bundle exceeded its boundary: ${runtimeBytes} B JS, ${stylesheetBytes} B CSS.`
+  );
+  process.exit(1);
+}
+
+if (
+  !runtime.includes("inovua-react-toolkit-text-input") ||
+  !stylesheet.includes(".tdg-text-input")
+) {
+  console.error("The TextInput runtime or standalone styles are incomplete.");
+  process.exit(1);
+}
+
+if (stylesheet.includes(".tdg-root")) {
+  console.error("Core grid selectors leaked into the TextInput stylesheet.");
+  process.exit(1);
+}
+
+console.log(
+  `Standalone TextInput boundary verified: ${runtimeBytes} B JS, ${stylesheetBytes} B CSS.`
+);

--- a/scripts/test-published-types.mjs
+++ b/scripts/test-published-types.mjs
@@ -81,6 +81,8 @@ try {
     "dist/column-visibility.js",
     "dist/column-visibility.css",
     "dist/column-visibility/index.d.ts",
+    "dist/components.js",
+    "dist/providers/index.d.ts",
     "dist/packages/TextInput/index.js",
     "dist/packages/TextInput/index.d.ts",
     "dist/packages/TextInput/style.css",
@@ -131,7 +133,7 @@ try {
     }
 
     console.log(
-      `Packed root, search, column-visibility, and TextInput types resolved with ${configuration}.`
+      `Packed root, search, column-visibility, components, and TextInput types resolved with ${configuration}.`
     );
   }
 } finally {

--- a/scripts/test-published-types.mjs
+++ b/scripts/test-published-types.mjs
@@ -77,6 +77,20 @@ try {
     );
   }
 
+  for (const relativePath of [
+    "dist/column-visibility.js",
+    "dist/column-visibility.css",
+    "dist/column-visibility/index.d.ts",
+    "dist/packages/TextInput/index.js",
+    "dist/packages/TextInput/index.d.ts",
+    "dist/packages/TextInput/style.css",
+  ]) {
+    const publishedPath = path.join(installedPackageDirectory, relativePath);
+    if (!fs.existsSync(publishedPath)) {
+      throw new Error(`Packed package is missing ${relativePath}.`);
+    }
+  }
+
   fs.writeFileSync(
     path.join(fixtureDirectory, "package.json"),
     `${JSON.stringify(
@@ -116,7 +130,9 @@ try {
       );
     }
 
-    console.log(`Packed root and search types resolved with ${configuration}.`);
+    console.log(
+      `Packed root, search, column-visibility, and TextInput types resolved with ${configuration}.`
+    );
   }
 } finally {
   fs.rmSync(fixtureDirectory, { recursive: true, force: true });

--- a/src/column-visibility/RDGColumnVisibilityProvider.tsx
+++ b/src/column-visibility/RDGColumnVisibilityProvider.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+
+import type { TypeDataGridProps } from "../types";
+import { isMarkedGridType } from "./runtime";
+import { RDGColumnVisibilityTarget } from "./RDGColumnVisibilityTarget";
+import {
+  createRDGColumnVisibilityStore,
+  RDGColumnVisibilityContext,
+} from "./store";
+
+export type RDGColumnVisibilityProviderProps = {
+  children: React.ReactNode;
+};
+
+export function RDGColumnVisibilityProvider(
+  props: RDGColumnVisibilityProviderProps
+) {
+  const { children } = props;
+  const [store] = React.useState(createRDGColumnVisibilityStore);
+
+  React.useEffect(() => () => store.dispose(), [store]);
+
+  const targets = React.useMemo(
+    () =>
+      React.Children.map(children, (child) =>
+        React.isValidElement(child) && isMarkedGridType(child.type) ? (
+          <RDGColumnVisibilityTarget>
+            {child as React.ReactElement<TypeDataGridProps>}
+          </RDGColumnVisibilityTarget>
+        ) : (
+          child
+        )
+      ),
+    [children]
+  );
+
+  return (
+    <RDGColumnVisibilityContext.Provider value={store}>
+      {targets}
+    </RDGColumnVisibilityContext.Provider>
+  );
+}

--- a/src/column-visibility/RDGColumnVisibilityTarget.tsx
+++ b/src/column-visibility/RDGColumnVisibilityTarget.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import * as React from "react";
+
+import type { TypeDataGridProps } from "../types";
+import { isMarkedGridType } from "./runtime";
+import { useRDGColumnVisibilityStore } from "./store";
+
+export type RDGColumnVisibilityTargetProps = {
+  children: React.ReactElement<TypeDataGridProps>;
+};
+
+function looksLikeGridElement(
+  child: React.ReactElement<unknown>
+): child is React.ReactElement<TypeDataGridProps> {
+  const props = child.props as Partial<TypeDataGridProps> | null;
+  return Boolean(
+    props &&
+    typeof props.idProperty === "string" &&
+    Array.isArray(props.columns) &&
+    props.dataSource != null
+  );
+}
+
+export function RDGColumnVisibilityTarget(
+  props: RDGColumnVisibilityTargetProps
+) {
+  const { children } = props;
+  const store = useRDGColumnVisibilityStore();
+  const registration = React.useMemo(
+    () => store.createTargetRegistration(),
+    [store]
+  );
+
+  React.useEffect(() => registration.attach(), [registration]);
+
+  if (!React.isValidElement(children)) {
+    throw new Error(
+      "RDGColumnVisibilityTarget expects exactly one ReactDataGrid child."
+    );
+  }
+
+  if (!isMarkedGridType(children.type) && !looksLikeGridElement(children)) {
+    throw new Error("RDGColumnVisibilityTarget expects a ReactDataGrid child.");
+  }
+
+  return React.cloneElement(
+    children as React.ReactElement<Record<string, unknown>>,
+    { __rdgColumnVisibilityController: registration.controller }
+  );
+}

--- a/src/column-visibility/RDGColumnVisibilityTarget.tsx
+++ b/src/column-visibility/RDGColumnVisibilityTarget.tsx
@@ -2,6 +2,11 @@
 
 import * as React from "react";
 
+import {
+  findTargetGridElement,
+  markOptionalTargetType,
+  RDG_COLUMN_VISIBILITY_TARGET_COMPONENT_MARKER,
+} from "../optional-target";
 import type { TypeDataGridProps } from "../types";
 import { isMarkedGridType } from "./runtime";
 import { useRDGColumnVisibilityStore } from "./store";
@@ -10,22 +15,15 @@ export type RDGColumnVisibilityTargetProps = {
   children: React.ReactElement<TypeDataGridProps>;
 };
 
-function looksLikeGridElement(
-  child: React.ReactElement<unknown>
-): child is React.ReactElement<TypeDataGridProps> {
-  const props = child.props as Partial<TypeDataGridProps> | null;
-  return Boolean(
-    props &&
-    typeof props.idProperty === "string" &&
-    Array.isArray(props.columns) &&
-    props.dataSource != null
-  );
-}
-
 export function RDGColumnVisibilityTarget(
   props: RDGColumnVisibilityTargetProps
 ) {
   const { children } = props;
+  const forwardedSearchController = (
+    props as RDGColumnVisibilityTargetProps & {
+      __rdgSearchController?: unknown;
+    }
+  ).__rdgSearchController;
   const store = useRDGColumnVisibilityStore();
   const registration = React.useMemo(
     () => store.createTargetRegistration(),
@@ -40,12 +38,24 @@ export function RDGColumnVisibilityTarget(
     );
   }
 
-  if (!isMarkedGridType(children.type) && !looksLikeGridElement(children)) {
+  if (!findTargetGridElement(children, isMarkedGridType)) {
     throw new Error("RDGColumnVisibilityTarget expects a ReactDataGrid child.");
+  }
+
+  const injectedProps: Record<string, unknown> = {
+    __rdgColumnVisibilityController: registration.controller,
+  };
+  if (forwardedSearchController !== undefined) {
+    injectedProps.__rdgSearchController = forwardedSearchController;
   }
 
   return React.cloneElement(
     children as React.ReactElement<Record<string, unknown>>,
-    { __rdgColumnVisibilityController: registration.controller }
+    injectedProps
   );
 }
+
+markOptionalTargetType(
+  RDGColumnVisibilityTarget,
+  RDG_COLUMN_VISIBILITY_TARGET_COMPONENT_MARKER
+);

--- a/src/column-visibility/RDGColumnVisibilityToolbar.tsx
+++ b/src/column-visibility/RDGColumnVisibilityToolbar.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import * as React from "react";
+
+import type { TypeColumn } from "../types";
+import { normalizeThemeName, resolveThemeBase } from "../theme/context";
+import { useRDGColumnVisibilitySnapshot } from "./store";
+
+export type RDGColumnVisibilityToolbarProps = {
+  children?: React.ReactNode;
+  ariaLabel?: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+};
+
+function getColumnId(column: TypeColumn): string {
+  return String(column.id ?? column.name ?? "");
+}
+
+function getColumnLabel(column: TypeColumn): React.ReactNode {
+  if (typeof column.header === "string" && column.header.trim()) {
+    return column.header;
+  }
+  if (typeof column.header === "number") return column.header;
+  return getColumnId(column);
+}
+
+function orderColumns(
+  columns: readonly TypeColumn[],
+  columnOrder: readonly string[]
+): TypeColumn[] {
+  const columnsById = new Map<string, TypeColumn>();
+  for (const column of columns) {
+    const columnId = getColumnId(column);
+    if (columnId && !columnsById.has(columnId)) {
+      columnsById.set(columnId, column);
+    }
+  }
+
+  const ordered: TypeColumn[] = [];
+  for (const columnId of columnOrder) {
+    const column = columnsById.get(columnId);
+    if (!column) continue;
+    ordered.push(column);
+    columnsById.delete(columnId);
+  }
+  ordered.push(...columnsById.values());
+  return ordered;
+}
+
+export function RDGColumnVisibilityToolbar(
+  props: RDGColumnVisibilityToolbarProps
+) {
+  const {
+    children,
+    ariaLabel = "Visible column toggles",
+    title = "Visible columns",
+    description = "Choose which columns are visible in the grid.",
+  } = props;
+  const snapshot = useRDGColumnVisibilitySnapshot();
+  const theme = normalizeThemeName(snapshot.theme);
+  const themeBase = resolveThemeBase(theme);
+  const orderedColumns = React.useMemo(
+    () => orderColumns(snapshot.columns, snapshot.columnOrder),
+    [snapshot.columnOrder, snapshot.columns]
+  );
+  const toggleColumns = React.useMemo(
+    () => orderedColumns.filter((column) => column.hideable !== false),
+    [orderedColumns]
+  );
+  const visibleColumnCount = orderedColumns.reduce(
+    (count, column) =>
+      count +
+      (snapshot.columnVisibilityMap[getColumnId(column)] === false ? 0 : 1),
+    0
+  );
+
+  return (
+    <div
+      className="tdg-column-visibility-root flex flex-col gap-3 rounded-xl border bg-card/60 p-3 text-foreground shadow-sm"
+      data-slot="rdg-column-visibility"
+      data-theme={theme}
+      data-theme-base={themeBase}
+    >
+      {title != null || description != null ? (
+        <div className="flex flex-col gap-1">
+          {title != null ? (
+            <div className="text-sm font-medium">{title}</div>
+          ) : null}
+          {description != null ? (
+            <div className="text-xs text-muted-foreground">{description}</div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+        <div
+          className="flex max-w-full flex-wrap gap-2"
+          role="group"
+          aria-label={ariaLabel}
+          data-slot="rdg-column-toggle-list"
+        >
+          {toggleColumns.map((column) => {
+            const columnId = getColumnId(column);
+            const visible = snapshot.columnVisibilityMap[columnId] !== false;
+            const disabled = visible && visibleColumnCount <= 1;
+
+            return (
+              <button
+                key={columnId}
+                type="button"
+                className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border px-3 text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:border-transparent data-[state=on]:bg-secondary data-[state=on]:text-secondary-foreground"
+                aria-pressed={visible}
+                disabled={disabled}
+                data-state={visible ? "on" : "off"}
+                data-slot="rdg-column-toggle"
+                data-column-id={columnId}
+                onClick={() => snapshot.setColumnVisible(columnId, !visible)}
+              >
+                {getColumnLabel(column)}
+              </button>
+            );
+          })}
+        </div>
+
+        {children != null ? (
+          <div
+            className="flex shrink-0 flex-wrap items-center gap-2"
+            data-slot="rdg-column-visibility-actions"
+          >
+            {children}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/column-visibility/RDGColumnVisibilityToolbar.tsx
+++ b/src/column-visibility/RDGColumnVisibilityToolbar.tsx
@@ -57,6 +57,8 @@ export function RDGColumnVisibilityToolbar(
     title = "Visible columns",
     description = "Choose which columns are visible in the grid.",
   } = props;
+  const titleId = React.useId();
+  const descriptionId = React.useId();
   const snapshot = useRDGColumnVisibilitySnapshot();
   const theme = normalizeThemeName(snapshot.theme);
   const themeBase = resolveThemeBase(theme);
@@ -81,14 +83,26 @@ export function RDGColumnVisibilityToolbar(
       data-slot="rdg-column-visibility"
       data-theme={theme}
       data-theme-base={themeBase}
+      role={title != null ? "region" : undefined}
+      aria-labelledby={title != null ? titleId : undefined}
+      aria-describedby={description != null ? descriptionId : undefined}
     >
       {title != null || description != null ? (
         <div className="flex flex-col gap-1">
           {title != null ? (
-            <div className="text-sm font-medium">{title}</div>
+            <div
+              id={titleId}
+              className="text-sm font-medium"
+              role="heading"
+              aria-level={2}
+            >
+              {title}
+            </div>
           ) : null}
           {description != null ? (
-            <div className="text-xs text-muted-foreground">{description}</div>
+            <div id={descriptionId} className="text-xs text-muted-foreground">
+              {description}
+            </div>
           ) : null}
         </div>
       ) : null}
@@ -98,6 +112,7 @@ export function RDGColumnVisibilityToolbar(
           className="flex max-w-full flex-wrap gap-2"
           role="group"
           aria-label={ariaLabel}
+          aria-describedby={description != null ? descriptionId : undefined}
           data-slot="rdg-column-toggle-list"
         >
           {toggleColumns.map((column) => {

--- a/src/column-visibility/controller.ts
+++ b/src/column-visibility/controller.ts
@@ -1,0 +1,14 @@
+import type { TypeColumn } from "../types";
+
+export type RDGColumnVisibilityPublishedSnapshot = {
+  columns: readonly TypeColumn[];
+  columnOrder: readonly string[];
+  columnVisibilityMap: Readonly<Record<string, boolean>>;
+  theme: string;
+  setColumnVisible: (columnId: string, visible: boolean) => void;
+};
+
+/** Private bridge injected by RDGColumnVisibilityTarget. */
+export type RDGColumnVisibilityController = {
+  publish: (snapshot: RDGColumnVisibilityPublishedSnapshot) => void;
+};

--- a/src/column-visibility/index.ts
+++ b/src/column-visibility/index.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import "./style.css";
+
+export { RDGColumnVisibilityProvider } from "./RDGColumnVisibilityProvider";
+export { RDGColumnVisibilityTarget } from "./RDGColumnVisibilityTarget";
+export { RDGColumnVisibilityToolbar } from "./RDGColumnVisibilityToolbar";
+
+export type { RDGColumnVisibilityProviderProps } from "./RDGColumnVisibilityProvider";
+export type { RDGColumnVisibilityTargetProps } from "./RDGColumnVisibilityTarget";
+export type { RDGColumnVisibilityToolbarProps } from "./RDGColumnVisibilityToolbar";

--- a/src/column-visibility/runtime.ts
+++ b/src/column-visibility/runtime.ts
@@ -1,0 +1,16 @@
+import ReactDataGrid from "../main";
+
+const RDG_GRID_TARGET_MARKER = Symbol.for(
+  "@geovi/the-datagrid/column-visibility-target"
+);
+
+export function isMarkedGridType(type: unknown): boolean {
+  if ((typeof type !== "function" && typeof type !== "object") || !type) {
+    return false;
+  }
+
+  return (
+    type === ReactDataGrid ||
+    (type as Record<PropertyKey, unknown>)[RDG_GRID_TARGET_MARKER] === true
+  );
+}

--- a/src/column-visibility/store.ts
+++ b/src/column-visibility/store.ts
@@ -1,0 +1,159 @@
+import * as React from "react";
+
+import type {
+  RDGColumnVisibilityController,
+  RDGColumnVisibilityPublishedSnapshot,
+} from "./controller";
+
+const EMPTY_COLUMNS: RDGColumnVisibilityPublishedSnapshot["columns"] = [];
+const EMPTY_COLUMN_ORDER: RDGColumnVisibilityPublishedSnapshot["columnOrder"] =
+  [];
+const EMPTY_COLUMN_VISIBILITY: RDGColumnVisibilityPublishedSnapshot["columnVisibilityMap"] =
+  {};
+const NOOP_SET_COLUMN_VISIBLE = () => {};
+
+export const EMPTY_COLUMN_VISIBILITY_SNAPSHOT: RDGColumnVisibilityPublishedSnapshot =
+  {
+    columns: EMPTY_COLUMNS,
+    columnOrder: EMPTY_COLUMN_ORDER,
+    columnVisibilityMap: EMPTY_COLUMN_VISIBILITY,
+    theme: "default",
+    setColumnVisible: NOOP_SET_COLUMN_VISIBLE,
+  };
+
+type TargetRegistration = {
+  attach: () => () => void;
+  controller: RDGColumnVisibilityController;
+};
+
+export type RDGColumnVisibilityStore = {
+  createTargetRegistration: () => TargetRegistration;
+  dispose: () => void;
+  getServerSnapshot: () => RDGColumnVisibilityPublishedSnapshot;
+  getSnapshot: () => RDGColumnVisibilityPublishedSnapshot;
+  subscribe: (listener: () => void) => () => void;
+};
+
+function sameArray<T>(left: readonly T[], right: readonly T[]): boolean {
+  return (
+    left === right ||
+    (left.length === right.length &&
+      left.every((value, index) => value === right[index]))
+  );
+}
+
+function sameVisibilityMap(
+  left: Readonly<Record<string, boolean>>,
+  right: Readonly<Record<string, boolean>>
+): boolean {
+  if (left === right) return true;
+
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (columnId) =>
+        Object.prototype.hasOwnProperty.call(right, columnId) &&
+        left[columnId] === right[columnId]
+    )
+  );
+}
+
+function sameSnapshot(
+  left: RDGColumnVisibilityPublishedSnapshot,
+  right: RDGColumnVisibilityPublishedSnapshot
+): boolean {
+  return (
+    sameArray(left.columns, right.columns) &&
+    sameArray(left.columnOrder, right.columnOrder) &&
+    sameVisibilityMap(left.columnVisibilityMap, right.columnVisibilityMap) &&
+    left.theme === right.theme &&
+    left.setColumnVisible === right.setColumnVisible
+  );
+}
+
+export function createRDGColumnVisibilityStore(): RDGColumnVisibilityStore {
+  let activeTarget: symbol | null = null;
+  let snapshot = EMPTY_COLUMN_VISIBILITY_SNAPSHOT;
+  const listeners = new Set<() => void>();
+
+  const emitSnapshot = (next: RDGColumnVisibilityPublishedSnapshot) => {
+    if (sameSnapshot(snapshot, next)) return;
+    snapshot = next;
+    listeners.forEach((listener) => listener());
+  };
+
+  return {
+    createTargetRegistration() {
+      const target = Symbol("rdg-column-visibility-target");
+      let attached = false;
+      let latestSnapshot: RDGColumnVisibilityPublishedSnapshot | null = null;
+
+      return {
+        controller: {
+          publish(nextSnapshot) {
+            latestSnapshot = nextSnapshot;
+            if (attached && activeTarget === target) {
+              emitSnapshot(nextSnapshot);
+            }
+          },
+        },
+        attach() {
+          if (activeTarget !== null && activeTarget !== target) {
+            throw new Error(
+              "RDGColumnVisibilityProvider supports one ReactDataGrid target. " +
+                "Use a separate provider for each grid."
+            );
+          }
+
+          attached = true;
+          activeTarget = target;
+          if (latestSnapshot) emitSnapshot(latestSnapshot);
+
+          return () => {
+            if (!attached) return;
+            attached = false;
+            if (activeTarget !== target) return;
+            activeTarget = null;
+            emitSnapshot(EMPTY_COLUMN_VISIBILITY_SNAPSHOT);
+          };
+        },
+      };
+    },
+    dispose() {
+      activeTarget = null;
+      snapshot = EMPTY_COLUMN_VISIBILITY_SNAPSHOT;
+      listeners.clear();
+    },
+    getSnapshot: () => snapshot,
+    getServerSnapshot: () => EMPTY_COLUMN_VISIBILITY_SNAPSHOT,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+export const RDGColumnVisibilityContext =
+  React.createContext<RDGColumnVisibilityStore | null>(null);
+
+export function useRDGColumnVisibilityStore(): RDGColumnVisibilityStore {
+  const store = React.useContext(RDGColumnVisibilityContext);
+  if (!store) {
+    throw new Error(
+      "RDG column visibility components must be rendered inside " +
+        "RDGColumnVisibilityProvider."
+    );
+  }
+  return store;
+}
+
+export function useRDGColumnVisibilitySnapshot(): RDGColumnVisibilityPublishedSnapshot {
+  const store = useRDGColumnVisibilityStore();
+  return React.useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot
+  );
+}

--- a/src/column-visibility/style.css
+++ b/src/column-visibility/style.css
@@ -1,0 +1,129 @@
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities) source(none);
+
+@source "./**/*.{ts,tsx}";
+
+.tdg-column-visibility-root,
+.tdg-column-visibility-root::before,
+.tdg-column-visibility-root::after,
+.tdg-column-visibility-root *,
+.tdg-column-visibility-root *::before,
+.tdg-column-visibility-root *::after {
+  box-sizing: border-box;
+}
+
+.tdg-column-visibility-root {
+  --tdg-column-visibility-background: var(
+    --tdg-color-background,
+    var(--background, oklch(1 0 0))
+  );
+  --tdg-column-visibility-foreground: var(
+    --tdg-color-foreground,
+    var(--foreground, oklch(0.145 0 0))
+  );
+  --tdg-column-visibility-card: var(
+    --tdg-color-card,
+    var(--card, oklch(1 0 0))
+  );
+  --tdg-column-visibility-secondary: var(
+    --tdg-color-secondary,
+    var(--secondary, oklch(0.97 0 0))
+  );
+  --tdg-column-visibility-secondary-foreground: var(
+    --tdg-color-secondary-foreground,
+    var(--secondary-foreground, oklch(0.205 0 0))
+  );
+  --tdg-column-visibility-accent: var(
+    --tdg-color-accent,
+    var(--accent, oklch(0.97 0 0))
+  );
+  --tdg-column-visibility-accent-foreground: var(
+    --tdg-color-accent-foreground,
+    var(--accent-foreground, oklch(0.205 0 0))
+  );
+  --tdg-column-visibility-muted-foreground: var(
+    --tdg-color-muted-foreground,
+    var(--muted-foreground, oklch(0.556 0 0))
+  );
+  --tdg-column-visibility-border: var(
+    --tdg-color-border,
+    var(--border, oklch(0.922 0 0))
+  );
+  --tdg-column-visibility-ring: var(
+    --tdg-color-ring,
+    var(--ring, oklch(0.708 0 0))
+  );
+  color-scheme: light;
+}
+
+.dark
+  .tdg-column-visibility-root[data-theme="default"][data-theme-base="default"],
+.tdg-column-visibility-root[data-theme-base="dark"] {
+  --tdg-column-visibility-background: var(
+    --tdg-color-background,
+    var(--background, oklch(0.145 0 0))
+  );
+  --tdg-column-visibility-foreground: var(
+    --tdg-color-foreground,
+    var(--foreground, oklch(0.985 0 0))
+  );
+  --tdg-column-visibility-card: var(
+    --tdg-color-card,
+    var(--card, oklch(0.205 0 0))
+  );
+  --tdg-column-visibility-secondary: var(
+    --tdg-color-secondary,
+    var(--secondary, oklch(0.269 0 0))
+  );
+  --tdg-column-visibility-secondary-foreground: var(
+    --tdg-color-secondary-foreground,
+    var(--secondary-foreground, oklch(0.985 0 0))
+  );
+  --tdg-column-visibility-accent: var(
+    --tdg-color-accent,
+    var(--accent, oklch(0.269 0 0))
+  );
+  --tdg-column-visibility-accent-foreground: var(
+    --tdg-color-accent-foreground,
+    var(--accent-foreground, oklch(0.985 0 0))
+  );
+  --tdg-column-visibility-muted-foreground: var(
+    --tdg-color-muted-foreground,
+    var(--muted-foreground, oklch(0.708 0 0))
+  );
+  --tdg-column-visibility-border: var(
+    --tdg-color-border,
+    var(--border, oklch(1 0 0 / 10%))
+  );
+  --tdg-column-visibility-ring: var(
+    --tdg-color-ring,
+    var(--ring, oklch(0.556 0 0))
+  );
+  color-scheme: dark;
+}
+
+.tdg-column-visibility-root.rounded-xl {
+  border-radius: var(
+    --tdg-radius-xl,
+    var(--radius-xl, calc(var(--radius, 0.5rem) + 4px))
+  );
+}
+
+@theme {
+  --radius-*: initial;
+}
+
+@theme inline {
+  --color-background: var(--tdg-column-visibility-background);
+  --color-foreground: var(--tdg-column-visibility-foreground);
+  --color-card: var(--tdg-column-visibility-card);
+  --color-secondary: var(--tdg-column-visibility-secondary);
+  --color-secondary-foreground: var(
+    --tdg-column-visibility-secondary-foreground
+  );
+  --color-accent: var(--tdg-column-visibility-accent);
+  --color-accent-foreground: var(--tdg-column-visibility-accent-foreground);
+  --color-muted-foreground: var(--tdg-column-visibility-muted-foreground);
+  --color-border: var(--tdg-column-visibility-border);
+  --color-ring: var(--tdg-column-visibility-ring);
+}

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -3961,6 +3961,22 @@ function ReactDataGrid(props: TypeDataGridProps) {
     [allInputColumns, getColumnIdCompat]
   );
 
+  const columnVisibilityIdsRef = React.useRef<ReadonlySet<string>>(new Set());
+  columnVisibilityIdsRef.current = new Set(
+    allInputColumns.map((column) => getColumnId(column))
+  );
+  const setColumnVisibleById = React.useCallback(
+    (columnId: string, visible: boolean) => {
+      if (!columnVisibilityIdsRef.current.has(columnId)) return;
+
+      setColumnVisibilityState((current) => {
+        if (current[columnId] === visible) return current;
+        return { ...current, [columnId]: visible };
+      });
+    },
+    []
+  );
+
   React.useLayoutEffect(() => {
     if (!columnVisibilityController) return;
 
@@ -3976,14 +3992,14 @@ function ReactDataGrid(props: TypeDataGridProps) {
       columnOrder: columnOrderForDs,
       columnVisibilityMap: consumerColumnVisibilityMap,
       theme: String(theme),
-      setColumnVisible: setColumnVisibleCompat,
+      setColumnVisible: setColumnVisibleById,
     });
   }, [
     columnOrderForDs,
     columnVisibilityController,
     columnVisibilityMap,
     inputColumns,
-    setColumnVisibleCompat,
+    setColumnVisibleById,
     theme,
   ]);
 
@@ -5169,6 +5185,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                 sortInfo={sortInfo}
                 defaultSortDirection={defaultSortDir}
                 searchEnabled={!searchConnected}
+                columnPickerEnabled={columnVisibilityController == null}
                 authoritativeResultCount={searchConnected ? count : undefined}
                 onSortInfoChange={setSortInfoAndResetPage}
                 onFilteredRowsCountChange={notifyFilteredRowsCount}

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -254,21 +254,35 @@ type InternalSearchController = {
   filterRows: <Row>(rows: Row[], columns: TypeColumn[]) => Row[];
 };
 
+type InternalColumnVisibilitySnapshot = {
+  columns: readonly TypeColumn[];
+  columnOrder: readonly string[];
+  columnVisibilityMap: Readonly<Record<string, boolean>>;
+  theme: string;
+  setColumnVisible: (columnId: string, visible: boolean) => void;
+};
+
+type InternalColumnVisibilityController = {
+  publish: (snapshot: InternalColumnVisibilitySnapshot) => void;
+};
+
 type InternalDataGridProps = TypeDataGridProps & {
   /** Injected by the optional search package; intentionally not public API. */
   __rdgSearchController?: InternalSearchController;
+  /** Injected by the optional column-visibility package; not public API. */
+  __rdgColumnVisibilityController?: InternalColumnVisibilityController;
 };
 
-let publicSearchPropsCache:
+let publicPropsCache:
   | WeakMap<InternalDataGridProps, InternalDataGridProps>
   | undefined;
 
-function getPublicSearchProps(
+function getPublicProps(
   internalProps: InternalDataGridProps
 ): InternalDataGridProps {
   const cache =
-    publicSearchPropsCache ??
-    (publicSearchPropsCache = new WeakMap<
+    publicPropsCache ??
+    (publicPropsCache = new WeakMap<
       InternalDataGridProps,
       InternalDataGridProps
     >());
@@ -277,6 +291,7 @@ function getPublicSearchProps(
 
   const publicProps = { ...internalProps };
   delete publicProps.__rdgSearchController;
+  delete publicProps.__rdgColumnVisibilityController;
   cache.set(internalProps, publicProps);
   return publicProps;
 }
@@ -426,11 +441,15 @@ function ensureLastColumnHeaderFits(args: {
 function ReactDataGrid(props: TypeDataGridProps) {
   const internalProps = props as InternalDataGridProps;
   const searchController = internalProps.__rdgSearchController;
+  const columnVisibilityController =
+    internalProps.__rdgColumnVisibilityController;
   const searchConnected = searchController != null;
-  // The optional search entry uses a private prop as its zero-dependency
-  // bridge. Keep that bridge out of every consumer-facing props mirror.
-  const publicProps: InternalDataGridProps = searchConnected
-    ? getPublicSearchProps(internalProps)
+  const optionalControllerConnected =
+    searchConnected || columnVisibilityController != null;
+  // Optional entries use private props as zero-dependency bridges. Keep those
+  // bridges out of every consumer-facing props mirror and remote-source args.
+  const publicProps: InternalDataGridProps = optionalControllerConnected
+    ? getPublicProps(internalProps)
     : internalProps;
   const searchValue = searchController?.value ?? "";
   const searchFilterRows = searchController?.filterRows;
@@ -3689,18 +3708,21 @@ function ReactDataGrid(props: TypeDataGridProps) {
   );
   const onReadyRef = React.useRef(props.onReady);
   const handleRef = React.useRef(props.handle);
+  const onDidMountRef = React.useRef(props.onDidMount);
   const onReadyNotifiedRef = React.useRef(false);
   const handleNotifiedRef = React.useRef(false);
 
   React.useLayoutEffect(() => {
     onReadyRef.current = props.onReady;
     handleRef.current = props.handle;
+    onDidMountRef.current = props.onDidMount;
 
     return () => {
       onReadyRef.current = undefined;
       handleRef.current = undefined;
+      onDidMountRef.current = undefined;
     };
-  }, [props.handle, props.onReady]);
+  }, [props.handle, props.onDidMount, props.onReady]);
 
   React.useLayoutEffect(() => {
     return () => {
@@ -3915,6 +3937,55 @@ function ReactDataGrid(props: TypeDataGridProps) {
     },
     [getColumnByCompat]
   );
+
+  const setColumnVisibleCompat = React.useCallback(
+    (column: TypeGetColumnByParam, visible: boolean) => {
+      const columnId = getColumnIdCompat(column);
+      if (!columnId) return;
+      if (
+        !allInputColumns.some(
+          (candidate) => getColumnId(candidate) === columnId
+        )
+      ) {
+        return;
+      }
+
+      // `hideable` constrains UI affordances, not the Inovua imperative API.
+      // Writing the sparse controlled override also avoids TanStack's
+      // `getCanHide()` gate for hideable:false columns.
+      setColumnVisibilityState((current) => {
+        if (current[columnId] === visible) return current;
+        return { ...current, [columnId]: visible };
+      });
+    },
+    [allInputColumns, getColumnIdCompat]
+  );
+
+  React.useLayoutEffect(() => {
+    if (!columnVisibilityController) return;
+
+    const consumerColumnVisibilityMap = Object.fromEntries(
+      inputColumns.map((column) => {
+        const columnId = getColumnId(column);
+        return [columnId, columnVisibilityMap[columnId] !== false];
+      })
+    );
+
+    columnVisibilityController.publish({
+      columns: inputColumns,
+      columnOrder: columnOrderForDs,
+      columnVisibilityMap: consumerColumnVisibilityMap,
+      theme: String(theme),
+      setColumnVisible: setColumnVisibleCompat,
+    });
+  }, [
+    columnOrderForDs,
+    columnVisibilityController,
+    columnVisibilityMap,
+    inputColumns,
+    setColumnVisibleCompat,
+    theme,
+  ]);
 
   const setColumnSortInfoCompat = React.useCallback(
     (column: TypeGetColumnByParam, dir: 1 | 0 | -1) => {
@@ -4274,21 +4345,44 @@ function ReactDataGrid(props: TypeDataGridProps) {
     );
   }, []);
 
-  const resolvedRowHeightLayout = React.useMemo(() => {
+  // Non-virtual rows still participate in Inovua's virtual-list compatibility
+  // API. Keep their explicit DOM measurements outside React state: the table
+  // already lays those rows out naturally, while the imperative getters need
+  // to report the same measured sizes immediately after `adjustHeights()`.
+  const nonVirtualRowHeightOverridesRef = React.useRef(
+    new Map<string, number>()
+  );
+  React.useEffect(() => {
+    const overrides = nonVirtualRowHeightOverridesRef.current;
+    if (typeof rowHeight === "number" || virtualized) {
+      overrides.clear();
+      return;
+    }
+    if (overrides.size === 0) return;
+
+    const currentRowIds = new Set(rowModel.map((row) => row.id));
+    for (const rowId of overrides.keys()) {
+      if (!currentRowIds.has(rowId)) overrides.delete(rowId);
+    }
+  }, [rowHeight, rowModel, virtualized]);
+  const getResolvedRowHeightLayout = React.useCallback(() => {
     let start = 0;
-    return rowModel.map((_, index) => {
-      const size = resolveRowHeight(index);
+    return rowModel.map((row, index) => {
+      const size =
+        (typeof rowHeight !== "number"
+          ? nonVirtualRowHeightOverridesRef.current.get(row.id)
+          : undefined) ?? resolveRowHeight(index);
       const item = { index, start, end: start + size, size };
       start += size;
       return item;
     });
-  }, [resolveRowHeight, rowModel]);
+  }, [resolveRowHeight, rowHeight, rowModel]);
 
   const getVirtualListRowsCompat =
     React.useCallback((): TypeComputedVirtualListRow[] => {
       const virtualRows = virtualized
         ? rowVirtualizer.getVirtualItems()
-        : resolvedRowHeightLayout;
+        : getResolvedRowHeightLayout();
 
       return virtualRows.map((virtualRow) => {
         const row = rowModel[virtualRow.index];
@@ -4310,7 +4404,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         };
       });
     }, [
-      resolvedRowHeightLayout,
+      getResolvedRowHeightLayout,
       rowModel,
       rowVirtualizer,
       stickyHeaderOffset,
@@ -4318,10 +4412,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
     ]);
 
   const getTotalRowHeightCompat = React.useCallback(() => {
-    return virtualized
-      ? rowVirtualizer.getTotalSize()
-      : (resolvedRowHeightLayout[resolvedRowHeightLayout.length - 1]?.end ?? 0);
-  }, [resolvedRowHeightLayout, rowVirtualizer, virtualized]);
+    if (virtualized) return rowVirtualizer.getTotalSize();
+
+    const resolvedRowHeightLayout = getResolvedRowHeightLayout();
+    return (
+      resolvedRowHeightLayout[resolvedRowHeightLayout.length - 1]?.end ?? 0
+    );
+  }, [getResolvedRowHeightLayout, rowVirtualizer, virtualized]);
 
   const getScrollHeightCompat = React.useCallback(() => {
     return Math.max(
@@ -4430,6 +4527,44 @@ function ReactDataGrid(props: TypeDataGridProps) {
     }
   }, [rowVirtualizer, virtualized]);
 
+  const adjustVirtualListHeightsCompat = React.useCallback((): void => {
+    // Inovua only performs manual measurement when row height is variable.
+    // A numeric value, including a non-finite one, selects fixed-height mode.
+    if (typeof rowHeight === "number") return;
+
+    const rowContainer = scrollRef.current ?? surfaceRef.current;
+    rowContainer
+      ?.querySelectorAll<HTMLElement>('[data-slot="grid-row"][data-row-index]')
+      .forEach((element) => {
+        const rowIndex = Number(element.dataset.rowIndex);
+        const measuredHeight = element.scrollHeight;
+        if (
+          !Number.isInteger(rowIndex) ||
+          rowIndex < 0 ||
+          rowIndex >= rowModel.length ||
+          !Number.isFinite(measuredHeight) ||
+          measuredHeight <= 0
+        ) {
+          return;
+        }
+
+        if (virtualized) {
+          // `measureElement()` also registers the node with TanStack's
+          // ResizeObserver/cache. Calling it imperatively for function-height
+          // rows (which have no ref cleanup) can retain disconnected DOM nodes
+          // after scrolling. Inovua reads `scrollHeight`; `resizeItem()` gives
+          // us the same explicit measurement without creating an observer.
+          rowVirtualizer.resizeItem(rowIndex, measuredHeight);
+          return;
+        }
+
+        const row = rowModel[rowIndex];
+        if (row) {
+          nonVirtualRowHeightOverridesRef.current.set(row.id, measuredHeight);
+        }
+      });
+  }, [rowHeight, rowModel, rowVirtualizer, virtualized]);
+
   const virtualListCompat = React.useMemo<TypeComputedVirtualList>(
     () => ({
       props: publicProps as unknown as Record<string, unknown>,
@@ -4485,6 +4620,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       setRowIndex: (index) => scrollToIndexCompat(index),
       scrollToIndex: scrollToIndexCompat,
       smoothScrollTo: smoothScrollToCompat,
+      adjustHeights: adjustVirtualListHeightsCompat,
       refreshLayout: refreshVirtualListLayoutCompat,
       updateVisibleCount: getVirtualListVisibleCountCompat,
       isRowRendered: isRowRenderedCompat,
@@ -4496,6 +4632,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       getMaxRenderCount: getVirtualListVisibleCountCompat,
     }),
     [
+      adjustVirtualListHeightsCompat,
       getClientSizeCompat,
       getScrollingElement,
       getScrollHeightCompat,
@@ -4586,19 +4723,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         const columnId = getColumnIdCompat(column);
         return columnId ? columnVisibilityMap[columnId] !== false : false;
       },
-      setColumnVisible: (column, visible) => {
-        const columnId = getColumnIdCompat(column);
-        if (!columnId) return;
-        if (!table.getColumn(columnId)) return;
-
-        // `hideable` constrains UI affordances, not the Inovua imperative API.
-        // Writing the sparse controlled override also avoids TanStack's
-        // `getCanHide()` gate for hideable:false columns.
-        setColumnVisibilityState((current) => {
-          if (current[columnId] === visible) return current;
-          return { ...current, [columnId]: visible };
-        });
-      },
+      setColumnVisible: setColumnVisibleCompat,
       gridId: gridIdRef.current,
       size: {
         width: viewportWidth,
@@ -4861,18 +4986,6 @@ function ReactDataGrid(props: TypeDataGridProps) {
     }
     Object.assign(stableApiTarget, baseApi);
     apiRef.current = stableApi;
-
-    const handle = handleRef.current;
-    if (!handleNotifiedRef.current && handle) {
-      handleNotifiedRef.current = true;
-      handle(apiRef);
-    }
-
-    const onReady = onReadyRef.current;
-    if (!onReadyNotifiedRef.current && onReady) {
-      onReadyNotifiedRef.current = true;
-      onReady(apiRef);
-    }
   }, [
     allComputedColumns,
     canNext,
@@ -4935,6 +5048,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     showZebraRows,
     setColumnFilterValueCompat,
     setColumnOrderCompat,
+    setColumnVisibleCompat,
     setColumnSortInfoCompat,
     setFilterValueAndResetPage,
     setLimitAndResetPage,
@@ -4971,6 +5085,28 @@ function ReactDataGrid(props: TypeDataGridProps) {
     virtualItems.length,
     virtualized,
   ]);
+
+  // Preserve Inovua's mount lifecycle: the API is hydrated by the preceding
+  // passive effect, then onDidMount observes that live ref before the other
+  // imperative lifecycle callbacks. React StrictMode intentionally replays
+  // this mount effect in development, just as it does upstream.
+  React.useEffect(() => {
+    onDidMountRef.current?.(apiRef);
+  }, []);
+
+  React.useEffect(() => {
+    const handle = handleRef.current;
+    if (!handleNotifiedRef.current && handle) {
+      handleNotifiedRef.current = true;
+      handle(apiRef);
+    }
+
+    const onReady = onReadyRef.current;
+    if (!onReadyNotifiedRef.current && onReady) {
+      onReadyNotifiedRef.current = true;
+      onReady(apiRef);
+    }
+  }, [props.handle, props.onReady]);
 
   /** ---------------- render ---------------- */
 
@@ -5232,6 +5368,12 @@ ReactDataGridWithDefaultProps.defaultProps = {
 Object.defineProperty(
   ReactDataGridWithDefaultProps,
   Symbol.for("@geovi/the-datagrid/search-target"),
+  { value: true }
+);
+
+Object.defineProperty(
+  ReactDataGridWithDefaultProps,
+  Symbol.for("@geovi/the-datagrid/column-visibility-target"),
   { value: true }
 );
 

--- a/src/grid/components/MobileGridList.tsx
+++ b/src/grid/components/MobileGridList.tsx
@@ -47,6 +47,7 @@ type MobileGridListProps = {
   sortInfo: TypeSortInfo;
   defaultSortDirection: 1 | -1;
   searchEnabled?: boolean;
+  columnPickerEnabled?: boolean;
   authoritativeResultCount?: number;
   onSortInfoChange: (sortInfo: TypeSortInfo) => void;
   onFilteredRowsCountChange?: (count: number) => void;
@@ -78,6 +79,7 @@ export function MobileGridList({
   sortInfo,
   defaultSortDirection,
   searchEnabled = true,
+  columnPickerEnabled = true,
   authoritativeResultCount,
   onSortInfoChange,
   onFilteredRowsCountChange,
@@ -381,7 +383,7 @@ export function MobileGridList({
               <ArrowUpDown />
             </Button>
           ) : null}
-          {displayColumns.length ? (
+          {columnPickerEnabled && displayColumns.length ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,18 @@ export { default, ReactDataGrid, plugins } from "./ReactDataGrid";
 
 export { DateFilter, NumberFilter, SelectFilter } from "./filters/editors";
 export { default as CheckBox } from "./packages/CheckBox";
+export { default as TextInput } from "./packages/TextInput";
+export type {
+  TextInputChangeEvent,
+  TextInputChangeHandler,
+  TextInputClearButtonConfig,
+  TextInputClearIconProps,
+  TextInputInputProps,
+  TextInputProps,
+  TextInputValue,
+  TextInputWrapperProps,
+  TypeTextInputProps,
+} from "./packages/TextInput";
 
 // optionally useful for consumers
 export { DEFAULT_FILTER_TYPES, filterTypes } from "./filters/utils";

--- a/src/optional-target.ts
+++ b/src/optional-target.ts
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import type { TypeDataGridProps } from "./types";
+
+export const RDG_SEARCH_TARGET_COMPONENT_MARKER = Symbol.for(
+  "@geovi/the-datagrid/search-target-component"
+);
+
+export const RDG_COLUMN_VISIBILITY_TARGET_COMPONENT_MARKER = Symbol.for(
+  "@geovi/the-datagrid/column-visibility-target-component"
+);
+
+function hasMarker(type: unknown, marker: symbol): boolean {
+  if ((typeof type !== "function" && typeof type !== "object") || !type) {
+    return false;
+  }
+
+  return (type as Record<PropertyKey, unknown>)[marker] === true;
+}
+
+export function isOptionalTargetType(type: unknown): boolean {
+  return (
+    hasMarker(type, RDG_SEARCH_TARGET_COMPONENT_MARKER) ||
+    hasMarker(type, RDG_COLUMN_VISIBILITY_TARGET_COMPONENT_MARKER)
+  );
+}
+
+export function findTargetGridElement(
+  element: React.ReactElement<unknown>,
+  isGridType: (type: unknown) => boolean
+): React.ReactElement<TypeDataGridProps> | null {
+  let current: React.ReactElement<unknown> = element;
+  const visited = new Set<React.ReactElement<unknown>>();
+
+  while (!visited.has(current)) {
+    visited.add(current);
+
+    if (isGridType(current.type)) {
+      return current as React.ReactElement<TypeDataGridProps>;
+    }
+    if (!isOptionalTargetType(current.type)) return null;
+
+    const nested = (current.props as { children?: React.ReactNode }).children;
+    if (!React.isValidElement(nested)) return null;
+    current = nested;
+  }
+
+  return null;
+}
+
+export function markOptionalTargetType(type: unknown, marker: symbol): void {
+  if ((typeof type !== "function" && typeof type !== "object") || !type) {
+    return;
+  }
+
+  Object.defineProperty(type, marker, { value: true });
+}

--- a/src/packages/TextInput/index.tsx
+++ b/src/packages/TextInput/index.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+/*
+ * TextInput intentionally keeps the value-first callbacks and imperative
+ * class instance used by @inovua/reactdatagrid-community. A native input's
+ * event-first onChange contract is not interchangeable with that API.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as React from "react";
+
+import "./style.css";
+
+const DEFAULT_ROOT_CLASS_NAME = "inovua-react-toolkit-text-input";
+
+function joinClassNames(
+  ...values: Array<string | false | null | undefined>
+): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export type TextInputValue = any;
+
+export type TextInputChangeEvent = any;
+
+export type TextInputChangeHandler = (
+  value: TextInputValue,
+  event?: TextInputChangeEvent
+) => void;
+
+export type TextInputClearIconProps = {
+  fill?: string;
+  height?: number | string;
+  width?: number | string;
+};
+
+export type TextInputClearButtonConfig = {
+  clearButtonClassName?: string;
+  clearButtonColor?: string;
+  clearButtonSize?: number | readonly [number, number] | null;
+  clearButtonStyle?: React.CSSProperties;
+};
+
+export type TextInputInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "onChange"
+> & {
+  onChange?: TextInputChangeHandler;
+  [key: string]: any;
+};
+
+export type TextInputWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
+  [key: string]: any;
+};
+
+export type TextInputProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "defaultValue" | "onChange"
+> & {
+  acceptClearToolFocus?: boolean;
+  autoFocus?: boolean;
+  clearButtonClassName?: string;
+  clearButtonColor?: string;
+  clearButtonSize?: number | readonly [number, number] | null;
+  clearButtonStyle?: React.CSSProperties;
+  defaultValue?: TextInputValue;
+  disabled?: boolean;
+  enableClearButton?: boolean;
+  hidden?: boolean;
+  inputProps?: TextInputInputProps | null;
+  maxLength?: number;
+  minLength?: number;
+  name?: string;
+  onChange?: TextInputChangeHandler;
+  placeholder?: string | null;
+  readOnly?: boolean;
+  renderClearIcon?: (
+    props: TextInputClearIconProps
+  ) => React.ReactNode | undefined;
+  required?: boolean;
+  rootClassName?: string;
+  rtl?: boolean;
+  size?: number;
+  stopChangePropagation?: boolean | null;
+  theme?: string;
+  type?: React.HTMLInputTypeAttribute;
+  value?: TextInputValue;
+  wrapperProps?: TextInputWrapperProps;
+
+  // The original component was declared with untyped props. Keep migration
+  // code source-compatible while documenting the supported surface above.
+  [key: string]: any;
+};
+
+export type TypeTextInputProps = TextInputProps;
+
+type TextInputState = {
+  focused: boolean;
+  value: TextInputValue;
+};
+
+function isControlled(props: TextInputProps): boolean {
+  return props.value !== undefined;
+}
+
+/**
+ * Inovua-compatible text input.
+ *
+ * A class component is intentional: existing consumers keep a component ref
+ * and call `focus()` or `setValue()` directly.
+ */
+export class TextInput extends React.Component<TextInputProps, TextInputState> {
+  static defaultProps: Partial<TextInputProps> = {
+    acceptClearToolFocus: false,
+    clearButtonSize: 10,
+    enableClearButton: true,
+    hidden: false,
+    rootClassName: DEFAULT_ROOT_CLASS_NAME,
+    stopChangePropagation: true,
+    theme: "default-light",
+    type: "text",
+  };
+
+  private field: HTMLInputElement | null = null;
+
+  constructor(props: TextInputProps) {
+    super(props);
+    // The upstream class auto-binds its public methods. Bind the prototype
+    // lookup (rather than replacing it with a class field) so subclasses can
+    // still override these two render hooks.
+    this.renderClearButton = this.renderClearButton.bind(this);
+    this.renderClearButtonWrapper = this.renderClearButtonWrapper.bind(this);
+  }
+
+  state: TextInputState = {
+    focused: false,
+    value: this.props.defaultValue == null ? "" : this.props.defaultValue,
+  };
+
+  private setFieldRef = (field: HTMLInputElement | null): void => {
+    this.field = field;
+  };
+
+  handleChange = (
+    value: TextInputValue,
+    event?: TextInputChangeEvent
+  ): void => {
+    this.setValue(value, event);
+  };
+
+  focus = (): void => {
+    this.field?.focus();
+  };
+
+  setValue = (value: TextInputValue, event?: TextInputChangeEvent): void => {
+    if (!isControlled(this.props)) {
+      this.setState({ value });
+    }
+
+    // Inovua invokes the nested callback first. Some consumers depend on this
+    // ordering to update controlled state before observing the root callback.
+    this.props.inputProps?.onChange?.(value, event);
+    this.props.onChange?.(value, event);
+  };
+
+  private handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    if (this.props.stopChangePropagation) {
+      event.stopPropagation();
+    }
+
+    this.handleChange(event.currentTarget.value, event);
+  };
+
+  private handleClearButtonMouseDown = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ): void => {
+    // Retain input focus so clearing does not create a blur/focus cycle.
+    event.preventDefault();
+  };
+
+  handleClearButtonClick = (event?: any): void => {
+    void event;
+    this.setState({ focused: true });
+    // The upstream clear callback does not forward the button click event.
+    this.setValue("");
+    this.focus();
+  };
+
+  onClick = (event: React.MouseEvent<HTMLDivElement>): void => {
+    if (!this.state.focused) {
+      this.focus();
+    }
+
+    this.props.wrapperProps?.onClick?.(event);
+  };
+
+  onBlur = (event: React.FocusEvent<HTMLDivElement>): void => {
+    this.setState({ focused: false });
+    this.props.onBlur?.(event);
+  };
+
+  onFocus = (event: React.FocusEvent<HTMLDivElement>): void => {
+    this.setState({ focused: true });
+    this.props.onFocus?.(event);
+  };
+
+  renderClearIcon = (iconProps: TextInputClearIconProps): React.ReactNode => {
+    const customIcon = this.props.renderClearIcon?.({ ...iconProps });
+    if (customIcon !== undefined) return customIcon;
+
+    return (
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        style={{ ...iconProps, color: iconProps.fill }}
+        viewBox="0 0 10 10"
+      >
+        <path
+          d="M1 1l8 8m0-8L1 9"
+          fill="none"
+          fillRule="evenodd"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeWidth="1.33"
+        />
+      </svg>
+    );
+  };
+
+  renderClearButton(config: TextInputClearButtonConfig): React.ReactNode {
+    const {
+      clearButtonClassName,
+      clearButtonColor,
+      clearButtonSize,
+      clearButtonStyle,
+    } = config;
+    const iconSize = clearButtonSize
+      ? Array.isArray(clearButtonSize)
+        ? { width: clearButtonSize[0], height: clearButtonSize[1] }
+        : { width: clearButtonSize, height: clearButtonSize }
+      : {};
+    const iconProps: TextInputClearIconProps = {
+      ...iconSize,
+      ...(clearButtonColor ? { fill: clearButtonColor } : {}),
+    };
+
+    return (
+      <button
+        aria-label="Clear input"
+        className={joinClassNames(
+          clearButtonClassName,
+          "tdg-text-input__clear-button"
+        )}
+        onClick={this.handleClearButtonClick}
+        onMouseDown={this.handleClearButtonMouseDown}
+        style={clearButtonStyle}
+        tabIndex={this.props.acceptClearToolFocus ? 0 : -1}
+        type="button"
+      >
+        {this.renderClearIcon(iconProps)}
+      </button>
+    );
+  }
+
+  renderClearButtonWrapper(fieldProps: any): React.ReactNode {
+    const {
+      clearButtonClassName,
+      clearButtonColor,
+      clearButtonSize = 10,
+      clearButtonStyle,
+      enableClearButton = true,
+      rootClassName = DEFAULT_ROOT_CLASS_NAME,
+    } = this.props;
+    const value = isControlled(this.props)
+      ? this.props.value
+      : this.state.value;
+    // Preserve the toolkit's observable loose-empty check. In particular,
+    // controlled `0` and `false` values do not expose a clear tool.
+    const emptyValue = value == null || value == "";
+    const showClearButton =
+      enableClearButton &&
+      !emptyValue &&
+      !fieldProps.disabled &&
+      !fieldProps.readOnly;
+
+    return (
+      <div
+        aria-hidden={showClearButton ? undefined : "true"}
+        className={joinClassNames(
+          `${rootClassName}__clear-button-wrapper`,
+          "tdg-text-input__clear-button-wrapper",
+          !showClearButton
+            ? `${rootClassName}__clear-button-wrapper--hidden`
+            : undefined,
+          !showClearButton
+            ? "tdg-text-input__clear-button-wrapper--hidden"
+            : undefined
+        )}
+      >
+        {this.renderClearButton({
+          clearButtonClassName: joinClassNames(
+            `${rootClassName}__clear-button`,
+            clearButtonClassName
+          ),
+          clearButtonColor,
+          clearButtonSize,
+          clearButtonStyle,
+        })}
+      </div>
+    );
+  }
+
+  render(): React.ReactNode {
+    const {
+      acceptClearToolFocus = false,
+      autoFocus,
+      className,
+      clearButtonClassName,
+      clearButtonColor,
+      clearButtonSize = 10,
+      clearButtonStyle,
+      defaultValue: _defaultValue,
+      disabled,
+      enableClearButton = true,
+      hidden,
+      inputProps: passedInputProps,
+      maxLength,
+      minLength,
+      name,
+      onBlur: _onBlur,
+      onChange: _onChange,
+      onFocus: _onFocus,
+      placeholder,
+      readOnly,
+      renderClearIcon: _renderClearIcon,
+      required,
+      rootClassName = DEFAULT_ROOT_CLASS_NAME,
+      rtl,
+      size,
+      stopChangePropagation: _stopChangePropagation,
+      style,
+      theme = "default-light",
+      type = "text",
+      value: controlledValue,
+      wrapperProps,
+      ...rootDomProps
+    } = this.props;
+    void acceptClearToolFocus;
+    void clearButtonClassName;
+    void clearButtonColor;
+    void clearButtonSize;
+    void clearButtonStyle;
+    void _defaultValue;
+    void _onBlur;
+    void _onChange;
+    void _onFocus;
+    void _renderClearIcon;
+    void _stopChangePropagation;
+
+    // The upstream component treats an explicitly null `inputProps` exactly
+    // like an omitted object. This matters for older spread-based call sites.
+    const inputProps = passedInputProps || {};
+    const {
+      className: inputClassName,
+      onChange: _inputOnChange,
+      stopChangePropagation: _inputStopChangePropagation,
+      ...inputDomProps
+    } = inputProps;
+    void _inputOnChange;
+    void _inputStopChangePropagation;
+    const value = isControlled(this.props) ? controlledValue : this.state.value;
+    const fieldDisabled = disabled || inputDomProps.disabled || false;
+    const fieldReadOnly = readOnly || inputDomProps.readOnly || false;
+
+    return (
+      <div
+        {...rootDomProps}
+        {...wrapperProps}
+        className={joinClassNames(
+          rootClassName,
+          className,
+          rtl ? `${rootClassName}--rtl` : `${rootClassName}--ltr`,
+          theme ? `${rootClassName}--theme-${theme}` : undefined,
+          enableClearButton
+            ? `${rootClassName}--enable-clear-button`
+            : undefined,
+          this.state.focused ? `${rootClassName}--focused` : undefined,
+          fieldDisabled ? `${rootClassName}--disabled` : undefined,
+          "tdg-text-input",
+          rtl ? "tdg-text-input--rtl" : "tdg-text-input--ltr",
+          this.state.focused ? "tdg-text-input--focused" : undefined,
+          fieldDisabled ? "tdg-text-input--disabled" : undefined
+        )}
+        onBlur={this.onBlur}
+        onClick={this.onClick}
+        onFocus={this.onFocus}
+        style={style}
+      >
+        <input
+          {...inputDomProps}
+          ref={this.setFieldRef}
+          autoFocus={autoFocus || inputDomProps.autoFocus}
+          className={joinClassNames(
+            `${rootClassName}__input`,
+            "tdg-text-input__input",
+            inputClassName
+          )}
+          disabled={fieldDisabled}
+          hidden={hidden || inputDomProps.hidden}
+          maxLength={maxLength ?? inputDomProps.maxLength}
+          minLength={minLength ?? inputDomProps.minLength}
+          name={name || inputDomProps.name}
+          onChange={this.handleInputChange}
+          placeholder={placeholder || inputDomProps.placeholder}
+          readOnly={fieldReadOnly}
+          required={required || inputDomProps.required}
+          size={size ?? inputDomProps.size ?? 1}
+          type={type}
+          value={value == null ? "" : value}
+        />
+
+        {this.renderClearButtonWrapper({
+          disabled: fieldDisabled,
+          readOnly: fieldReadOnly,
+        })}
+      </div>
+    );
+  }
+}
+
+export default TextInput;

--- a/src/packages/TextInput/style.css
+++ b/src/packages/TextInput/style.css
@@ -1,0 +1,150 @@
+.tdg-text-input {
+  box-sizing: border-box;
+  direction: ltr;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  height: 2.25rem;
+  min-height: 2.25rem;
+  overflow: hidden;
+  padding-inline: 0.75rem;
+  border: 1px solid
+    var(--tdg-input-border-color, var(--input, oklch(0.922 0 0)));
+  border-radius: var(--tdg-radius-md, calc(var(--radius, 0.625rem) - 2px));
+  background: var(--tdg-input-bg, var(--background, oklch(1 0 0)));
+  color: var(--tdg-input-color, var(--foreground, oklch(0.145 0 0)));
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: start;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    opacity 150ms ease;
+}
+
+.tdg-text-input *,
+.tdg-text-input *::before,
+.tdg-text-input *::after {
+  box-sizing: border-box;
+}
+
+.tdg-text-input--rtl {
+  direction: rtl;
+}
+
+.tdg-text-input:hover:not(.tdg-text-input--disabled) {
+  border-color: var(
+    --tdg-input-border-color-hover,
+    var(--ring, oklch(0.708 0 0))
+  );
+}
+
+.tdg-text-input--focused {
+  border-color: var(
+    --tdg-input-border-color-focus,
+    var(--ring, oklch(0.708 0 0))
+  );
+  box-shadow:
+    0 0 0 1px var(--tdg-color-ring, var(--ring, oklch(0.708 0 0))),
+    0 1px 2px 0 rgb(0 0 0 / 0.05);
+}
+
+.tdg-text-input--disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.tdg-text-input__input {
+  appearance: none;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  box-shadow: none;
+}
+
+.tdg-text-input__input::placeholder {
+  color: var(--muted-foreground, oklch(0.556 0 0));
+}
+
+.tdg-text-input__input::-ms-clear {
+  display: none;
+}
+
+.tdg-text-input__clear-button-wrapper {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  margin-inline-start: 0.375rem;
+  opacity: 1;
+  visibility: visible;
+  transform: translate3d(0, 0, 0);
+  transition:
+    opacity 150ms ease,
+    visibility 150ms ease;
+}
+
+.tdg-text-input__clear-button-wrapper--hidden {
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.tdg-text-input__clear-button {
+  appearance: none;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: calc(var(--radius, 0.625rem) - 4px);
+  outline: 0;
+  background: transparent;
+  color: var(--muted-foreground, oklch(0.556 0 0));
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.tdg-text-input__clear-button:hover {
+  background: var(--accent, oklch(0.97 0 0));
+  color: var(--accent-foreground, oklch(0.205 0 0));
+}
+
+.tdg-text-input__clear-button:focus-visible {
+  box-shadow: 0 0 0 2px var(--ring, oklch(0.708 0 0));
+}
+
+.tdg-text-input__clear-button svg {
+  display: block;
+  flex: none;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tdg-text-input,
+  .tdg-text-input__clear-button-wrapper,
+  .tdg-text-input__clear-button {
+    transition: none;
+  }
+}

--- a/src/providers/RDGProvider.tsx
+++ b/src/providers/RDGProvider.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+
+import { RDGColumnVisibilityProvider } from "../column-visibility/index";
+import { RDGSearchProvider } from "../search/index";
+import { isMarkedGridType } from "../search/marker";
+import type { TypeDataGridProps } from "../types";
+import { RDGTarget } from "./RDGTarget";
+
+export type RDGProviderProps = {
+  children: React.ReactNode;
+  defaultSearchValue?: string;
+};
+
+export function RDGProvider(props: RDGProviderProps) {
+  const { children, defaultSearchValue = "" } = props;
+  const targets = React.useMemo(
+    () =>
+      React.Children.map(children, (child) =>
+        React.isValidElement(child) && isMarkedGridType(child.type) ? (
+          <RDGTarget>
+            {child as React.ReactElement<TypeDataGridProps>}
+          </RDGTarget>
+        ) : (
+          child
+        )
+      ),
+    [children]
+  );
+
+  return (
+    <RDGSearchProvider defaultValue={defaultSearchValue}>
+      <RDGColumnVisibilityProvider>{targets}</RDGColumnVisibilityProvider>
+    </RDGSearchProvider>
+  );
+}

--- a/src/providers/RDGTarget.tsx
+++ b/src/providers/RDGTarget.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import * as React from "react";
+
+import { RDGColumnVisibilityTarget } from "../column-visibility/index";
+import { RDGSearchTarget } from "../search/index";
+import type { TypeDataGridProps } from "../types";
+
+export type RDGTargetProps = {
+  children: React.ReactElement<TypeDataGridProps>;
+};
+
+export function RDGTarget(props: RDGTargetProps) {
+  const columnVisibilityTarget = (
+    <RDGColumnVisibilityTarget>{props.children}</RDGColumnVisibilityTarget>
+  ) as unknown as React.ReactElement<TypeDataGridProps>;
+
+  return <RDGSearchTarget>{columnVisibilityTarget}</RDGSearchTarget>;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,28 @@
+"use client";
+
+export { RDGProvider } from "./RDGProvider";
+export { RDGTarget } from "./RDGTarget";
+
+export {
+  RDGSearchBar,
+  RDGSearchProvider,
+  RDGSearchTarget,
+} from "../search/index";
+export {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+} from "../column-visibility/index";
+
+export type { RDGProviderProps } from "./RDGProvider";
+export type { RDGTargetProps } from "./RDGTarget";
+export type {
+  RDGSearchBarProps,
+  RDGSearchProviderProps,
+  RDGSearchTargetProps,
+} from "../search/index";
+export type {
+  RDGColumnVisibilityProviderProps,
+  RDGColumnVisibilityTargetProps,
+  RDGColumnVisibilityToolbarProps,
+} from "../column-visibility/index";

--- a/src/search/RDGSearchTarget.tsx
+++ b/src/search/RDGSearchTarget.tsx
@@ -2,6 +2,11 @@
 
 import * as React from "react";
 import type { TypeColumn, TypeDataGridProps } from "../types";
+import {
+  findTargetGridElement,
+  markOptionalTargetType,
+  RDG_SEARCH_TARGET_COMPONENT_MARKER,
+} from "../optional-target";
 import { isMarkedGridType } from "./marker";
 import { filterRDGSearchIndex, getCachedRDGSearchIndex } from "./utils";
 import { useRDGSearchSnapshot, useRDGSearchStore } from "./store";
@@ -15,26 +20,13 @@ export type RDGSearchTargetProps = {
   children: React.ReactElement<TypeDataGridProps>;
 };
 
-function isMarkedGridElement(
-  child: React.ReactElement<unknown>
-): child is React.ReactElement<TypeDataGridProps> {
-  return isMarkedGridType(child.type);
-}
-
-function looksLikeGridElement(
-  child: React.ReactElement<unknown>
-): child is React.ReactElement<TypeDataGridProps> {
-  const props = child.props as Partial<TypeDataGridProps> | null;
-  return Boolean(
-    props &&
-    typeof props.idProperty === "string" &&
-    Array.isArray(props.columns) &&
-    props.dataSource != null
-  );
-}
-
 export function RDGSearchTarget(props: RDGSearchTargetProps) {
   const { children } = props;
+  const forwardedColumnVisibilityController = (
+    props as RDGSearchTargetProps & {
+      __rdgColumnVisibilityController?: unknown;
+    }
+  ).__rdgColumnVisibilityController;
   const store = useRDGSearchStore();
   const committedValue = useRDGSearchSnapshot();
   const query = committedValue.trim();
@@ -43,12 +35,13 @@ export function RDGSearchTarget(props: RDGSearchTargetProps) {
     throw new Error("RDGSearchTarget expects exactly one ReactDataGrid child.");
   }
 
-  if (!isMarkedGridElement(children) && !looksLikeGridElement(children)) {
+  const gridElement = findTargetGridElement(children, isMarkedGridType);
+  if (!gridElement) {
     throw new Error("RDGSearchTarget expects a ReactDataGrid child.");
   }
 
-  const targetColumns = children.props.columns;
-  const targetTheme = children.props.theme;
+  const targetColumns = gridElement.props.columns;
+  const targetTheme = gridElement.props.theme;
   React.useEffect(
     () => store.registerTarget(targetColumns, targetTheme),
     [store, targetColumns, targetTheme]
@@ -67,8 +60,18 @@ export function RDGSearchTarget(props: RDGSearchTargetProps) {
     [query]
   );
 
+  const injectedProps: Record<string, unknown> = {
+    __rdgSearchController: controller,
+  };
+  if (forwardedColumnVisibilityController !== undefined) {
+    injectedProps.__rdgColumnVisibilityController =
+      forwardedColumnVisibilityController;
+  }
+
   return React.cloneElement(
     children as React.ReactElement<Record<string, unknown>>,
-    { __rdgSearchController: controller }
+    injectedProps
   );
 }
+
+markOptionalTargetType(RDGSearchTarget, RDG_SEARCH_TARGET_COMPONENT_MARKER);

--- a/src/types.ts
+++ b/src/types.ts
@@ -563,6 +563,13 @@ export type TypeComputedVirtualList = {
   setRowIndex: (index: number) => void;
   scrollToIndex: TypeScrollToIndex;
   smoothScrollTo: TypeSmoothScrollTo;
+  /**
+   * Remeasure the currently rendered variable-height rows.
+   *
+   * This mirrors Inovua's virtual-list compatibility method: it is a no-op
+   * for fixed numeric row heights and returns synchronously.
+   */
+  adjustHeights: () => void;
   refreshLayout: () => void;
   updateVisibleCount: () => number;
   isRowRendered: (rowIndex: number) => boolean;
@@ -975,6 +982,13 @@ export type TypeDataGridProps = {
   checkboxOnlyRowSelect?: boolean;
   checkboxSelectEnableShiftKey?: boolean;
 
+  /**
+   * Invoked from the grid's mount effect after the imperative API has been
+   * hydrated and before `handle` / `onReady` are notified.
+   */
+  onDidMount?: (
+    computedPropsRef: React.MutableRefObject<TypeComputedProps | null>
+  ) => void;
   onReady?: (
     computedPropsRef: React.MutableRefObject<TypeComputedProps | null>
   ) => void;

--- a/tests/playwright/combined-provider.spec.ts
+++ b/tests/playwright/combined-provider.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const COMPAT_ROUTE = "/compat/column-visibility";
+
+function combinedScope(page: Page, target: "direct" | "nested") {
+  return page.getByTestId(`combined-provider-${target}-target`);
+}
+
+function gridIn(scope: Locator) {
+  return scope.locator(".InovuaReactDataGrid.tdg-root");
+}
+
+function visibilityToolbar(scope: Locator) {
+  return scope.locator('[data-slot="rdg-column-visibility"]');
+}
+
+function columnToggle(scope: Locator, columnId: string) {
+  return visibilityToolbar(scope).locator(
+    `[data-slot="rdg-column-toggle"][data-column-id="${columnId}"]`
+  );
+}
+
+function columnHeader(grid: Locator, columnId: string) {
+  return grid.locator(
+    `[data-slot="grid-header-cell"][data-column-id="${columnId}"]`
+  );
+}
+
+function mountedColumnCells(grid: Locator, columnId: string) {
+  return grid.locator(`[data-slot="grid-row"] [data-column-id="${columnId}"]`);
+}
+
+test.describe("combined provider", () => {
+  test("direct targeting searches and changes the same grid column model", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(COMPAT_ROUTE);
+
+    const scope = combinedScope(page, "direct");
+    const grid = gridIn(scope);
+    const rows = grid.locator('[data-slot="grid-row"]');
+    const search = scope.getByRole("searchbox", {
+      name: "Search direct combined grid",
+    });
+    const cityToggle = columnToggle(scope, "city");
+
+    await expect(grid).toHaveCount(1);
+    await expect(visibilityToolbar(scope)).toHaveCount(1);
+    await expect(search).toHaveCount(1);
+    await expect(rows).toHaveCount(3);
+    await expect(columnHeader(grid, "city")).toBeVisible();
+    await expect(cityToggle).toHaveAttribute("aria-pressed", "true");
+
+    await search.fill("Grace Hopper");
+
+    await expect(rows).toHaveCount(1);
+    await expect(grid.getByText("Grace Hopper", { exact: true })).toBeVisible();
+    await expect(grid.getByText("Ada Lovelace", { exact: true })).toHaveCount(
+      0
+    );
+
+    await cityToggle.click();
+
+    await expect(cityToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(columnHeader(grid, "city")).toHaveCount(0);
+    await expect(mountedColumnCells(grid, "city")).toHaveCount(0);
+    await expect(rows).toHaveCount(1);
+
+    await search.fill("Paris");
+
+    await expect(rows).toHaveCount(1);
+    await expect(
+      grid.getByText("Katherine Johnson", { exact: true })
+    ).toBeVisible();
+    await expect(grid.getByText("Paris", { exact: true })).toHaveCount(0);
+
+    await cityToggle.click();
+
+    await expect(cityToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(columnHeader(grid, "city")).toBeVisible();
+    await expect(grid.getByText("Paris", { exact: true })).toBeVisible();
+  });
+
+  test("an explicit target works with controls imported from legacy entries", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(COMPAT_ROUTE);
+
+    const scope = combinedScope(page, "nested");
+    const grid = gridIn(scope);
+    const rows = grid.locator('[data-slot="grid-row"]');
+    const search = scope.getByRole("searchbox", {
+      name: "Search nested combined grid",
+    });
+    const roleToggle = columnToggle(scope, "role");
+
+    await expect(grid).toHaveCount(1);
+    await expect(visibilityToolbar(scope)).toHaveCount(1);
+    await expect(search).toHaveCount(1);
+    await expect(search).toHaveValue("London");
+    await expect(rows).toHaveCount(1);
+    await expect(grid.getByText("Ada Lovelace", { exact: true })).toBeVisible();
+    await expect(columnHeader(grid, "role")).toBeVisible();
+
+    await roleToggle.click();
+
+    await expect(roleToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(columnHeader(grid, "role")).toHaveCount(0);
+    await expect(mountedColumnCells(grid, "role")).toHaveCount(0);
+    await expect(rows).toHaveCount(1);
+
+    await search.fill("");
+
+    await expect(rows).toHaveCount(3);
+    await expect(columnHeader(grid, "name")).toBeVisible();
+    await expect(columnHeader(grid, "city")).toBeVisible();
+  });
+
+  test("mobile uses the external search and visibility controls as the sole pickers", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(COMPAT_ROUTE);
+
+    const scope = combinedScope(page, "direct");
+    const grid = gridIn(scope);
+    const toolbar = visibilityToolbar(scope);
+    const search = scope.getByRole("searchbox", {
+      name: "Search direct combined grid",
+    });
+    const cityToggle = columnToggle(scope, "city");
+    const firstCard = grid.locator('article[data-row-id="combined-1"]');
+
+    await expect(grid).toHaveCount(1);
+    await expect(grid).toHaveAttribute("data-layout", "mobile-list");
+    await expect(search).toHaveCount(1);
+    await expect(scope.getByRole("searchbox")).toHaveCount(1);
+    await expect(toolbar).toHaveCount(1);
+    await expect(
+      toolbar.locator('[data-slot="rdg-column-toggle-list"]')
+    ).toHaveCount(1);
+    await expect(
+      grid.getByRole("button", { name: "Display columns" })
+    ).toHaveCount(0);
+    await expect(firstCard).toBeVisible();
+    await expect(firstCard.getByText("City", { exact: true })).toBeVisible();
+    await expect(firstCard.getByText("London", { exact: true })).toBeVisible();
+
+    await cityToggle.click();
+
+    await expect(cityToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(firstCard.getByText("City", { exact: true })).toHaveCount(0);
+    await expect(firstCard.getByText("London", { exact: true })).toHaveCount(0);
+
+    await search.fill("Paris");
+
+    const parisCard = grid.locator('article[data-row-id="combined-3"]');
+    await expect(grid.locator("article[data-row-id]")).toHaveCount(1);
+    await expect(parisCard).toBeVisible();
+    await expect(
+      parisCard.getByText("Katherine Johnson", { exact: true })
+    ).toBeVisible();
+    await expect(parisCard.getByText("City", { exact: true })).toHaveCount(0);
+    await expect(parisCard.getByText("Paris", { exact: true })).toHaveCount(0);
+
+    await cityToggle.click();
+
+    await expect(cityToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(parisCard.getByText("City", { exact: true })).toBeVisible();
+    await expect(parisCard.getByText("Paris", { exact: true })).toBeVisible();
+  });
+});

--- a/tests/playwright/computed-props-compat.spec.ts
+++ b/tests/playwright/computed-props-compat.spec.ts
@@ -32,7 +32,7 @@ test("computed props expose the broader Inovua-compatible runtime surface", asyn
   await expect(page.getByTestId("compat-size")).not.toContainText("0x0");
   await expect(page.getByTestId("compat-scrollWorked")).toContainText("true");
   await expect(page.getByTestId("compat-virtualListKeys")).toContainText(
-    "getVisibleRange,getVisibleCount,getScrollSize,getClientSize,getScrollHeight,getTotalRowHeight,getRows,scrollToIndex,smoothScrollTo"
+    "getVisibleRange,getVisibleCount,getScrollSize,getClientSize,getScrollHeight,getTotalRowHeight,getRows,scrollToIndex,smoothScrollTo,adjustHeights"
   );
   await expect(page.getByTestId("compat-virtualListRange")).not.toContainText(
     "missing"

--- a/tests/playwright/example.spec.ts
+++ b/tests/playwright/example.spec.ts
@@ -774,34 +774,6 @@ test("clips long cell content inside a resized column", async ({ page }) => {
   );
 });
 
-test("shows and hides columns when the grid receives a filtered columns array", async ({
-  page,
-}) => {
-  await page.goto("/users");
-
-  const usersExample = page.getByTestId("example-preview-panel");
-  await expect(usersExample).toBeVisible();
-
-  const usersGrid = usersExample
-    .locator(".InovuaReactDataGrid.tdg-root")
-    .first();
-  const failedLoginsHeader = usersGrid.locator(".tdg-header-cell", {
-    hasText: "Failed logins",
-  });
-
-  await expect(failedLoginsHeader).toHaveCount(0);
-
-  await usersExample
-    .getByRole("button", { name: "Failed logins", exact: true })
-    .click();
-  await expect(failedLoginsHeader).toHaveCount(1);
-
-  await usersExample
-    .getByRole("button", { name: "Failed logins", exact: true })
-    .click();
-  await expect(failedLoginsHeader).toHaveCount(0);
-});
-
 test("keeps the actions header vertically centered", async ({ page }) => {
   await page.goto("/users");
 
@@ -834,7 +806,10 @@ test("keeps body columns aligned after vertical scrolling in a wide virtualized 
     "Password changed",
     "Language",
   ]) {
-    await usersExample.getByRole("button", { name: columnName }).click();
+    await usersExample
+      .locator('[data-slot="rdg-column-toggle-list"]')
+      .getByRole("button", { name: columnName, exact: true })
+      .click();
   }
 
   const usersGrid = usersExample
@@ -903,7 +878,10 @@ test("keeps header and body cells horizontally aligned while scrolling", async (
     "Password changed",
     "Language",
   ]) {
-    await usersExample.getByRole("button", { name: columnName }).click();
+    await usersExample
+      .locator('[data-slot="rdg-column-toggle-list"]')
+      .getByRole("button", { name: columnName, exact: true })
+      .click();
   }
 
   const usersGrid = usersExample

--- a/tests/playwright/issue-48-compat.spec.ts
+++ b/tests/playwright/issue-48-compat.spec.ts
@@ -1,0 +1,593 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+type Issue48Scenario =
+  | "text-input"
+  | "did-mount"
+  | "did-mount-zero-width"
+  | "did-mount-async"
+  | "adjust-natural"
+  | "adjust-fixed"
+  | "adjust-function"
+  | "adjust-nonvirtual"
+  | "adjust-safe";
+
+type MountEvent = {
+  type: "didMount" | "handle" | "ready";
+  refId: number;
+  callbackVersion: number;
+  apiLive: boolean;
+  domConnected: boolean;
+  rowCount: number | null;
+};
+
+type HeightSnapshot = {
+  height: number | null;
+  start: number | null;
+  end: number | null;
+  nextStart: number | null;
+  total: number | null;
+};
+
+type AdjustReport = {
+  methodExists: boolean;
+  returnedUndefined: boolean;
+  error: string | null;
+  mode: string;
+  before: HeightSnapshot;
+  stale: HeightSnapshot;
+  after: HeightSnapshot;
+  domHeight: number | null;
+  totalRows: number;
+  mountedIndexes: number[];
+  measuredIndexes: number[];
+};
+
+async function openScenario(page: Page, scenario: Issue48Scenario) {
+  await page.goto(`/compat/issue-48?scenario=${scenario}`);
+
+  const scope = page.getByTestId("issue-48-scenario");
+  await expect(scope).toHaveAttribute("data-scenario", scenario);
+  await expect(scope.getByRole("heading", { name: scenario })).toBeVisible();
+  return scope;
+}
+
+async function readJson<T>(locator: Locator): Promise<T> {
+  return JSON.parse((await locator.textContent())?.trim() || "null") as T;
+}
+
+async function readMountEvents(locator: Locator): Promise<MountEvent[]> {
+  return readJson<MountEvent[]>(locator);
+}
+
+test.describe("issue #48 TextInput compatibility", () => {
+  test("supports uncontrolled value-first callbacks, callback ordering, propagation and clear", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "text-input");
+    const availability = scope.getByTestId("text-input-availability");
+    await expect(availability).toHaveAttribute("data-available", "true");
+
+    const input = scope.getByTestId("uncontrolled-input");
+    await expect(input).toHaveValue("seed");
+    await input.fill("changed");
+
+    await expect
+      .poll(async () =>
+        readJson<string[]>(scope.getByTestId("text-input-events"))
+      )
+      .toEqual(["input:changed", "root:changed"]);
+    await expect(scope.getByTestId("text-input-outer-changes")).toHaveText("0");
+
+    await scope.getByTestId("propagating-input").fill("bubbles");
+    await expect(scope.getByTestId("text-input-outer-changes")).toHaveText("1");
+    await expect
+      .poll(async () =>
+        readJson<string[]>(scope.getByTestId("text-input-events"))
+      )
+      .toContain("propagating:bubbles");
+
+    const clear = scope.locator("button.issue48-uncontrolled-clear");
+    await expect(clear).toBeVisible();
+    await clear.click();
+    await expect(input).toHaveValue("");
+    await expect(input).toBeFocused();
+    await expect(clear).toBeHidden();
+
+    const events = await readJson<string[]>(
+      scope.getByTestId("text-input-events")
+    );
+    expect(events.slice(-2)).toEqual(["input:", "root:"]);
+    await expect(scope.getByTestId("text-input-outer-changes")).toHaveText("1");
+  });
+
+  test("keeps controlled ownership and exposes focus/setValue through its ref", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "text-input");
+    await expect(scope.getByTestId("text-input-availability")).toHaveAttribute(
+      "data-available",
+      "true"
+    );
+
+    const controlled = scope.getByTestId("controlled-input");
+    await controlled.fill("consumer proposal");
+    await expect(scope.getByTestId("controlled-candidate")).toHaveText(
+      "consumer proposal"
+    );
+    await expect(controlled).toHaveValue("locked");
+    await scope.getByTestId("apply-controlled").click();
+    await expect(controlled).toHaveValue("consumer proposal");
+
+    const uncontrolled = scope.getByTestId("uncontrolled-input");
+    await scope.getByTestId("imperative-focus").click();
+    await expect(uncontrolled).toBeFocused();
+    await scope.getByTestId("imperative-set-value").click();
+    await expect(uncontrolled).toHaveValue("imperative");
+
+    const events = await readJson<string[]>(
+      scope.getByTestId("text-input-events")
+    );
+    expect(events.slice(-2)).toEqual(["input:imperative", "root:imperative"]);
+
+    await scope.getByTestId("call-detached-clear-renderer").click();
+    await expect(scope.getByTestId("detached-render-status")).toHaveText(
+      "rendered"
+    );
+  });
+
+  test("keeps the legacy state classes and suppresses clear for disabled/read-only fields", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "text-input");
+    await expect(scope.getByTestId("text-input-availability")).toHaveAttribute(
+      "data-available",
+      "true"
+    );
+
+    const root = scope.getByTestId("uncontrolled-root");
+    await expect(root).toHaveClass(/inovua-react-toolkit-text-input/);
+    await expect(root).toHaveClass(
+      /inovua-react-toolkit-text-input--theme-default-light/
+    );
+    await expect(root).toHaveClass(/inovua-react-toolkit-text-input--ltr/);
+    await expect(root).toHaveClass(
+      /inovua-react-toolkit-text-input--enable-clear-button/
+    );
+
+    await scope.getByTestId("uncontrolled-input").focus();
+    await expect(root).toHaveClass(/inovua-react-toolkit-text-input--focused/);
+    await expect(scope.getByTestId("disabled-root")).toHaveClass(
+      /inovua-react-toolkit-text-input--disabled/
+    );
+    await expect(scope.locator("button.issue48-disabled-clear")).toBeHidden();
+    await expect(scope.locator("button.issue48-readonly-clear")).toBeHidden();
+    await expect(
+      scope.locator("button.issue48-uncontrolled-clear")
+    ).toHaveAttribute("tabindex", "-1");
+    await expect(
+      scope.locator("button.issue48-focusable-clear")
+    ).toHaveAttribute("tabindex", "0");
+
+    const customRoot = scope.getByTestId("custom-theme-root");
+    await expect(customRoot).toHaveClass(/issue48-custom-text-input/);
+    await expect(customRoot).toHaveClass(/issue48-custom-text-input--rtl/);
+    await expect(customRoot).toHaveClass(
+      /issue48-custom-text-input--theme-midnight/
+    );
+    await expect(customRoot).toHaveAttribute(
+      "data-theme",
+      "consumer-theme-hook"
+    );
+    await expect(customRoot).toHaveAttribute(
+      "data-disabled",
+      "consumer-disabled-hook"
+    );
+    await expect(customRoot).toHaveAttribute(
+      "data-focused",
+      "consumer-focused-hook"
+    );
+    await expect(customRoot).toHaveAttribute("dir", "auto");
+    await expect(
+      scope.getByTestId("focusable-clear-input")
+    ).not.toHaveAttribute("stopchangepropagation");
+
+    const subclassClear = scope.getByTestId("subclass-clear-button");
+    await expect(subclassClear).toHaveClass(/issue48-subclass-clear/);
+    await expect(subclassClear).toHaveAttribute(
+      "data-clear-color",
+      "rgb(10, 20, 30)"
+    );
+    await expect(subclassClear).toHaveAttribute("data-clear-size", "[13,17]");
+    await expect(subclassClear).toHaveAttribute(
+      "data-clear-style",
+      '{"opacity":0.75}'
+    );
+
+    // The examples app also loads an Inovua theme for migration demos. Probe
+    // the custom BEM root so the geometry can only come from our standalone
+    // tdg-text-input styling, never from an upstream legacy selector.
+    const standaloneGeometry = await customRoot.evaluate((element) => {
+      const input = element.querySelector("input");
+      const clear = element.querySelector("button");
+      if (!input || !clear) return null;
+      const rootRect = element.getBoundingClientRect();
+      const inputRect = input.getBoundingClientRect();
+      const clearRect = clear.getBoundingClientRect();
+      const rootStyle = getComputedStyle(element);
+      const inputStyle = getComputedStyle(input);
+      return {
+        display: rootStyle.display,
+        borderWidth: Number.parseFloat(rootStyle.borderTopWidth),
+        inputBorderWidth: Number.parseFloat(inputStyle.borderTopWidth),
+        rootWidth: rootRect.width,
+        rootHeight: rootRect.height,
+        inputVisible: inputRect.width > 0 && inputRect.height > 0,
+        inputContained:
+          inputRect.left >= rootRect.left - 1 &&
+          inputRect.right <= rootRect.right + 1 &&
+          inputRect.top >= rootRect.top - 1 &&
+          inputRect.bottom <= rootRect.bottom + 1,
+        clearCenterContained:
+          clearRect.left + clearRect.width / 2 >= rootRect.left &&
+          clearRect.right - clearRect.width / 2 <= rootRect.right &&
+          clearRect.top + clearRect.height / 2 >= rootRect.top &&
+          clearRect.bottom - clearRect.height / 2 <= rootRect.bottom,
+      };
+    });
+    expect(standaloneGeometry).not.toBeNull();
+    expect(standaloneGeometry?.display).toBe("inline-flex");
+    expect(standaloneGeometry?.borderWidth ?? 0).toBeGreaterThan(0);
+    expect(standaloneGeometry?.inputBorderWidth).toBe(0);
+    expect(standaloneGeometry?.rootWidth ?? 0).toBeGreaterThan(100);
+    expect(standaloneGeometry?.rootHeight ?? 0).toBeGreaterThanOrEqual(28);
+    expect(standaloneGeometry?.inputVisible).toBe(true);
+    expect(standaloneGeometry?.inputContained).toBe(true);
+    expect(standaloneGeometry?.clearCenterContained).toBe(true);
+  });
+
+  test("accepts null legacy options and keeps Inovua's falsey clear semantics", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "text-input");
+
+    const nullPropsRoot = scope.getByTestId("null-input-props-root");
+    await expect(nullPropsRoot.locator("input")).toHaveValue("null-safe");
+
+    await expect(scope.getByTestId("numeric-zero-input")).toHaveValue("0");
+    await expect(
+      scope.locator("button.issue48-numeric-zero-clear")
+    ).toBeHidden();
+
+    const zeroSizeClear = scope.locator("button.issue48-zero-size-clear");
+    await expect(zeroSizeClear).toBeVisible();
+    const zeroSizeIcon = await zeroSizeClear.locator("svg").evaluate((icon) => {
+      const rect = icon.getBoundingClientRect();
+      return { width: rect.width, height: rect.height };
+    });
+    expect(zeroSizeIcon.width).toBe(20);
+    expect(zeroSizeIcon.height).toBe(20);
+
+    await scope.getByTestId("null-propagation-input").fill("still bubbles");
+    await expect(scope.getByTestId("text-input-outer-changes")).toHaveText("1");
+  });
+});
+
+test.describe("issue #48 onDidMount compatibility", () => {
+  test("runs after the DOM/API commit, before handle/onReady, and shares their stable ref", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "did-mount");
+    const output = scope.getByTestId("did-mount-events");
+
+    await expect
+      .poll(async () => {
+        const events = await readMountEvents(output);
+        return ["didMount", "handle", "ready"].every((type) =>
+          events.some((event) => event.type === type)
+        );
+      })
+      .toBe(true);
+
+    const events = await readMountEvents(output);
+    const didMountEvents = events.filter((event) => event.type === "didMount");
+    const firstDidMount = events.findIndex(
+      (event) => event.type === "didMount"
+    );
+    const firstHandle = events.findIndex((event) => event.type === "handle");
+    const firstReady = events.findIndex((event) => event.type === "ready");
+
+    expect(firstDidMount).toBeGreaterThanOrEqual(0);
+    expect(firstDidMount).toBeLessThan(firstHandle);
+    expect(firstHandle).toBeLessThan(firstReady);
+    expect(new Set(events.map((event) => event.refId))).toEqual(
+      new Set([didMountEvents[0]!.refId])
+    );
+    expect(
+      didMountEvents.every(
+        (event) =>
+          event.apiLive && event.domConnected && event.rowCount !== null
+      )
+    ).toBe(true);
+    expect(didMountEvents[0]!.rowCount).toBe(0);
+  });
+
+  test("does not rerun for callback replacement/rerender and gets a new ref on a real remount", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "did-mount");
+    const output = scope.getByTestId("did-mount-events");
+
+    await expect
+      .poll(
+        async () =>
+          (await readMountEvents(output)).filter(
+            (event) => event.type === "didMount"
+          ).length
+      )
+      .toBeGreaterThan(0);
+
+    // Let StrictMode's deliberate development-only effect replay settle, then
+    // compare counts instead of assuming either one or two raw mount calls.
+    await page.waitForTimeout(100);
+    const before = await readMountEvents(output);
+    const beforeDidMount = before.filter((event) => event.type === "didMount");
+    const firstRefId = beforeDidMount[0]!.refId;
+    const firstRefRawCalls = beforeDidMount.filter(
+      (event) => event.refId === firstRefId
+    ).length;
+
+    await scope.getByTestId("did-mount-rerender").click();
+    await page.waitForTimeout(100);
+    const rerendered = await readMountEvents(output);
+    expect(rerendered.filter((event) => event.type === "didMount").length).toBe(
+      beforeDidMount.length
+    );
+
+    await scope.getByTestId("did-mount-remount").click();
+    await expect
+      .poll(async () => {
+        const events = await readMountEvents(output);
+        return new Set(
+          events
+            .filter((event) => event.type === "didMount")
+            .map((event) => event.refId)
+        ).size;
+      })
+      .toBe(2);
+
+    await page.waitForTimeout(100);
+    const remounted = await readMountEvents(output);
+    const remountDidEvents = remounted.filter(
+      (event) => event.type === "didMount"
+    );
+    const secondRefId = remountDidEvents.find(
+      (event) => event.refId !== firstRefId
+    )!.refId;
+    expect(
+      remountDidEvents.filter((event) => event.refId === secondRefId).length
+    ).toBe(firstRefRawCalls);
+    expect(
+      remountDidEvents
+        .filter((event) => event.refId === secondRefId)
+        .every((event) => event.callbackVersion === 1)
+    ).toBe(true);
+  });
+
+  test("fires for a committed zero-width grid", async ({ page }) => {
+    const scope = await openScenario(page, "did-mount-zero-width");
+    await expect(scope.getByTestId("zero-width-host")).toHaveCSS(
+      "width",
+      "0px"
+    );
+
+    const output = scope.getByTestId("did-mount-zero-events");
+    await expect
+      .poll(async () => (await readMountEvents(output)).length)
+      .toBeGreaterThan(0);
+
+    const events = await readMountEvents(output);
+    expect(events.every((event) => event.apiLive && event.domConnected)).toBe(
+      true
+    );
+  });
+
+  test("fires before an async data source resolves and does not repeat on load", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "did-mount-async");
+    const calls = scope.getByTestId("did-mount-async-calls");
+
+    await expect
+      .poll(async () => Number((await calls.textContent()) ?? 0))
+      .toBeGreaterThan(0);
+    const settledMountCalls = Number(await calls.textContent());
+
+    await scope.getByTestId("resolve-async-data").click();
+    const grid = scope.locator(".InovuaReactDataGrid.tdg-root");
+    await expect(
+      grid.locator('[data-slot="grid-row"][data-row-id="1"]')
+    ).toBeVisible();
+    await page.waitForTimeout(100);
+    await expect(calls).toHaveText(String(settledMountCalls));
+  });
+});
+
+test.describe("issue #48 virtualList.adjustHeights compatibility", () => {
+  test("remeasures only mounted natural-height rows and rebuilds offsets", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "adjust-natural");
+    await scope.getByTestId("run-adjust-heights").click();
+    const output = scope.getByTestId("adjust-heights-report");
+    await expect
+      .poll(async () => {
+        const report = await readJson<AdjustReport | null>(output);
+        return Boolean(
+          report &&
+          report.domHeight != null &&
+          report.after.height != null &&
+          report.after.height >= report.domHeight - 1
+        );
+      })
+      .toBe(true);
+    const report = await readJson<AdjustReport>(output);
+
+    expect(report.methodExists).toBe(true);
+    expect(report.returnedUndefined).toBe(true);
+    expect(report.error).toBeNull();
+    expect(report.before.height).not.toBeNull();
+    expect(report.stale.height).toBe(report.before.height);
+    expect(report.domHeight ?? 0).toBeGreaterThan(report.before.height ?? 0);
+    expect(report.after.height ?? 0).toBeGreaterThanOrEqual(
+      (report.domHeight ?? 0) - 1
+    );
+    expect(report.after.nextStart).toBe(report.after.end);
+    expect((report.after.total ?? 0) - (report.before.total ?? 0)).toBe(
+      (report.after.height ?? 0) - (report.before.height ?? 0)
+    );
+
+    expect(report.mountedIndexes.length).toBeGreaterThan(1);
+    expect(report.mountedIndexes.length).toBeLessThan(report.totalRows);
+    expect(new Set(report.measuredIndexes)).toEqual(
+      new Set(report.mountedIndexes)
+    );
+  });
+
+  test("keeps a numeric rowHeight authoritative", async ({ page }) => {
+    const scope = await openScenario(page, "adjust-fixed");
+    await scope.getByTestId("run-adjust-heights").click();
+    const report = await readJson<AdjustReport>(
+      scope.getByTestId("adjust-heights-report")
+    );
+
+    expect(report.methodExists).toBe(true);
+    expect(report.returnedUndefined).toBe(true);
+    expect(report.error).toBeNull();
+    expect(report.before.height).toBe(48);
+    expect(report.stale.height).toBe(48);
+    expect(report.after.height).toBe(48);
+    expect(report.after.nextStart).toBe(report.after.end);
+    expect(report.after.total).toBe(report.before.total);
+    expect(report.measuredIndexes).toEqual([]);
+  });
+
+  test("remeasures function-valued row heights like Inovua 5.10.2", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      const observedRowIndexes: string[] = [];
+      Object.defineProperty(window, "__issue48ObservedRowIndexes", {
+        configurable: true,
+        value: observedRowIndexes,
+      });
+
+      const originalObserve = ResizeObserver.prototype.observe;
+      ResizeObserver.prototype.observe = function (
+        target: Element,
+        options?: ResizeObserverOptions
+      ) {
+        if (
+          target instanceof HTMLElement &&
+          target.dataset.slot === "grid-row"
+        ) {
+          observedRowIndexes.push(target.dataset.rowIndex ?? "");
+        }
+        return originalObserve.call(this, target, options);
+      };
+    });
+
+    const scope = await openScenario(page, "adjust-function");
+    await page.evaluate(() => {
+      const trackedWindow = window as Window & {
+        __issue48ObservedRowIndexes?: string[];
+      };
+      if (trackedWindow.__issue48ObservedRowIndexes) {
+        trackedWindow.__issue48ObservedRowIndexes.length = 0;
+      }
+    });
+    await scope.getByTestId("run-adjust-heights").click();
+    const output = scope.getByTestId("adjust-heights-report");
+    await expect
+      .poll(async () => {
+        const report = await readJson<AdjustReport | null>(output);
+        return (report?.after.height ?? 0) > 48;
+      })
+      .toBe(true);
+    const report = await readJson<AdjustReport>(output);
+
+    expect(report.methodExists).toBe(true);
+    expect(report.returnedUndefined).toBe(true);
+    expect(report.error).toBeNull();
+    expect(report.before.height).toBe(48);
+    expect(report.stale.height).toBe(48);
+    expect(report.domHeight ?? 0).toBeGreaterThan(48);
+    expect(report.after.height ?? 0).toBeGreaterThan(48);
+    expect(report.after.nextStart).toBe(report.after.end);
+    expect(report.after.total ?? 0).toBeGreaterThan(report.before.total ?? 0);
+    expect(new Set(report.measuredIndexes)).toEqual(
+      new Set(report.mountedIndexes)
+    );
+
+    // Function-height rows do not carry TanStack's measureElement ref. The
+    // imperative compatibility method must not register them with a
+    // ResizeObserver, otherwise scrolled-out nodes remain cached/observed.
+    await page.waitForTimeout(50);
+    const observedRows = await page.evaluate(() => {
+      const trackedWindow = window as Window & {
+        __issue48ObservedRowIndexes?: string[];
+      };
+      return trackedWindow.__issue48ObservedRowIndexes ?? [];
+    });
+    expect(observedRows).toEqual([]);
+  });
+
+  test("remeasures every instantiated row in non-virtual natural layout", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "adjust-nonvirtual");
+    await scope.getByTestId("run-adjust-heights").click();
+    const output = scope.getByTestId("adjust-heights-report");
+    await expect
+      .poll(async () => {
+        const report = await readJson<AdjustReport | null>(output);
+        return Boolean(
+          report &&
+          report.domHeight != null &&
+          report.after.height != null &&
+          report.after.height >= report.domHeight - 1
+        );
+      })
+      .toBe(true);
+    const report = await readJson<AdjustReport>(output);
+
+    expect(report.methodExists).toBe(true);
+    expect(report.returnedUndefined).toBe(true);
+    expect(report.error).toBeNull();
+    expect(report.mountedIndexes).toHaveLength(report.totalRows);
+    expect(new Set(report.measuredIndexes)).toEqual(
+      new Set(report.mountedIndexes)
+    );
+    expect(report.after.nextStart).toBe(report.after.end);
+    expect((report.after.total ?? 0) - (report.before.total ?? 0)).toBe(
+      (report.after.height ?? 0) - (report.before.height ?? 0)
+    );
+  });
+
+  test("is a safe void no-op for an empty non-virtual grid", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "adjust-safe");
+    await scope.getByTestId("run-safe-adjust-heights").click();
+    const report = await readJson<{
+      methodExists: boolean;
+      returnedUndefined: boolean;
+      error: string | null;
+    }>(scope.getByTestId("adjust-safe-report"));
+
+    expect(report).toEqual({
+      methodExists: true,
+      returnedUndefined: true,
+      error: null,
+    });
+  });
+});

--- a/tests/playwright/overflow.spec.ts
+++ b/tests/playwright/overflow.spec.ts
@@ -116,7 +116,10 @@ test("keeps the horizontal scrollbar above cells and draggable", async ({
     "Password changed",
     "Language",
   ]) {
-    await preview.getByRole("button", { name: columnName }).click();
+    await preview
+      .locator('[data-slot="rdg-column-toggle-list"]')
+      .getByRole("button", { name: columnName, exact: true })
+      .click();
   }
 
   const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();

--- a/tests/playwright/provider-docs.spec.ts
+++ b/tests/playwright/provider-docs.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+
+test("documents provider requirements and conditional grid targets", async ({
+  page,
+}) => {
+  await page.goto("/docs/reference/providers-and-targets");
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Providers and targets" })
+  ).toBeVisible();
+
+  const sidebarLink = page
+    .getByTestId("docs-sidebar")
+    .getByRole("link", { name: "Providers & targets", exact: true });
+  await expect(sidebarLink).toHaveAttribute("aria-current", "page");
+
+  for (const heading of [
+    "The provider contract",
+    "Direct grid children connect automatically",
+    "When a target is required",
+    "Required target: nested search layout",
+    "Required target: custom visibility layout",
+    "Scope providers deliberately",
+    "Troubleshooting provider connections",
+    "Stable feature-specific APIs",
+  ]) {
+    await expect(
+      page.getByRole("heading", { level: 2, name: heading })
+    ).toBeAttached();
+  }
+
+  await expect(
+    page.getByRole("cell", {
+      name: "Grid is an immediate provider child",
+      exact: true,
+    })
+  ).toBeAttached();
+  await expect(
+    page.getByRole("cell", {
+      name: "Grid is inside a div, section, card, or panel",
+      exact: true,
+    })
+  ).toBeAttached();
+  await expect(
+    page.getByRole("cell", { name: "Required", exact: true }).first()
+  ).toBeAttached();
+
+  for (const publicApi of [
+    "RDGSearchProvider",
+    "RDGSearchTarget",
+    "RDGColumnVisibilityProvider",
+    "RDGColumnVisibilityTarget",
+  ]) {
+    await expect(
+      page.getByRole("cell", { name: publicApi, exact: true })
+    ).toBeAttached();
+  }
+
+  await expect(
+    page.getByRole("link", { name: "table search guide", exact: true })
+  ).toHaveAttribute("href", "/docs/guides/table-search");
+  await expect(
+    page.getByRole("link", {
+      name: "column visibility toolbar reference",
+      exact: true,
+    })
+  ).toHaveAttribute("href", "/docs/reference/column-visibility-toolbar");
+});

--- a/tests/playwright/provider-docs.spec.ts
+++ b/tests/playwright/provider-docs.spec.ts
@@ -18,15 +18,16 @@ test("documents provider requirements and conditional grid targets", async ({
     "The provider contract",
     "Direct grid children connect automatically",
     "When a target is required",
-    "Required target: nested search layout",
-    "Required target: custom visibility layout",
+    "Required target: nested mixed-controls layout",
+    "Combined provider with existing control imports",
+    "Why targets exist",
     "Scope providers deliberately",
     "Troubleshooting provider connections",
-    "Stable feature-specific APIs",
+    "Combined and stable feature-specific APIs",
   ]) {
     await expect(
       page.getByRole("heading", { level: 2, name: heading })
-    ).toBeAttached();
+    ).toBeVisible();
   }
 
   await expect(
@@ -35,26 +36,41 @@ test("documents provider requirements and conditional grid targets", async ({
       exact: true,
     })
   ).toBeAttached();
-  await expect(
-    page.getByRole("cell", {
+  const nestedLayoutRow = page.getByRole("row").filter({
+    has: page.getByRole("cell", {
       name: "Grid is inside a div, section, card, or panel",
       exact: true,
-    })
-  ).toBeAttached();
+    }),
+  });
+  await expect(nestedLayoutRow).toHaveCount(1);
   await expect(
-    page.getByRole("cell", { name: "Required", exact: true }).first()
-  ).toBeAttached();
+    nestedLayoutRow.getByRole("cell", { name: "Required", exact: true })
+  ).toBeVisible();
 
+  const stableApiSection = page.locator("#stable-provider-apis");
   for (const publicApi of [
+    "RDGProvider",
+    "RDGTarget",
     "RDGSearchProvider",
     "RDGSearchTarget",
     "RDGColumnVisibilityProvider",
     "RDGColumnVisibilityTarget",
   ]) {
     await expect(
-      page.getByRole("cell", { name: publicApi, exact: true })
-    ).toBeAttached();
+      stableApiSection.getByRole("cell", { name: publicApi, exact: true })
+    ).toBeVisible();
   }
+
+  const pageContent = page.locator("main");
+  await expect(pageContent).toContainText("@geovi/the-datagrid/components");
+  await expect(pageContent).toContainText("@geovi/the-datagrid/search");
+  await expect(pageContent).toContainText(
+    "@geovi/the-datagrid/column-visibility"
+  );
+  await expect(pageContent).toContainText(
+    "The four feature-specific APIs above remain available"
+  );
+  await expect(pageContent).toContainText("defaultSearchValue");
 
   await expect(
     page.getByRole("link", { name: "table search guide", exact: true })
@@ -65,4 +81,22 @@ test("documents provider requirements and conditional grid targets", async ({
       exact: true,
     })
   ).toHaveAttribute("href", "/docs/reference/column-visibility-toolbar");
+});
+
+test("documents column visibility initialization, remount, and semantics", async ({
+  page,
+}) => {
+  await page.goto("/docs/reference/column-visibility-toolbar");
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Column visibility toolbar" })
+  ).toBeVisible();
+
+  const content = page.locator("main");
+  await expect(content).toContainText("visible: false");
+  await expect(content).toContainText("defaultHidden");
+  await expect(content).toContainText("real grid remount");
+  await expect(content).toContainText("level-two heading");
+  await expect(content).toContainText("aria-describedby");
+  await expect(content).toContainText("@geovi/the-datagrid/components");
 });

--- a/tests/playwright/published-column-visibility.spec.ts
+++ b/tests/playwright/published-column-visibility.spec.ts
@@ -1,0 +1,87 @@
+import { resolve } from "node:path";
+import { expect, test } from "@playwright/test";
+
+function viteFsUrl(filePath: string): string {
+  return `/@fs${resolve(process.cwd(), filePath)}`;
+}
+
+test("published core and column-visibility entries hide and show a column", async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  const columnVisibilityUrl = viteFsUrl("dist/column-visibility.js");
+  const coreUrl = viteFsUrl("dist/index.js");
+  const reactDomUrl = viteFsUrl("node_modules/.vite/deps/react-dom_client.js");
+  const reactUrl = viteFsUrl("node_modules/.vite/deps/react.js");
+
+  await page.goto("/");
+  await page.setContent('<div id="published-column-visibility-root"></div>');
+  await page.addScriptTag({
+    type: "module",
+    content: `
+      import React from ${JSON.stringify(reactUrl)};
+      import ReactDOMClient from ${JSON.stringify(reactDomUrl)};
+      import ReactDataGrid from ${JSON.stringify(coreUrl)};
+      import {
+        RDGColumnVisibilityProvider,
+        RDGColumnVisibilityToolbar,
+      } from ${JSON.stringify(columnVisibilityUrl)};
+
+      const columns = [
+        { name: "name", header: "Name" },
+        { name: "city", header: "City", visible: false },
+      ];
+      const rows = [
+        { id: 1, name: "Ada", city: "London" },
+        { id: 2, name: "Grace", city: "New York" },
+      ];
+
+      function PublishedColumnVisibilitySmoke() {
+        return React.createElement(
+          RDGColumnVisibilityProvider,
+          null,
+          React.createElement(RDGColumnVisibilityToolbar, {
+            title: "Visible columns",
+          }),
+          React.createElement(ReactDataGrid, {
+            columns,
+            dataSource: rows,
+            idProperty: "id",
+            showColumnMenuTool: false,
+            virtualized: false,
+          })
+        );
+      }
+
+      ReactDOMClient.createRoot(
+        document.getElementById("published-column-visibility-root")
+      ).render(React.createElement(PublishedColumnVisibilitySmoke));
+    `,
+  });
+
+  const toolbar = page.locator('[data-slot="rdg-column-visibility"]');
+  const cityToggle = toolbar.locator(
+    '[data-slot="rdg-column-toggle"][data-column-id="city"]'
+  );
+  const cityHeader = page.locator(
+    '[data-slot="grid-header-cell"][data-column-id="city"]'
+  );
+
+  await expect(toolbar).toBeVisible();
+  await expect(cityToggle).toHaveAccessibleName("City");
+  await expect(cityToggle).toHaveAttribute("aria-pressed", "false");
+  await expect(cityHeader).toHaveCount(0);
+
+  await cityToggle.click();
+
+  await expect(cityToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(cityHeader).toBeVisible();
+
+  await cityToggle.click();
+
+  await expect(cityToggle).toHaveAttribute("aria-pressed", "false");
+  await expect(cityHeader).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+});

--- a/tests/playwright/published-combined-provider.spec.ts
+++ b/tests/playwright/published-combined-provider.spec.ts
@@ -1,0 +1,116 @@
+import { resolve } from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+function viteFsUrl(filePath: string): string {
+  return `/@fs${resolve(process.cwd(), filePath)}`;
+}
+
+test("published combined provider shares legacy search and visibility contexts", async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  const columnVisibilityUrl = viteFsUrl("dist/column-visibility.js");
+  const componentsUrl = viteFsUrl("dist/components.js");
+  const coreUrl = viteFsUrl("dist/index.js");
+  const reactDomUrl = viteFsUrl("node_modules/.vite/deps/react-dom_client.js");
+  const reactUrl = viteFsUrl("node_modules/.vite/deps/react.js");
+  const searchUrl = viteFsUrl("dist/search.js");
+
+  await page.goto("/");
+  await page.setContent('<div id="published-combined-provider-root"></div>');
+  await page.addScriptTag({
+    type: "module",
+    content: `
+      import React from ${JSON.stringify(reactUrl)};
+      import ReactDOMClient from ${JSON.stringify(reactDomUrl)};
+      import ReactDataGrid from ${JSON.stringify(coreUrl)};
+      import { RDGProvider, RDGTarget } from ${JSON.stringify(componentsUrl)};
+      import { RDGSearchBar } from ${JSON.stringify(searchUrl)};
+      import { RDGColumnVisibilityToolbar } from ${JSON.stringify(columnVisibilityUrl)};
+
+      const columns = [
+        { name: "name", header: "Name" },
+        { name: "city", header: "City" },
+      ];
+      const rows = [
+        { id: 1, name: "Ada Lovelace", city: "London" },
+        { id: 2, name: "Grace Hopper", city: "New York" },
+      ];
+
+      function PublishedCombinedProviderSmoke() {
+        return React.createElement(
+          RDGProvider,
+          null,
+          React.createElement(RDGSearchBar, {
+            ariaLabel: "Search published combined grid",
+            debounceMs: 0,
+          }),
+          React.createElement(RDGColumnVisibilityToolbar, {
+            title: "Published combined columns",
+          }),
+          React.createElement(
+            "div",
+            { style: { height: 280 } },
+            React.createElement(
+              RDGTarget,
+              null,
+              React.createElement(ReactDataGrid, {
+                columns,
+                dataSource: rows,
+                idProperty: "id",
+                showColumnMenuTool: false,
+                virtualized: false,
+              })
+            )
+          )
+        );
+      }
+
+      ReactDOMClient.createRoot(
+        document.getElementById("published-combined-provider-root")
+      ).render(React.createElement(PublishedCombinedProviderSmoke));
+    `,
+  });
+
+  const grid = page.locator(".InovuaReactDataGrid.tdg-root");
+  const rows = grid.locator('[data-slot="grid-row"]');
+  const search = page.getByRole("searchbox", {
+    name: "Search published combined grid",
+  });
+  const cityToggle = page.locator(
+    '[data-slot="rdg-column-toggle"][data-column-id="city"]'
+  );
+  const cityHeader = grid.locator(
+    '[data-slot="grid-header-cell"][data-column-id="city"]'
+  );
+  const cityCells = grid.locator(
+    '[data-slot="grid-row"] [data-column-id="city"]'
+  );
+
+  await expect(grid).toHaveCount(1);
+  await expect(search).toHaveCount(1);
+  await expect(cityToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(cityHeader).toBeVisible();
+  await expect(rows).toHaveCount(2);
+
+  await search.fill("Grace Hopper");
+
+  await expect(rows).toHaveCount(1);
+  await expect(grid.getByText("Grace Hopper", { exact: true })).toBeVisible();
+
+  await cityToggle.click();
+
+  await expect(cityToggle).toHaveAttribute("aria-pressed", "false");
+  await expect(cityHeader).toHaveCount(0);
+  await expect(cityCells).toHaveCount(0);
+
+  await search.fill("London");
+
+  await expect(rows).toHaveCount(1);
+  await expect(grid.getByText("Ada Lovelace", { exact: true })).toBeVisible();
+  await expect(grid.getByText("London", { exact: true })).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+});

--- a/tests/playwright/users-column-visibility.spec.ts
+++ b/tests/playwright/users-column-visibility.spec.ts
@@ -27,7 +27,7 @@ function usersPreview(page: Page) {
 }
 
 function usersGrid(preview: Locator) {
-  return preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  return preview.locator(".InovuaReactDataGrid.tdg-root");
 }
 
 function visibilityToolbar(preview: Locator) {
@@ -104,12 +104,26 @@ test.describe("external column visibility controls", () => {
     const toolbar = visibilityToolbar(preview);
     const group = toggleList(toolbar);
     const toggles = group.locator('[data-slot="rdg-column-toggle"]');
+    const description = toolbar.getByText(
+      "Toggle columns, export the current dataset shape, and show or hide the filter row.",
+      { exact: true }
+    );
 
     await expect(preview).toBeVisible();
+    await expect(grid).toHaveCount(1);
     await expect(grid).toBeVisible();
     await expect(toolbar).toBeVisible();
+    await expect(toolbar).toHaveRole("region");
+    await expect(toolbar).toHaveAccessibleName("Visible columns");
+    await expect(
+      toolbar.getByRole("heading", { level: 2, name: "Visible columns" })
+    ).toBeVisible();
     await expect(group).toHaveRole("group");
     await expect(group).toHaveAccessibleName("Visible column toggles");
+    const descriptionId = await description.getAttribute("id");
+    expect(descriptionId).toBeTruthy();
+    await expect(toolbar).toHaveAttribute("aria-describedby", descriptionId!);
+    await expect(group).toHaveAttribute("aria-describedby", descriptionId!);
     await expectColumnIds(toggles, ALL_COLUMN_IDS);
 
     const initiallyVisible = new Set(INITIALLY_VISIBLE_COLUMN_IDS);
@@ -139,6 +153,7 @@ test.describe("external column visibility controls", () => {
     const failedLoginsToggle = columnToggle(toolbar, "failed_login_attempts");
     const emailToggle = columnToggle(toolbar, "csemail");
 
+    await expect(grid).toHaveCount(1);
     await expect(failedLoginsToggle).toHaveAttribute("aria-pressed", "false");
     await expect(columnHeader(grid, "failed_login_attempts")).toHaveCount(0);
     await expect(emailToggle).toHaveAttribute("aria-pressed", "true");
@@ -177,6 +192,7 @@ test.describe("external column visibility controls", () => {
     const toolbar = visibilityToolbar(preview);
     const languageToggle = columnToggle(toolbar, "lang");
 
+    await expect(grid).toHaveCount(1);
     await expect(languageToggle).toHaveAccessibleName("Language");
     await languageToggle.focus();
     await expect(languageToggle).toBeFocused();
@@ -211,6 +227,7 @@ test.describe("external column visibility controls", () => {
       grid.locator('[data-slot="grid-header-cell"][data-column-id]')
     );
 
+    await expect(grid).toHaveCount(1);
     await expect(actions).toBeVisible();
     await expect(actions.getByRole("button", { name: "Export" })).toBeVisible();
     await expect(
@@ -256,6 +273,7 @@ test.describe("external column visibility controls", () => {
     const toolbar = visibilityToolbar(preview);
     const survivorId = "csuserid";
 
+    await expect(grid).toHaveCount(1);
     for (const columnId of INITIALLY_VISIBLE_COLUMN_IDS) {
       if (columnId === survivorId) continue;
 
@@ -293,6 +311,7 @@ test("an explicit nested target follows controlled order after a remount", async
   );
 
   await expect(scope).toBeVisible();
+  await expect(grid).toHaveCount(1);
   await expect(toolbar).toBeVisible();
   await expectColumnIds(toggles, ["id", "name", "city"]);
   await expectColumnIds(headers, ["id", "name"]);
@@ -339,6 +358,7 @@ test("auto-targets a direct grid and omits non-hideable columns", async ({
   const optionalToggle = columnToggle(toolbar, "optional");
 
   await expect(scope).toBeVisible();
+  await expect(grid).toHaveCount(1);
   await expect(toggles).toHaveCount(1);
   expect(await columnIds(toggles)).toEqual(["optional"]);
   await expect(columnToggle(toolbar, "locked")).toHaveCount(0);

--- a/tests/playwright/users-column-visibility.spec.ts
+++ b/tests/playwright/users-column-visibility.spec.ts
@@ -1,378 +1,358 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
-// Timing is a secondary guard because CI scheduling can be noisy. DOM identity
-// below is the deterministic signal for the expensive renderer churn.
-const MAX_FRAME_DELAY_MS = 250;
-const MAX_LONG_TASK_MS = 250;
-const MAX_GEOMETRY_DRIFT_PX = 2;
-const MAX_LAYOUT_DRIFT_PX = 1;
-const OPTIONAL_COLUMNS = [
-  { label: "Failed logins", id: "failed_login_attempts" },
-  { label: "Last login", id: "date_last_successful_login" },
-  { label: "Password changed", id: "date_pwdchanged" },
-  { label: "Language", id: "lang" },
+const ALL_COLUMN_IDS = [
+  "csuserid",
+  "csrolename",
+  "csemail",
+  "failed_login_attempts",
+  "date_last_successful_login",
+  "date_pwdchanged",
+  "lang",
+  "disabled",
+  "tfa_enabled",
+  "actions",
 ] as const;
 
-function captureRuntimeFailures(page: Page) {
-  const failures: string[] = [];
-  const renderLoopPattern =
-    /too many re-renders|maximum update depth|cannot update a component while rendering/i;
+const INITIALLY_VISIBLE_COLUMN_IDS = [
+  "csuserid",
+  "csrolename",
+  "csemail",
+  "disabled",
+  "tfa_enabled",
+  "actions",
+] as const;
 
-  page.on("pageerror", (error) => failures.push(error.message));
-  page.on("console", (message) => {
-    if (message.type() === "error" && renderLoopPattern.test(message.text())) {
-      failures.push(message.text());
-    }
-  });
-
-  return failures;
+function usersPreview(page: Page) {
+  return page.getByTestId("example-preview-panel");
 }
 
-test("Visible columns toggles stay responsive and geometrically consistent", async ({
-  page,
-}) => {
-  const runtimeFailures = captureRuntimeFailures(page);
+function usersGrid(preview: Locator) {
+  return preview.locator(".InovuaReactDataGrid.tdg-root").first();
+}
 
-  // This width exposed the old icon-driven wrap: toggling a hidden column
-  // changed the toolbar from one line to two and moved the complete grid.
-  await page.setViewportSize({ width: 940, height: 900 });
-  await page.goto("/users");
+function visibilityToolbar(preview: Locator) {
+  return preview.locator('[data-slot="rdg-column-visibility"]');
+}
 
-  const preview = page.getByTestId("example-preview-panel");
-  const toggleGroup = preview.getByRole("group", {
-    name: "Visible column toggles",
-  });
-  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
-  const failedLoginsButton = toggleGroup.getByRole("button", {
-    name: "Failed logins",
-    exact: true,
-  });
-  const failedLoginsHeader = grid.locator(
-    '[data-slot="grid-header-cell"][data-column-id="failed_login_attempts"]'
+function toggleList(toolbar: Locator) {
+  return toolbar.locator('[data-slot="rdg-column-toggle-list"]');
+}
+
+function columnToggle(toolbar: Locator, columnId: string) {
+  return toggleList(toolbar).locator(
+    `[data-slot="rdg-column-toggle"][data-column-id="${columnId}"]`
   );
+}
 
-  await expect(preview).toBeVisible();
-  await expect(grid).toBeVisible();
-  await expect(failedLoginsButton).toBeVisible();
-  await expect(failedLoginsHeader).toHaveCount(0);
-  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "false");
-
-  const mountedRows = grid.locator('[data-slot="grid-row"][data-row-id]');
-  await expect(mountedRows.first()).toBeVisible();
-  const mountedRowCount = await mountedRows.count();
-  expect(mountedRowCount).toBeGreaterThan(0);
-  expect(mountedRowCount).toBeLessThan(48);
-
-  // Column toggles are text controls. Their state must not add an eye icon or
-  // change the button's accessible name when a column is hidden.
-  const initialIconCount = await toggleGroup.locator("svg").count();
-
-  // Exercise one browser-driven round trip before the in-page probe. This
-  // catches pointer/focus regressions that a synthetic click alone would miss.
-  await failedLoginsButton.click();
-  await expect(failedLoginsHeader).toBeVisible();
-  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "true");
-  await failedLoginsButton.click();
-  await expect(failedLoginsHeader).toHaveCount(0);
-  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "false");
-
-  const result = await preview.evaluate(
-    async (previewElement, optionalColumns) => {
-      const gridElement = previewElement.querySelector<HTMLElement>(
-        ".InovuaReactDataGrid.tdg-root"
-      );
-      const group = previewElement.querySelector<HTMLElement>(
-        '[role="group"][aria-label="Visible column toggles"]'
-      );
-      if (!gridElement || !group) {
-        return { error: "Visibility controls or grid were not found" } as const;
-      }
-
-      const longTasks: number[] = [];
-      const observer =
-        typeof PerformanceObserver === "function" &&
-        PerformanceObserver.supportedEntryTypes.includes("longtask")
-          ? new PerformanceObserver((list) => {
-              for (const entry of list.getEntries()) {
-                longTasks.push(entry.duration);
-              }
-            })
-          : null;
-
-      observer?.observe({ entryTypes: ["longtask"] });
-
-      const nextFrame = () =>
-        new Promise<number>((resolve) => requestAnimationFrame(resolve));
-
-      // Do not attribute route initialization or first-paint work to toggles.
-      await nextFrame();
-      await nextFrame();
-
-      const samples: Array<{
-        frameDelay: number;
-        geometryDrift: number;
-        headerIds: string[];
-        bodyIds: string[];
-        expectedVisible: boolean;
-        visibleOnNextFrame: boolean;
-        iconCount: number;
-        label: string;
-        pressedOnNextFrame: boolean;
-        replacedContentNodes: number;
-        buttonWidthDrift: number;
-        groupHeightDrift: number;
-        gridTopDrift: number;
-      }> = [];
-
-      const toggleColumn = async (
-        target: { label: string; id: string },
-        expectedVisible: boolean
-      ) => {
-        const button = Array.from(
-          group.querySelectorAll<HTMLButtonElement>("button")
-        ).find((element) => element.textContent?.trim() === target.label);
-        if (!button) throw new Error(`Missing ${target.label} toggle`);
-
-        // Existing renderers are the strongest deterministic proxy for work:
-        // adding one column must not remount content in every unaffected cell.
-        const preservedContent = new Map<string, Element>();
-        for (const rowElement of gridElement.querySelectorAll<HTMLElement>(
-          '[data-slot="grid-row"][data-row-id]'
-        )) {
-          for (const cellElement of rowElement.querySelectorAll<HTMLElement>(
-            `[data-column-id]:not([data-column-id="${target.id}"])`
-          )) {
-            const content = cellElement.querySelector(".tdg-cell-content > *");
-            if (!content) continue;
-
-            preservedContent.set(
-              `${rowElement.dataset.rowId}\u0000${cellElement.dataset.columnId}`,
-              content
-            );
-          }
-        }
-
-        const buttonWidthBefore = button.getBoundingClientRect().width;
-        const groupHeightBefore = group.getBoundingClientRect().height;
-        const gridTopBefore = gridElement.getBoundingClientRect().top;
-        const clickTime = performance.now();
-        button.click();
-        const frameTime = await nextFrame();
-
-        const header = gridElement.querySelector<HTMLElement>(
-          `[data-slot="grid-header-cell"][data-column-id="${target.id}"]`
-        );
-        const firstRow = gridElement.querySelector<HTMLElement>(
-          '[data-slot="grid-row"][data-row-id]'
-        );
-        const headers = Array.from(
-          gridElement.querySelectorAll<HTMLElement>(
-            '[data-slot="grid-header-cell"][data-column-id]'
-          )
-        );
-        const cells = Array.from(
-          firstRow?.querySelectorAll<HTMLElement>("[data-column-id]") ?? []
-        );
-        const headerIds = headers.map(
-          (element) => element.dataset.columnId ?? ""
-        );
-        const bodyIds = cells.map((element) => element.dataset.columnId ?? "");
-        let replacedContentNodes = 0;
-        for (const [key, previousContent] of preservedContent) {
-          const [rowId, columnId] = key.split("\u0000");
-          const currentContent = gridElement.querySelector(
-            `[data-slot="grid-row"][data-row-id="${rowId}"] ` +
-              `[data-column-id="${columnId}"] .tdg-cell-content > *`
-          );
-
-          if (currentContent !== previousContent) replacedContentNodes += 1;
-        }
-        const geometryDrift = headers.reduce(
-          (maximum, headerElement, index) => {
-            const cellElement = cells[index];
-            if (!cellElement) return Number.POSITIVE_INFINITY;
-
-            const headerRect = headerElement.getBoundingClientRect();
-            const cellRect = cellElement.getBoundingClientRect();
-            return Math.max(
-              maximum,
-              Math.abs(headerRect.left - cellRect.left),
-              Math.abs(headerRect.width - cellRect.width)
-            );
-          },
-          0
-        );
-
-        samples.push({
-          frameDelay: frameTime - clickTime,
-          geometryDrift,
-          headerIds,
-          bodyIds,
-          expectedVisible,
-          visibleOnNextFrame: Boolean(header),
-          iconCount: group.querySelectorAll("svg").length,
-          label: target.label,
-          pressedOnNextFrame:
-            button.getAttribute("aria-pressed") === String(expectedVisible),
-          replacedContentNodes,
-          buttonWidthDrift: Math.abs(
-            button.getBoundingClientRect().width - buttonWidthBefore
-          ),
-          groupHeightDrift: Math.abs(
-            group.getBoundingClientRect().height - groupHeightBefore
-          ),
-          gridTopDrift: Math.abs(
-            gridElement.getBoundingClientRect().top - gridTopBefore
-          ),
-        });
-      };
-
-      for (let cycle = 0; cycle < 2; cycle += 1) {
-        for (const target of optionalColumns) {
-          await toggleColumn(target, true);
-        }
-        for (const target of [...optionalColumns].reverse()) {
-          await toggleColumn(target, false);
-        }
-      }
-
-      // Let PerformanceObserver deliver any entry generated by the final
-      // toggle before disconnecting it.
-      await nextFrame();
-      observer?.disconnect();
-
-      return {
-        error: null,
-        longTasks,
-        samples,
-      };
-    },
-    OPTIONAL_COLUMNS
+function columnHeader(grid: Locator, columnId: string) {
+  return grid.locator(
+    `[data-slot="grid-header-cell"][data-column-id="${columnId}"]`
   );
+}
 
-  expect(result.error).toBeNull();
-  if (result.error) return;
+function mountedColumnCells(grid: Locator, columnId: string) {
+  return grid.locator(`[data-slot="grid-row"] [data-column-id="${columnId}"]`);
+}
 
-  expect(result.samples).toHaveLength(16);
-  for (const sample of result.samples) {
-    // A click is a discrete React event, so the complete header/body state must
-    // be committed before the next paint rather than settling over many frames.
-    expect(sample.visibleOnNextFrame).toBe(sample.expectedVisible);
-    expect(sample.pressedOnNextFrame).toBe(true);
-    expect(sample.headerIds).toEqual(sample.bodyIds);
-    expect(sample.geometryDrift).toBeLessThanOrEqual(MAX_GEOMETRY_DRIFT_PX);
-    expect(sample.replacedContentNodes).toBe(0);
-    expect(sample.buttonWidthDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
-    expect(sample.groupHeightDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
-    expect(sample.gridTopDrift).toBeLessThanOrEqual(MAX_LAYOUT_DRIFT_PX);
-    expect(sample.frameDelay).toBeLessThan(MAX_FRAME_DELAY_MS);
+async function columnIds(locator: Locator): Promise<string[]> {
+  const elements = await locator.all();
+  return Promise.all(
+    elements.map(
+      async (element) => (await element.getAttribute("data-column-id")) ?? ""
+    )
+  );
+}
+
+async function expectColumnIds(
+  locator: Locator,
+  expectedColumnIds: readonly string[]
+) {
+  await expect(locator).toHaveCount(expectedColumnIds.length);
+
+  for (const [index, columnId] of expectedColumnIds.entries()) {
+    await expect(locator.nth(index)).toHaveAttribute(
+      "data-column-id",
+      columnId
+    );
+  }
+}
+
+async function pressedState(
+  toolbar: Locator
+): Promise<Record<string, string | null>> {
+  const state: Record<string, string | null> = {};
+
+  for (const columnId of ALL_COLUMN_IDS) {
+    state[columnId] = await columnToggle(toolbar, columnId).getAttribute(
+      "aria-pressed"
+    );
   }
 
-  expect(Math.max(0, ...result.longTasks)).toBeLessThan(MAX_LONG_TASK_MS);
-  await expect(failedLoginsHeader).toHaveCount(0);
+  return state;
+}
 
-  const filterLifecycle = await preview.evaluate(async (previewElement) => {
-    const initialGridRoot = previewElement.querySelector<HTMLElement>(
-      ".InovuaReactDataGrid.tdg-root"
-    );
-    const group = previewElement.querySelector<HTMLElement>(
-      '[role="group"][aria-label="Visible column toggles"]'
-    );
-    const failedLoginsToggle = Array.from(
-      group?.querySelectorAll<HTMLButtonElement>("button") ?? []
-    ).find((element) => element.textContent?.trim() === "Failed logins");
+test.describe("external column visibility controls", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/examples/users");
+  });
 
-    if (!initialGridRoot || !failedLoginsToggle) {
-      return { error: "Grid root or visibility toggle was not found" } as const;
+  test("reflects the registered grid order and initial visibility", async ({
+    page,
+  }) => {
+    const preview = usersPreview(page);
+    const grid = usersGrid(preview);
+    const toolbar = visibilityToolbar(preview);
+    const group = toggleList(toolbar);
+    const toggles = group.locator('[data-slot="rdg-column-toggle"]');
+
+    await expect(preview).toBeVisible();
+    await expect(grid).toBeVisible();
+    await expect(toolbar).toBeVisible();
+    await expect(group).toHaveRole("group");
+    await expect(group).toHaveAccessibleName("Visible column toggles");
+    await expectColumnIds(toggles, ALL_COLUMN_IDS);
+
+    const initiallyVisible = new Set(INITIALLY_VISIBLE_COLUMN_IDS);
+    for (const columnId of ALL_COLUMN_IDS) {
+      const visible = initiallyVisible.has(
+        columnId as (typeof INITIALLY_VISIBLE_COLUMN_IDS)[number]
+      );
+      await expect(columnToggle(toolbar, columnId)).toHaveAttribute(
+        "aria-pressed",
+        String(visible)
+      );
+      await expect(columnHeader(grid, columnId)).toHaveCount(visible ? 1 : 0);
     }
 
-    let rootWasDisconnected = false;
-    const rootObserver = new MutationObserver(() => {
-      if (!initialGridRoot.isConnected) rootWasDisconnected = true;
-    });
-    rootObserver.observe(previewElement, { childList: true, subtree: true });
-
-    const nextFrame = () =>
-      new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    const findButton = (label: string) =>
-      Array.from(
-        previewElement.querySelectorAll<HTMLButtonElement>("button")
-      ).find((element) => element.textContent?.trim() === label);
-    const currentGridRoot = () =>
-      previewElement.querySelector<HTMLElement>(
-        ".InovuaReactDataGrid.tdg-root"
-      );
-    const failedLoginsIsVisible = () =>
-      Boolean(
-        currentGridRoot()?.querySelector(
-          '[data-slot="grid-header-cell"][data-column-id="failed_login_attempts"]'
-        )
-      );
-
-    failedLoginsToggle.click();
-    await nextFrame();
-    const afterColumnShow = {
-      sameRoot: currentGridRoot() === initialGridRoot,
-      columnVisible: failedLoginsIsVisible(),
-      pressed: failedLoginsToggle.getAttribute("aria-pressed"),
-    };
-
-    const hideFilters = findButton("Hide filters");
-    hideFilters?.click();
-    await nextFrame();
-    const afterFilterHide = {
-      sameRoot: currentGridRoot() === initialGridRoot,
-      columnVisible: failedLoginsIsVisible(),
-      filterCellCount:
-        currentGridRoot()?.querySelectorAll(".tdg-filter-cell").length ?? -1,
-    };
-
-    const showFilters = findButton("Show filters");
-    showFilters?.click();
-    await nextFrame();
-    const afterFilterShow = {
-      sameRoot: currentGridRoot() === initialGridRoot,
-      columnVisible: failedLoginsIsVisible(),
-      filterCellCount:
-        currentGridRoot()?.querySelectorAll(".tdg-filter-cell").length ?? -1,
-    };
-
-    rootObserver.disconnect();
-
-    return {
-      error: hideFilters && showFilters ? null : "Filter toggle was not found",
-      afterColumnShow,
-      afterFilterHide,
-      afterFilterShow,
-      rootWasDisconnected,
-    };
+    await expectColumnIds(
+      grid.locator('[data-slot="grid-header-cell"][data-column-id]'),
+      INITIALLY_VISIBLE_COLUMN_IDS
+    );
   });
 
-  expect(filterLifecycle.error).toBeNull();
-  if (filterLifecycle.error) return;
+  test("shows and hides columns independently with pointer input", async ({
+    page,
+  }) => {
+    const preview = usersPreview(page);
+    const grid = usersGrid(preview);
+    const toolbar = visibilityToolbar(preview);
+    const failedLoginsToggle = columnToggle(toolbar, "failed_login_attempts");
+    const emailToggle = columnToggle(toolbar, "csemail");
 
-  expect(filterLifecycle.afterColumnShow).toEqual({
-    sameRoot: true,
-    columnVisible: true,
-    pressed: "true",
-  });
-  expect(filterLifecycle.afterFilterHide).toEqual({
-    sameRoot: true,
-    columnVisible: true,
-    filterCellCount: 0,
-  });
-  expect(filterLifecycle.afterFilterShow.sameRoot).toBe(true);
-  expect(filterLifecycle.afterFilterShow.columnVisible).toBe(true);
-  expect(filterLifecycle.afterFilterShow.filterCellCount).toBeGreaterThan(0);
-  expect(filterLifecycle.rootWasDisconnected).toBe(false);
-  await expect(failedLoginsHeader).toBeVisible();
-  await expect(failedLoginsButton).toHaveAttribute("aria-pressed", "true");
+    await expect(failedLoginsToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(columnHeader(grid, "failed_login_attempts")).toHaveCount(0);
+    await expect(emailToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(columnHeader(grid, "csemail")).toBeVisible();
 
-  expect(runtimeFailures).toEqual([]);
-  expect(
-    Math.max(
-      initialIconCount,
-      ...result.samples.map((sample) => sample.iconCount)
-    )
-  ).toBe(0);
+    await failedLoginsToggle.click();
+
+    await expect(failedLoginsToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(columnHeader(grid, "failed_login_attempts")).toBeVisible();
+    await expect(
+      mountedColumnCells(grid, "failed_login_attempts").first()
+    ).toBeVisible();
+
+    await emailToggle.click();
+
+    await expect(emailToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(columnHeader(grid, "csemail")).toHaveCount(0);
+    await expect(mountedColumnCells(grid, "csemail")).toHaveCount(0);
+    await expect(failedLoginsToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(columnHeader(grid, "csrolename")).toBeVisible();
+
+    await emailToggle.click();
+    await failedLoginsToggle.click();
+
+    await expect(emailToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(columnHeader(grid, "csemail")).toBeVisible();
+    await expect(failedLoginsToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(columnHeader(grid, "failed_login_attempts")).toHaveCount(0);
+  });
+
+  test("supports native keyboard toggling and retains focus", async ({
+    page,
+  }) => {
+    const preview = usersPreview(page);
+    const grid = usersGrid(preview);
+    const toolbar = visibilityToolbar(preview);
+    const languageToggle = columnToggle(toolbar, "lang");
+
+    await expect(languageToggle).toHaveAccessibleName("Language");
+    await languageToggle.focus();
+    await expect(languageToggle).toBeFocused();
+
+    await languageToggle.press(" ");
+
+    await expect(languageToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(languageToggle).toBeFocused();
+    await expect(columnHeader(grid, "lang")).toBeVisible();
+    await expect(mountedColumnCells(grid, "lang").first()).toBeVisible();
+
+    await languageToggle.press("Enter");
+
+    await expect(languageToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(languageToggle).toBeFocused();
+    await expect(columnHeader(grid, "lang")).toHaveCount(0);
+    await expect(mountedColumnCells(grid, "lang")).toHaveCount(0);
+  });
+
+  test("keeps composed export and filter controls isolated from visibility", async ({
+    page,
+  }) => {
+    const preview = usersPreview(page);
+    const grid = usersGrid(preview);
+    const toolbar = visibilityToolbar(preview);
+    const group = toggleList(toolbar);
+    const actions = toolbar.locator(
+      '[data-slot="rdg-column-visibility-actions"]'
+    );
+    const initialPressedState = await pressedState(toolbar);
+    const initialHeaderIds = await columnIds(
+      grid.locator('[data-slot="grid-header-cell"][data-column-id]')
+    );
+
+    await expect(actions).toBeVisible();
+    await expect(actions.getByRole("button", { name: "Export" })).toBeVisible();
+    await expect(
+      actions.getByRole("button", { name: "Hide filters" })
+    ).toBeVisible();
+    await expect(group.getByRole("button", { name: "Export" })).toHaveCount(0);
+    await expect(
+      group.getByRole("button", { name: "Hide filters" })
+    ).toHaveCount(0);
+    await expect(grid.locator(".tdg-filter-cell").first()).toBeVisible();
+
+    await actions.getByRole("button", { name: "Hide filters" }).click();
+
+    await expect(grid.locator(".tdg-filter-cell")).toHaveCount(0);
+    await expect(
+      actions.getByRole("button", { name: "Show filters" })
+    ).toBeVisible();
+    expect(await pressedState(toolbar)).toEqual(initialPressedState);
+    expect(
+      await columnIds(
+        grid.locator('[data-slot="grid-header-cell"][data-column-id]')
+      )
+    ).toEqual(initialHeaderIds);
+
+    await actions.getByRole("button", { name: "Export" }).click();
+    await expect(
+      page.getByRole("menuitem", { name: "Export CSV" })
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByRole("menuitem", { name: "Export CSV" })
+    ).toHaveCount(0);
+    expect(await pressedState(toolbar)).toEqual(initialPressedState);
+
+    await actions.getByRole("button", { name: "Show filters" }).click();
+    await expect(grid.locator(".tdg-filter-cell").first()).toBeVisible();
+    expect(await pressedState(toolbar)).toEqual(initialPressedState);
+  });
+
+  test("never hides the final visible column", async ({ page }) => {
+    const preview = usersPreview(page);
+    const grid = usersGrid(preview);
+    const toolbar = visibilityToolbar(preview);
+    const survivorId = "csuserid";
+
+    for (const columnId of INITIALLY_VISIBLE_COLUMN_IDS) {
+      if (columnId === survivorId) continue;
+
+      const toggle = columnToggle(toolbar, columnId);
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-pressed", "false");
+      await expect(columnHeader(grid, columnId)).toHaveCount(0);
+    }
+
+    const survivor = columnToggle(toolbar, survivorId);
+    await expect(survivor).toHaveAttribute("aria-pressed", "true");
+    await expect(columnHeader(grid, survivorId)).toBeVisible();
+    await expect(survivor).toBeDisabled();
+    await expect(survivor).toHaveAttribute("aria-pressed", "true");
+    await expect(columnHeader(grid, survivorId)).toBeVisible();
+    await expect(
+      grid.locator('[data-slot="grid-header-cell"][data-column-id]')
+    ).toHaveCount(1);
+  });
+});
+
+test("an explicit nested target follows controlled order after a remount", async ({
+  page,
+}) => {
+  await page.goto("/compat/column-visibility");
+
+  const scope = page.getByTestId("column-visibility-nested-target");
+  const toolbar = visibilityToolbar(scope);
+  const grid = usersGrid(scope);
+  const toggles = toggleList(toolbar).locator(
+    '[data-slot="rdg-column-toggle"]'
+  );
+  const headers = grid.locator(
+    '[data-slot="grid-header-cell"][data-column-id]'
+  );
+
+  await expect(scope).toBeVisible();
+  await expect(toolbar).toBeVisible();
+  await expectColumnIds(toggles, ["id", "name", "city"]);
+  await expectColumnIds(headers, ["id", "name"]);
+  await expect(columnToggle(toolbar, "city")).toHaveAttribute(
+    "aria-pressed",
+    "false"
+  );
+
+  await page.getByTestId("column-visibility-reverse-order").click();
+
+  await expectColumnIds(toggles, ["city", "name", "id"]);
+  await expectColumnIds(headers, ["name", "id"]);
+
+  await page.getByTestId("column-visibility-remount-grid").click();
+
+  await expectColumnIds(toggles, ["city", "name", "id"]);
+  await expectColumnIds(headers, ["name", "id"]);
+  await expect(columnToggle(toolbar, "city")).toHaveAttribute(
+    "aria-pressed",
+    "false"
+  );
+
+  await columnToggle(toolbar, "city").click();
+
+  await expect(columnToggle(toolbar, "city")).toHaveAttribute(
+    "aria-pressed",
+    "true"
+  );
+  await expectColumnIds(headers, ["city", "name", "id"]);
+  await expect(mountedColumnCells(grid, "city").first()).toBeVisible();
+});
+
+test("auto-targets a direct grid and omits non-hideable columns", async ({
+  page,
+}) => {
+  await page.goto("/compat/column-visibility");
+
+  const scope = page.getByTestId("column-visibility-direct-target");
+  const toolbar = visibilityToolbar(scope);
+  const grid = usersGrid(scope);
+  const toggles = toggleList(toolbar).locator(
+    '[data-slot="rdg-column-toggle"]'
+  );
+  const optionalToggle = columnToggle(toolbar, "optional");
+
+  await expect(scope).toBeVisible();
+  await expect(toggles).toHaveCount(1);
+  expect(await columnIds(toggles)).toEqual(["optional"]);
+  await expect(columnToggle(toolbar, "locked")).toHaveCount(0);
+  await expect(columnHeader(grid, "locked")).toBeVisible();
+  await expect(columnHeader(grid, "optional")).toHaveCount(0);
+  await expect(optionalToggle).toBeEnabled();
+  await expect(optionalToggle).toHaveAttribute("aria-pressed", "false");
+
+  await optionalToggle.click();
+  await expect(optionalToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(columnHeader(grid, "optional")).toBeVisible();
+
+  await optionalToggle.click();
+  await expect(optionalToggle).toHaveAttribute("aria-pressed", "false");
+  await expect(columnHeader(grid, "optional")).toHaveCount(0);
+  await expect(columnHeader(grid, "locked")).toBeVisible();
 });

--- a/tests/published-types/consumer.ts
+++ b/tests/published-types/consumer.ts
@@ -19,6 +19,18 @@ import {
   type RDGColumnVisibilityTargetProps,
   type RDGColumnVisibilityToolbarProps,
 } from "@geovi/the-datagrid/column-visibility";
+import {
+  RDGColumnVisibilityProvider as ComponentsColumnVisibilityProvider,
+  RDGColumnVisibilityTarget as ComponentsColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar as ComponentsColumnVisibilityToolbar,
+  RDGProvider,
+  RDGSearchBar as ComponentsSearchBar,
+  RDGSearchProvider as ComponentsSearchProvider,
+  RDGSearchTarget as ComponentsSearchTarget,
+  RDGTarget,
+  type RDGProviderProps,
+  type RDGTargetProps,
+} from "@geovi/the-datagrid/components";
 import TextInput, {
   type TextInputClearButtonConfig,
   type TextInputProps,
@@ -64,6 +76,28 @@ export type PublishedColumnVisibilityToolbarProps = ComponentProps<
 >;
 export type PublishedColumnVisibilityTargetProps = ComponentProps<
   typeof RDGColumnVisibilityTarget
+>;
+export type PublishedComponentsProviderProps = ComponentProps<
+  typeof RDGProvider
+>;
+export type PublishedComponentsTargetProps = ComponentProps<typeof RDGTarget>;
+export type PublishedComponentsSearchBarProps = ComponentProps<
+  typeof ComponentsSearchBar
+>;
+export type PublishedComponentsSearchProviderProps = ComponentProps<
+  typeof ComponentsSearchProvider
+>;
+export type PublishedComponentsSearchTargetProps = ComponentProps<
+  typeof ComponentsSearchTarget
+>;
+export type PublishedComponentsColumnVisibilityProviderProps = ComponentProps<
+  typeof ComponentsColumnVisibilityProvider
+>;
+export type PublishedComponentsColumnVisibilityTargetProps = ComponentProps<
+  typeof ComponentsColumnVisibilityTarget
+>;
+export type PublishedComponentsColumnVisibilityToolbarProps = ComponentProps<
+  typeof ComponentsColumnVisibilityToolbar
 >;
 export type PublishedTextInputProps = ComponentProps<typeof TextInput>;
 export type PublishedRootTextInputProps = ComponentProps<typeof RootTextInput>;
@@ -141,4 +175,22 @@ export const publishedColumnVisibilityProviderProps = {
 export const publishedColumnVisibilityComposition = createElement(
   RDGColumnVisibilityProvider,
   publishedColumnVisibilityProviderProps
+);
+
+const publishedComponentsTargetProps = {
+  children: publishedGridElement,
+} satisfies RDGTargetProps;
+export const publishedComponentsProviderProps = {
+  defaultSearchValue: "Ada",
+  children: [
+    createElement(ComponentsSearchBar, { placeholder: "Search records" }),
+    createElement(ComponentsColumnVisibilityToolbar, {
+      children: createElement("button", { type: "button" }, "Export"),
+    }),
+    createElement(RDGTarget, publishedComponentsTargetProps),
+  ],
+} satisfies RDGProviderProps;
+export const publishedComponentsComposition = createElement(
+  RDGProvider,
+  publishedComponentsProviderProps
 );

--- a/tests/published-types/consumer.ts
+++ b/tests/published-types/consumer.ts
@@ -1,4 +1,7 @@
 import ReactDataGrid, {
+  TextInput as RootTextInput,
+  type TextInputClearButtonConfig as RootTextInputClearButtonConfig,
+  type TypeTextInputProps as RootTypeTextInputProps,
   type TypeColumns,
   type TypeDataGridProps,
   type TypeDataSourceArgs,
@@ -8,7 +11,20 @@ import {
   RDGSearchProvider,
   RDGSearchTarget,
 } from "@geovi/the-datagrid/search";
-import type { ComponentProps } from "react";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+  type RDGColumnVisibilityProviderProps,
+  type RDGColumnVisibilityTargetProps,
+  type RDGColumnVisibilityToolbarProps,
+} from "@geovi/the-datagrid/column-visibility";
+import TextInput, {
+  type TextInputClearButtonConfig,
+  type TextInputProps,
+  type TypeTextInputProps,
+} from "@geovi/the-datagrid/packages/TextInput";
+import { createElement, type ComponentProps } from "react";
 
 const columns: TypeColumns = [{ name: "id", searchable: true }];
 
@@ -16,6 +32,12 @@ export const gridProps = {
   idProperty: "id",
   columns,
   dataSource: [{ id: 1 }],
+  onDidMount(ref) {
+    const result: void | undefined = ref.current
+      ?.getVirtualList()
+      .adjustHeights();
+    void result;
+  },
 } satisfies TypeDataGridProps;
 
 export const remoteArgs: TypeDataSourceArgs = {
@@ -34,3 +56,89 @@ export type PublishedSearchProviderProps = ComponentProps<
   typeof RDGSearchProvider
 >;
 export type PublishedSearchTargetProps = ComponentProps<typeof RDGSearchTarget>;
+export type PublishedColumnVisibilityProviderProps = ComponentProps<
+  typeof RDGColumnVisibilityProvider
+>;
+export type PublishedColumnVisibilityToolbarProps = ComponentProps<
+  typeof RDGColumnVisibilityToolbar
+>;
+export type PublishedColumnVisibilityTargetProps = ComponentProps<
+  typeof RDGColumnVisibilityTarget
+>;
+export type PublishedTextInputProps = ComponentProps<typeof TextInput>;
+export type PublishedRootTextInputProps = ComponentProps<typeof RootTextInput>;
+
+export const textInputProps = {
+  acceptClearToolFocus: true,
+  clearButtonSize: [12, 14] as const,
+  defaultValue: "Ada",
+  inputProps: {
+    "aria-label": "Migration input",
+    "data-consumer-input": "true",
+    onChange(value) {
+      void value;
+    },
+  },
+  onChange(value, event) {
+    void value;
+    void event;
+  },
+  renderClearIcon({ fill, height, width }) {
+    void fill;
+    void height;
+    void width;
+    return null;
+  },
+  rootClassName: "legacy-text-input",
+  rtl: true,
+  stopChangePropagation: false,
+  theme: "blue-dark",
+} satisfies TextInputProps;
+
+export const aliasedTextInputProps: TypeTextInputProps = textInputProps;
+export const rootAliasedTextInputProps: RootTypeTextInputProps = textInputProps;
+
+export const legacyNullTextInputProps = {
+  defaultValue: 0,
+  inputProps: null,
+  stopChangePropagation: null,
+} satisfies TextInputProps;
+
+export declare const textInputInstance: InstanceType<typeof TextInput>;
+textInputInstance.focus();
+textInputInstance.setValue("Grace");
+const clearButtonConfig: TextInputClearButtonConfig = {
+  clearButtonClassName: "legacy-clear",
+  clearButtonColor: "currentColor",
+  clearButtonSize: [12, 14],
+};
+const rootClearButtonConfig: RootTextInputClearButtonConfig = clearButtonConfig;
+void rootClearButtonConfig;
+textInputInstance.renderClearButton(clearButtonConfig);
+
+const publishedGridElement = createElement(ReactDataGrid, gridProps);
+const publishedColumnVisibilityToolbarProps = {
+  ariaLabel: "Published column toggles",
+  children: createElement("button", { type: "button" }, "Export"),
+  description: "Choose visible columns.",
+  title: "Visible columns",
+} satisfies RDGColumnVisibilityToolbarProps;
+const publishedColumnVisibilityTargetProps = {
+  children: publishedGridElement,
+} satisfies RDGColumnVisibilityTargetProps;
+export const publishedColumnVisibilityProviderProps = {
+  children: [
+    createElement(
+      RDGColumnVisibilityToolbar,
+      publishedColumnVisibilityToolbarProps
+    ),
+    createElement(
+      RDGColumnVisibilityTarget,
+      publishedColumnVisibilityTargetProps
+    ),
+  ],
+} satisfies RDGColumnVisibilityProviderProps;
+export const publishedColumnVisibilityComposition = createElement(
+  RDGColumnVisibilityProvider,
+  publishedColumnVisibilityProviderProps
+);

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -11,6 +11,7 @@
       "@geovi/the-datagrid/column-visibility": [
         "./src/column-visibility/index.ts"
       ],
+      "@geovi/the-datagrid/components": ["./src/providers/index.ts"],
       "@geovi/the-datagrid/search": ["./src/search/index.ts"]
     }
   },

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -5,6 +5,12 @@
     "paths": {
       "@/*": ["./src/*"],
       "@geovi/the-datagrid": ["./src/main.ts"],
+      "@geovi/the-datagrid/packages/TextInput": [
+        "./src/packages/TextInput/index.tsx"
+      ],
+      "@geovi/the-datagrid/column-visibility": [
+        "./src/column-visibility/index.ts"
+      ],
       "@geovi/the-datagrid/search": ["./src/search/index.ts"]
     }
   },

--- a/tests/types/type-column-visibility-entry.ts
+++ b/tests/types/type-column-visibility-entry.ts
@@ -1,0 +1,83 @@
+import ReactDataGrid, {
+  type TypeColumns,
+  type TypeDataGridProps,
+} from "@geovi/the-datagrid";
+import * as ColumnVisibilityEntry from "@geovi/the-datagrid/column-visibility";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+  type RDGColumnVisibilityProviderProps,
+  type RDGColumnVisibilityTargetProps,
+  type RDGColumnVisibilityToolbarProps,
+} from "@geovi/the-datagrid/column-visibility";
+import { createElement, type ComponentProps } from "react";
+
+type AssertNever<T extends never> = T;
+
+type ColumnVisibilityRuntimeExport =
+  | "RDGColumnVisibilityProvider"
+  | "RDGColumnVisibilityTarget"
+  | "RDGColumnVisibilityToolbar";
+
+export type ColumnVisibilityEntryHasNoPublicInternals = AssertNever<
+  Exclude<keyof typeof ColumnVisibilityEntry, ColumnVisibilityRuntimeExport>
+>;
+
+export type ColumnVisibilityStaysOutsideCoreRuntime = AssertNever<
+  Extract<
+    ColumnVisibilityRuntimeExport,
+    keyof typeof import("@geovi/the-datagrid")
+  >
+>;
+
+export type InternalColumnVisibilityBridgeStaysPrivate = AssertNever<
+  Extract<"__rdgColumnVisibilityController", keyof TypeDataGridProps>
+>;
+
+const columns: TypeColumns = [
+  { name: "id", header: "ID", hideable: false },
+  { name: "name", header: "Name" },
+  { name: "city", header: "City", visible: false },
+];
+
+const gridProps = {
+  idProperty: "id",
+  columns,
+  dataSource: [{ id: 1, name: "Ada", city: "London" }],
+} satisfies TypeDataGridProps;
+
+const gridElement = createElement(ReactDataGrid, gridProps);
+
+export const columnVisibilityToolbarProps = {
+  ariaLabel: "Account column toggles",
+  children: createElement("button", { type: "button" }, "Export CSV"),
+  description: "Choose fields shown in this table.",
+  title: "Visible fields",
+} satisfies RDGColumnVisibilityToolbarProps;
+
+export const columnVisibilityTargetProps = {
+  children: gridElement,
+} satisfies RDGColumnVisibilityTargetProps;
+
+export const columnVisibilityProviderProps = {
+  children: [
+    createElement(RDGColumnVisibilityToolbar, columnVisibilityToolbarProps),
+    createElement(RDGColumnVisibilityTarget, columnVisibilityTargetProps),
+  ],
+} satisfies RDGColumnVisibilityProviderProps;
+
+export const columnVisibilityComposition = createElement(
+  RDGColumnVisibilityProvider,
+  columnVisibilityProviderProps
+);
+
+export type ColumnVisibilityProviderPropsAreExported = ComponentProps<
+  typeof RDGColumnVisibilityProvider
+>;
+export type ColumnVisibilityToolbarPropsAreExported = ComponentProps<
+  typeof RDGColumnVisibilityToolbar
+>;
+export type ColumnVisibilityTargetPropsAreExported = ComponentProps<
+  typeof RDGColumnVisibilityTarget
+>;

--- a/tests/types/type-components-entry.ts
+++ b/tests/types/type-components-entry.ts
@@ -1,0 +1,116 @@
+import ReactDataGrid, {
+  type TypeColumns,
+  type TypeDataGridProps,
+} from "@geovi/the-datagrid";
+import * as ComponentsEntry from "@geovi/the-datagrid/components";
+import {
+  RDGColumnVisibilityProvider,
+  RDGColumnVisibilityTarget,
+  RDGColumnVisibilityToolbar,
+  RDGProvider,
+  RDGSearchBar,
+  RDGSearchProvider,
+  RDGSearchTarget,
+  RDGTarget,
+  type RDGColumnVisibilityProviderProps,
+  type RDGColumnVisibilityTargetProps,
+  type RDGColumnVisibilityToolbarProps,
+  type RDGProviderProps,
+  type RDGSearchBarProps,
+  type RDGSearchProviderProps,
+  type RDGSearchTargetProps,
+  type RDGTargetProps,
+} from "@geovi/the-datagrid/components";
+import { createElement, type ComponentProps } from "react";
+
+type AssertNever<T extends never> = T;
+
+type ComponentsRuntimeExport =
+  | "RDGProvider"
+  | "RDGTarget"
+  | "RDGSearchBar"
+  | "RDGSearchProvider"
+  | "RDGSearchTarget"
+  | "RDGColumnVisibilityProvider"
+  | "RDGColumnVisibilityTarget"
+  | "RDGColumnVisibilityToolbar";
+
+export type ComponentsEntryHasNoPublicInternals = AssertNever<
+  Exclude<keyof typeof ComponentsEntry, ComponentsRuntimeExport>
+>;
+
+export type UnifiedComponentsStayOutsideCoreRuntime = AssertNever<
+  Extract<
+    "RDGProvider" | "RDGTarget",
+    keyof typeof import("@geovi/the-datagrid")
+  >
+>;
+
+const columns: TypeColumns = [
+  { name: "id", header: "ID", hideable: false },
+  { name: "name", header: "Name", searchable: true },
+  { name: "city", header: "City", visible: false },
+];
+
+const gridProps = {
+  idProperty: "id",
+  columns,
+  dataSource: [{ id: 1, name: "Ada", city: "London" }],
+} satisfies TypeDataGridProps;
+
+const gridElement = createElement(ReactDataGrid, gridProps);
+
+export const componentsTargetProps = {
+  children: gridElement,
+} satisfies RDGTargetProps;
+
+export const componentsProviderProps = {
+  defaultSearchValue: "Ada",
+  children: [
+    createElement(RDGSearchBar, { placeholder: "Search people" }),
+    createElement(RDGColumnVisibilityToolbar, {
+      children: createElement("button", { type: "button" }, "Export"),
+    }),
+    createElement(RDGTarget, componentsTargetProps),
+  ],
+} satisfies RDGProviderProps;
+
+export const componentsComposition = createElement(
+  RDGProvider,
+  componentsProviderProps
+);
+
+export type ComponentsProviderPropsAreExported = ComponentProps<
+  typeof RDGProvider
+>;
+export type ComponentsTargetPropsAreExported = ComponentProps<typeof RDGTarget>;
+export type ComponentsSearchBarPropsAreExported = ComponentProps<
+  typeof RDGSearchBar
+>;
+export type ComponentsSearchProviderPropsAreExported = ComponentProps<
+  typeof RDGSearchProvider
+>;
+export type ComponentsSearchTargetPropsAreExported = ComponentProps<
+  typeof RDGSearchTarget
+>;
+export type ComponentsColumnVisibilityProviderPropsAreExported = ComponentProps<
+  typeof RDGColumnVisibilityProvider
+>;
+export type ComponentsColumnVisibilityTargetPropsAreExported = ComponentProps<
+  typeof RDGColumnVisibilityTarget
+>;
+export type ComponentsColumnVisibilityToolbarPropsAreExported = ComponentProps<
+  typeof RDGColumnVisibilityToolbar
+>;
+
+export type ComponentsProviderPropsMatchExport = RDGProviderProps;
+export type ComponentsTargetPropsMatchExport = RDGTargetProps;
+export type ComponentsSearchBarPropsMatchExport = RDGSearchBarProps;
+export type ComponentsSearchProviderPropsMatchExport = RDGSearchProviderProps;
+export type ComponentsSearchTargetPropsMatchExport = RDGSearchTargetProps;
+export type ComponentsColumnVisibilityProviderPropsMatchExport =
+  RDGColumnVisibilityProviderProps;
+export type ComponentsColumnVisibilityTargetPropsMatchExport =
+  RDGColumnVisibilityTargetProps;
+export type ComponentsColumnVisibilityToolbarPropsMatchExport =
+  RDGColumnVisibilityToolbarProps;

--- a/tests/types/type-issue-48-grid-contract.ts
+++ b/tests/types/type-issue-48-grid-contract.ts
@@ -1,0 +1,31 @@
+import type * as React from "react";
+
+import type { TypeComputedProps, TypeDataGridProps } from "../../src/main";
+
+type ExpectedOnDidMount = (
+  computedPropsRef: React.MutableRefObject<TypeComputedProps | null>
+) => void;
+
+const onDidMount: ExpectedOnDidMount = (computedPropsRef) => {
+  const currentApi: TypeComputedProps | null = computedPropsRef.current;
+  currentApi?.reload();
+  currentApi?.getVirtualList().adjustHeights();
+};
+
+export const issue48LifecycleProps = {
+  idProperty: "id",
+  columns: [{ name: "name", header: "Name" }],
+  dataSource: [{ id: 1, name: "Ada Lovelace" }],
+  onDidMount,
+} satisfies TypeDataGridProps;
+
+export function exerciseIssue48VirtualListContract(
+  virtualList: ReturnType<TypeComputedProps["getVirtualList"]>
+): void {
+  const result: void = virtualList.adjustHeights();
+  void result;
+
+  // Inovua's adjustHeights method is an argument-free synchronous command.
+  // @ts-expect-error adjustHeights does not accept configuration arguments.
+  virtualList.adjustHeights({ force: true });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,6 +141,7 @@ function injectLibraryCssEntry() {
     "column-visibility.js": "column-visibility.css",
     "packages/TextInput/index.js": "packages/TextInput/style.css",
   };
+  const clientEntriesWithoutCss = new Set(["components.js"]);
 
   return {
     name: "inject-library-css-entry",
@@ -151,7 +152,22 @@ function injectLibraryCssEntry() {
         if (item?.type !== "chunk" || item.isEntry !== true) continue;
 
         const cssFileName = cssEntryByJsEntry[item.fileName];
-        if (!cssFileName || bundle[cssFileName]?.type !== "asset") continue;
+        const hasCssAsset =
+          cssFileName != null && bundle[cssFileName]?.type === "asset";
+        if (!hasCssAsset && !clientEntriesWithoutCss.has(item.fileName)) {
+          continue;
+        }
+
+        if (typeof item.code !== "string") continue;
+        const withoutClientDirective = item.code.replace(
+          /^\s*["']use client["'];\s*/,
+          ""
+        );
+
+        if (!hasCssAsset || !cssFileName) {
+          item.code = `"use client";\n${withoutClientDirective}`;
+          continue;
+        }
 
         const relativeCssPath = path.posix.relative(
           path.posix.dirname(item.fileName),
@@ -162,12 +178,6 @@ function injectLibraryCssEntry() {
             ? relativeCssPath
             : `./${relativeCssPath}`
         }";`;
-        if (typeof item.code !== "string") continue;
-
-        const withoutClientDirective = item.code.replace(
-          /^\s*["']use client["'];\s*/,
-          ""
-        );
         const withoutInjectedCss = withoutClientDirective.replace(
           new RegExp(
             `^${cssImport.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*`
@@ -241,11 +251,14 @@ export default defineConfig(({ command, mode }) => {
   const isSearchLibraryBuild = command === "build" && mode === "library-search";
   const isColumnVisibilityLibraryBuild =
     command === "build" && mode === "library-column-visibility";
+  const isComponentsLibraryBuild =
+    command === "build" && mode === "library-components";
   const isTextInputLibraryBuild =
     command === "build" && mode === "library-text-input";
   const isSupplementalLibraryBuild =
     isSearchLibraryBuild ||
     isColumnVisibilityLibraryBuild ||
+    isComponentsLibraryBuild ||
     isTextInputLibraryBuild;
   const isCoreDependentSupplementalBuild =
     isSearchLibraryBuild || isColumnVisibilityLibraryBuild;
@@ -278,24 +291,35 @@ export default defineConfig(({ command, mode }) => {
     ? "search"
     : isColumnVisibilityLibraryBuild
       ? "column-visibility"
-      : isTextInputLibraryBuild
-        ? "packages/TextInput/index"
-        : "index";
+      : isComponentsLibraryBuild
+        ? "components"
+        : isTextInputLibraryBuild
+          ? "packages/TextInput/index"
+          : "index";
   const coreLibraryEntry = fileURLToPath(
     new URL("./src/main.ts", import.meta.url)
   );
   const coreLibraryModuleId = coreLibraryEntry.replace(/\.ts$/, "");
+  const searchLibraryEntry = fileURLToPath(
+    new URL("./src/search/index.ts", import.meta.url)
+  );
+  const columnVisibilityLibraryEntry = fileURLToPath(
+    new URL("./src/column-visibility/index.ts", import.meta.url)
+  );
+  const componentsLibraryEntry = fileURLToPath(
+    new URL("./src/providers/index.ts", import.meta.url)
+  );
   const libraryEntry = isSearchLibraryBuild
-    ? fileURLToPath(new URL("./src/search/index.ts", import.meta.url))
+    ? searchLibraryEntry
     : isColumnVisibilityLibraryBuild
-      ? fileURLToPath(
-          new URL("./src/column-visibility/index.ts", import.meta.url)
-        )
-      : isTextInputLibraryBuild
-        ? fileURLToPath(
-            new URL("./src/packages/TextInput/index.tsx", import.meta.url)
-          )
-        : coreLibraryEntry;
+      ? columnVisibilityLibraryEntry
+      : isComponentsLibraryBuild
+        ? componentsLibraryEntry
+        : isTextInputLibraryBuild
+          ? fileURLToPath(
+              new URL("./src/packages/TextInput/index.tsx", import.meta.url)
+            )
+          : coreLibraryEntry;
   const externalDependencies = new Set([
     "react",
     "react-dom",
@@ -307,10 +331,28 @@ export default defineConfig(({ command, mode }) => {
     "@radix-ui/react-select",
     "@radix-ui/react-label",
   ]);
+  const componentsSearchEntryIds = new Set([
+    "../search",
+    "../search/index",
+    "../search/index.js",
+    "../search/index.ts",
+    searchLibraryEntry,
+    searchLibraryEntry.replace(/\.ts$/, ""),
+  ]);
+  const componentsColumnVisibilityEntryIds = new Set([
+    "../column-visibility",
+    "../column-visibility/index",
+    "../column-visibility/index.js",
+    "../column-visibility/index.ts",
+    columnVisibilityLibraryEntry,
+    columnVisibilityLibraryEntry.replace(/\.ts$/, ""),
+  ]);
 
   // Build core, optional UI entries, and the legacy TextInput path
   // independently. Search and column visibility externalize the already
-  // required core runtime; TextInput stays standalone.
+  // required core runtime. Components composes those exact optional module
+  // instances instead of bundling duplicate provider contexts. TextInput stays
+  // standalone.
   return {
     plugins: [
       react(),
@@ -348,16 +390,32 @@ export default defineConfig(({ command, mode }) => {
         external: (id) =>
           externalDependencies.has(id) ||
           (isCoreDependentSupplementalBuild &&
-            (id === "../main" || id === coreLibraryEntry)),
+            (id === "../main" || id === coreLibraryEntry)) ||
+          (isComponentsLibraryBuild &&
+            (componentsSearchEntryIds.has(id) ||
+              componentsColumnVisibilityEntryIds.has(id))),
         output: {
           inlineDynamicImports: true,
-          paths: (id) =>
-            isCoreDependentSupplementalBuild &&
-            (id === "../main" ||
-              id === coreLibraryEntry ||
-              id === coreLibraryModuleId)
-              ? "./index.js"
-              : id,
+          paths: (id) => {
+            if (
+              isCoreDependentSupplementalBuild &&
+              (id === "../main" ||
+                id === coreLibraryEntry ||
+                id === coreLibraryModuleId)
+            ) {
+              return "./index.js";
+            }
+            if (isComponentsLibraryBuild && componentsSearchEntryIds.has(id)) {
+              return "./search.js";
+            }
+            if (
+              isComponentsLibraryBuild &&
+              componentsColumnVisibilityEntryIds.has(id)
+            ) {
+              return "./column-visibility.js";
+            }
+            return id;
+          },
           preserveModules: false,
         },
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,6 +138,8 @@ function injectLibraryCssEntry() {
   const cssEntryByJsEntry: Record<string, string> = {
     "index.js": "index.css",
     "search.js": "search.css",
+    "column-visibility.js": "column-visibility.css",
+    "packages/TextInput/index.js": "packages/TextInput/style.css",
   };
 
   return {
@@ -151,7 +153,15 @@ function injectLibraryCssEntry() {
         const cssFileName = cssEntryByJsEntry[item.fileName];
         if (!cssFileName || bundle[cssFileName]?.type !== "asset") continue;
 
-        const cssImport = `import "./${cssFileName}";`;
+        const relativeCssPath = path.posix.relative(
+          path.posix.dirname(item.fileName),
+          cssFileName
+        );
+        const cssImport = `import "${
+          relativeCssPath.startsWith(".")
+            ? relativeCssPath
+            : `./${relativeCssPath}`
+        }";`;
         if (typeof item.code !== "string") continue;
 
         const withoutClientDirective = item.code.replace(
@@ -189,27 +199,35 @@ function scopeLibraryCssBundle() {
         const scopeSelector =
           cssAsset.fileName === "search.css"
             ? ".tdg-search-root"
-            : DATAGRID_SCOPE_SELECTOR;
+            : cssAsset.fileName === "column-visibility.css"
+              ? ".tdg-column-visibility-root"
+              : DATAGRID_SCOPE_SELECTOR;
         cssAsset.source = scopeLibraryCss(source, scopeSelector);
       }
     },
   };
 }
 
-function scopeSearchCssForSite() {
-  const searchStyleSuffix = "/src/search/style.css";
+function scopeOptionalCssForSite() {
+  const optionalStyleScopes = new Map([
+    ["/src/search/style.css", ".tdg-search-root"],
+    ["/src/column-visibility/style.css", ".tdg-column-visibility-root"],
+  ]);
 
   return {
-    name: "scope-search-css-for-site",
+    name: "scope-optional-css-for-site",
     // Tailwind's generator is also `pre`; placing this plugin after it scopes
     // the generated CSS before Vite turns the stylesheet into a JS module.
     enforce: "pre" as const,
     transform(code: string, id: string) {
       const cleanId = id.split("?", 1)[0].replaceAll("\\", "/");
-      if (!cleanId.endsWith(searchStyleSuffix)) return null;
+      const scopeEntry = Array.from(optionalStyleScopes.entries()).find(
+        ([styleSuffix]) => cleanId.endsWith(styleSuffix)
+      );
+      if (!scopeEntry) return null;
 
       return {
-        code: scopeLibraryCss(code, ".tdg-search-root"),
+        code: scopeLibraryCss(code, scopeEntry[1]),
         map: null,
       };
     },
@@ -221,6 +239,16 @@ export default defineConfig(({ command, mode }) => {
   const isDev = command === "serve";
   const isSiteBuild = command === "build" && mode === "site";
   const isSearchLibraryBuild = command === "build" && mode === "library-search";
+  const isColumnVisibilityLibraryBuild =
+    command === "build" && mode === "library-column-visibility";
+  const isTextInputLibraryBuild =
+    command === "build" && mode === "library-text-input";
+  const isSupplementalLibraryBuild =
+    isSearchLibraryBuild ||
+    isColumnVisibilityLibraryBuild ||
+    isTextInputLibraryBuild;
+  const isCoreDependentSupplementalBuild =
+    isSearchLibraryBuild || isColumnVisibilityLibraryBuild;
   const resolveAlias = {
     "@": path.resolve(__dirname, "./src"),
   };
@@ -231,7 +259,7 @@ export default defineConfig(({ command, mode }) => {
   // In site mode, build the same app for GitHub Pages.
   if (isDev || isSiteBuild) {
     return {
-      plugins: [react(), tailwindcss(), scopeSearchCssForSite()],
+      plugins: [react(), tailwindcss(), scopeOptionalCssForSite()],
       resolve: {
         alias: resolveAlias,
       },
@@ -246,14 +274,28 @@ export default defineConfig(({ command, mode }) => {
     };
   }
 
-  const libraryEntryName = isSearchLibraryBuild ? "search" : "index";
+  const libraryEntryName = isSearchLibraryBuild
+    ? "search"
+    : isColumnVisibilityLibraryBuild
+      ? "column-visibility"
+      : isTextInputLibraryBuild
+        ? "packages/TextInput/index"
+        : "index";
   const coreLibraryEntry = fileURLToPath(
     new URL("./src/main.ts", import.meta.url)
   );
   const coreLibraryModuleId = coreLibraryEntry.replace(/\.ts$/, "");
   const libraryEntry = isSearchLibraryBuild
     ? fileURLToPath(new URL("./src/search/index.ts", import.meta.url))
-    : coreLibraryEntry;
+    : isColumnVisibilityLibraryBuild
+      ? fileURLToPath(
+          new URL("./src/column-visibility/index.ts", import.meta.url)
+        )
+      : isTextInputLibraryBuild
+        ? fileURLToPath(
+            new URL("./src/packages/TextInput/index.tsx", import.meta.url)
+          )
+        : coreLibraryEntry;
   const externalDependencies = new Set([
     "react",
     "react-dom",
@@ -266,14 +308,14 @@ export default defineConfig(({ command, mode }) => {
     "@radix-ui/react-label",
   ]);
 
-  // Build core and search independently. Search externalizes the already
-  // required core entry, giving it one shared component/engine at runtime
-  // without extracting a chunk that plain core consumers would need to fetch.
+  // Build core, optional UI entries, and the legacy TextInput path
+  // independently. Search and column visibility externalize the already
+  // required core runtime; TextInput stays standalone.
   return {
     plugins: [
       react(),
       tailwindcss(),
-      ...(isSearchLibraryBuild
+      ...(isSupplementalLibraryBuild
         ? []
         : [
             dts({
@@ -290,25 +332,27 @@ export default defineConfig(({ command, mode }) => {
     },
     build: {
       copyPublicDir: false,
-      cssCodeSplit: true,
-      emptyOutDir: !isSearchLibraryBuild,
+      cssCodeSplit: !isTextInputLibraryBuild,
+      emptyOutDir: !isSupplementalLibraryBuild,
       lib: {
         entry: {
           [libraryEntryName]: libraryEntry,
         },
         formats: ["es"],
         fileName: (_format, entryName) => `${entryName}.js`,
-        cssFileName: libraryEntryName,
+        cssFileName: isTextInputLibraryBuild
+          ? "packages/TextInput/style"
+          : libraryEntryName,
       },
       rollupOptions: {
         external: (id) =>
           externalDependencies.has(id) ||
-          (isSearchLibraryBuild &&
+          (isCoreDependentSupplementalBuild &&
             (id === "../main" || id === coreLibraryEntry)),
         output: {
           inlineDynamicImports: true,
           paths: (id) =>
-            isSearchLibraryBuild &&
+            isCoreDependentSupplementalBuild &&
             (id === "../main" ||
               id === coreLibraryEntry ||
               id === coreLibraryModuleId)


### PR DESCRIPTION
## Summary

- add optional `@geovi/the-datagrid/column-visibility` controls and the unified `@geovi/the-datagrid/components` entry
- add `RDGProvider` / `RDGTarget` so Search and Column Visibility safely control the same grid
- preserve `RDGSearchProvider`, `RDGSearchTarget`, `RDGColumnVisibilityProvider`, and `RDGColumnVisibilityTarget` as supported APIs
- reuse the existing optional runtimes and styles so mixed imports share singleton contexts without duplicate CSS
- rework the Users example and add direct, nested, mobile, mixed-import, and published-package E2E coverage
- document provider requirements, one-grid scoping, initial visibility, remount behavior, and accessibility semantics
- complete the audited Issue 48 compatibility batch: standalone TextInput, onDidMount, and virtual-list height adjustment
- set the package version to 0.0.9

## Review fixes applied

Independent review found and resolved:

- Search and Column Visibility targets could not previously compose on one grid
- mobile mode exposed a conflicting second column-visibility picker
- the visibility toolbar callback changed during unrelated layout updates
- target validation accepted unmarked grid-shaped wrappers
- toolbar heading/description semantics and several E2E locators were too weak
- copied independent-provider layout markup did not create real DOM scope wrappers

## Validation

- `yarn test:types`
- `yarn build` including packed NodeNext and Node10 consumers and all bundle boundaries
- `yarn build:site`
- focused provider/published/docs/Users E2E: 13/13
- full E2E: 196 passed; three unrelated high-concurrency geometry/memory checks failed and then passed 3/3 in a serial rerun
- targeted ESLint for all new provider, packaging, fixture, and E2E paths
- `git diff --check`
- `npm pack --dry-run --json` confirms version 0.0.9 and the components artifacts

GitHub CI validated the final pushed commit: source types, packed build/types, and the full E2E job are green.