### PR TITLE
test(e2e): audit every GitHub issue

### DIFF
--- a/examples/src/DefaultPropsCompatPage.tsx
+++ b/examples/src/DefaultPropsCompatPage.tsx
@@ -1,10 +1,22 @@
 import * as React from "react";
 
-import ReactDataGrid, { type TypeColumns } from "../../src/main";
+import ReactDataGrid, {
+  filterTypes,
+  type CellProps,
+  type TypeColumns,
+  type TypeFilterTypes,
+} from "../../src/main";
+
+const exportedFilterTypes: TypeFilterTypes = filterTypes;
 
 const columns: TypeColumns = [
   { name: "id", header: "ID", defaultWidth: 72 },
-  { name: "name", header: "Name", defaultWidth: 180 },
+  {
+    name: "name",
+    header: "Name",
+    defaultWidth: 180,
+    render: (cellProps: CellProps) => String(cellProps.value ?? ""),
+  },
   { name: "team", header: "Team", defaultWidth: 160 },
 ];
 
@@ -103,6 +115,19 @@ export default function DefaultPropsCompatPage() {
             data-testid="default-props-filtered-count"
           >
             {filteredCount}
+          </div>
+        </div>
+        <div className="rounded-md border bg-background p-3">
+          <div className="text-xs font-medium uppercase text-muted-foreground">
+            issue #21 exports
+          </div>
+          <div
+            className="mt-2 break-all font-mono text-sm"
+            data-testid="issue-21-runtime-exports"
+          >
+            {`${exportedFilterTypes.string.type}:${exportedFilterTypes.string.operators
+              .map((operator) => operator.name)
+              .join(",")}`}
           </div>
         </div>
       </section>

--- a/examples/src/GitHubIssues31And32CompatPage.tsx
+++ b/examples/src/GitHubIssues31And32CompatPage.tsx
@@ -22,6 +22,37 @@ const defaultRows = [
   { id: "row-2", name: "Grace Hopper" },
 ];
 
+const activeNameFilter = [
+  {
+    name: "name",
+    type: "string",
+    operator: "contains",
+    value: "Ada",
+  },
+];
+
+const inactiveNameFilter = [
+  {
+    ...activeNameFilter[0],
+    active: false,
+  },
+];
+
+const cyrillicGlyphFilter = [
+  {
+    ...activeNameFilter[0],
+    value: "ЙЁЩЦДЪ gjpqy",
+  },
+];
+
+const glyphRows = [
+  { id: "latin", name: "ÁÉÍÓÚ ÂĂÅÇÑ ĞŐŰÝ gjpqy" },
+  {
+    id: "cyrillic",
+    name: "ЙЁЩЦДЪ ФЫВАПРОЛДЖЭ ЯЧСМИТЬБЮ йцурфдщ",
+  },
+];
+
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -36,8 +67,29 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
+function Issue31FilterGrid({
+  testId,
+  ...filterProps
+}: { testId: string } & Record<string, unknown>) {
+  return (
+    <div className="h-[180px] min-h-0 rounded-lg border" data-testid={testId}>
+      <UntypedReactDataGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={defaultRows}
+        virtualized={false}
+        {...filterProps}
+      />
+    </div>
+  );
+}
+
 function Issue31Probe() {
-  const [rootClicks, setRootClicks] = React.useState(0);
+  const [rootLifecycle, setRootLifecycle] = React.useState({
+    focus: 0,
+    blur: 0,
+    keyDown: [] as string[],
+  });
   const defaults = ReactDataGrid.defaultProps as Record<string, unknown>;
   const observedDefaults = {
     idProperty: defaults.idProperty ?? null,
@@ -46,6 +98,7 @@ function Issue31Probe() {
     filterRowHeight: defaults.filterRowHeight ?? null,
     enableColumnFilterContextMenu:
       defaults.enableColumnFilterContextMenu ?? null,
+    enableFiltering: defaults.enableFiltering ?? null,
     columnUserSelect: defaults.columnUserSelect ?? null,
     showColumnMenuTool: defaults.showColumnMenuTool ?? null,
   };
@@ -55,7 +108,9 @@ function Issue31Probe() {
       <output data-testid="issue-31-default-props">
         {JSON.stringify(observedDefaults)}
       </output>
-      <output data-testid="issue-31-root-clicks">{rootClicks}</output>
+      <output data-testid="issue-31-root-lifecycle">
+        {JSON.stringify(rootLifecycle)}
+      </output>
 
       <div
         className="h-[260px] min-h-0 rounded-lg border"
@@ -65,10 +120,32 @@ function Issue31Probe() {
           columns={columns}
           dataSource={defaultRows}
           virtualized={false}
-          data-host-attribute="forwarded"
-          onClick={() => setRootClicks((current) => current + 1)}
+          className="issue-31-consumer-root"
+          style={{ scrollMarginTop: "13px" }}
+          onFocus={() =>
+            setRootLifecycle((current) => ({
+              ...current,
+              focus: current.focus + 1,
+            }))
+          }
+          onBlur={() =>
+            setRootLifecycle((current) => ({
+              ...current,
+              blur: current.blur + 1,
+            }))
+          }
+          onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) =>
+            setRootLifecycle((current) => ({
+              ...current,
+              keyDown: [...current.keyDown, event.key],
+            }))
+          }
         />
       </div>
+
+      <button type="button" data-testid="issue-31-lifecycle-focus-sink">
+        Move focus outside the grid
+      </button>
 
       <div
         className="h-[260px] min-h-0 rounded-lg border"
@@ -77,14 +154,72 @@ function Issue31Probe() {
         <UntypedReactDataGrid
           columns={columns}
           dataSource={defaultRows}
-          defaultFilterValue={[
-            {
-              name: "name",
-              type: "string",
-              operator: "contains",
-              value: "",
-            },
-          ]}
+          defaultFilterValue={activeNameFilter}
+          virtualized={false}
+        />
+      </div>
+
+      <section
+        className="grid gap-4 lg:grid-cols-2"
+        data-testid="issue-31-filter-precedence"
+      >
+        <Issue31FilterGrid testId="issue-31-filter-omitted" />
+        <Issue31FilterGrid
+          testId="issue-31-filter-default-active"
+          defaultFilterValue={activeNameFilter}
+        />
+        <Issue31FilterGrid
+          testId="issue-31-filter-controlled"
+          filterValue={activeNameFilter}
+        />
+        <Issue31FilterGrid
+          testId="issue-31-filter-explicit-true"
+          enableFiltering
+        />
+        <Issue31FilterGrid
+          testId="issue-31-filter-explicit-false-default"
+          enableFiltering={false}
+          defaultFilterValue={activeNameFilter}
+        />
+        <Issue31FilterGrid
+          testId="issue-31-filter-explicit-false-controlled"
+          enableFiltering={false}
+          filterValue={activeNameFilter}
+        />
+        <Issue31FilterGrid
+          testId="issue-31-filter-empty-default"
+          defaultFilterValue={[]}
+        />
+        <Issue31FilterGrid
+          testId="issue-31-filter-inactive-default"
+          defaultFilterValue={inactiveNameFilter}
+        />
+      </section>
+
+      <div
+        className="h-[180px] min-h-0 rounded-lg border"
+        data-testid="issue-31-40px-glyph-grid-shell"
+      >
+        <UntypedReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={glyphRows}
+          rowHeight={40}
+          virtualized={false}
+        />
+      </div>
+
+      <div
+        className="h-[180px] min-h-0 rounded-lg border"
+        data-testid="issue-31-40px-filter-glyph-grid-shell"
+      >
+        <UntypedReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={glyphRows}
+          defaultFilterValue={cyrillicGlyphFilter}
+          filterRowHeight={40}
+          rowHeight={40}
           virtualized={false}
         />
       </div>

--- a/examples/src/GitHubIssues31And32CompatPage.tsx
+++ b/examples/src/GitHubIssues31And32CompatPage.tsx
@@ -1,0 +1,183 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  type TypeColumns,
+  type TypeDataGridProps,
+} from "../../src/main";
+import { Button } from "../../src/components/ui/button";
+
+type UntypedGridProps = TypeDataGridProps & Record<string, unknown>;
+
+const UntypedReactDataGrid = ReactDataGrid as React.ComponentType<
+  Partial<UntypedGridProps>
+>;
+
+const columns: TypeColumns = [
+  { name: "id", header: "ID", width: 100 },
+  { name: "name", header: "Name", width: 220, filterable: true },
+];
+
+const defaultRows = [
+  { id: "row-1", name: "Ada Lovelace" },
+  { id: "row-2", name: "Grace Hopper" },
+];
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+function Issue31Probe() {
+  const [rootClicks, setRootClicks] = React.useState(0);
+  const defaults = ReactDataGrid.defaultProps as Record<string, unknown>;
+  const observedDefaults = {
+    idProperty: defaults.idProperty ?? null,
+    theme: defaults.theme ?? null,
+    rowHeight: defaults.rowHeight ?? null,
+    filterRowHeight: defaults.filterRowHeight ?? null,
+    enableColumnFilterContextMenu:
+      defaults.enableColumnFilterContextMenu ?? null,
+    columnUserSelect: defaults.columnUserSelect ?? null,
+    showColumnMenuTool: defaults.showColumnMenuTool ?? null,
+  };
+
+  return (
+    <section className="space-y-4" data-testid="github-issue-31-probe">
+      <output data-testid="issue-31-default-props">
+        {JSON.stringify(observedDefaults)}
+      </output>
+      <output data-testid="issue-31-root-clicks">{rootClicks}</output>
+
+      <div
+        className="h-[260px] min-h-0 rounded-lg border"
+        data-testid="issue-31-default-grid-shell"
+      >
+        <UntypedReactDataGrid
+          columns={columns}
+          dataSource={defaultRows}
+          virtualized={false}
+          data-host-attribute="forwarded"
+          onClick={() => setRootClicks((current) => current + 1)}
+        />
+      </div>
+
+      <div
+        className="h-[260px] min-h-0 rounded-lg border"
+        data-testid="issue-31-inferred-filter-grid-shell"
+      >
+        <UntypedReactDataGrid
+          columns={columns}
+          dataSource={defaultRows}
+          defaultFilterValue={[
+            {
+              name: "name",
+              type: "string",
+              operator: "contains",
+              value: "",
+            },
+          ]}
+          virtualized={false}
+        />
+      </div>
+    </section>
+  );
+}
+
+type Issue32Result = {
+  data: Array<{ id: string; name: string }>;
+  count: number;
+};
+
+function Issue32Probe() {
+  const [deferred] = React.useState(() => createDeferred<Issue32Result>());
+  const [loadingEvents, setLoadingEvents] = React.useState<boolean[]>([]);
+  const resolvePage = React.useCallback(() => {
+    deferred.resolve({
+      data: [
+        { id: "remote-3", name: "Remote row 3" },
+        { id: "remote-4", name: "Remote row 4" },
+      ],
+      count: 6,
+    });
+  }, [deferred]);
+  const handleLoadingChange = React.useCallback((loading: boolean) => {
+    setLoadingEvents((current) => [...current, loading]);
+  }, []);
+
+  return (
+    <section className="space-y-4" data-testid="github-issue-32-probe">
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          data-testid="issue-32-resolve-static-promise"
+          onClick={resolvePage}
+        >
+          Resolve static Promise page
+        </Button>
+        <output data-testid="issue-32-loading-events">
+          {JSON.stringify(loadingEvents)}
+        </output>
+      </div>
+
+      <div
+        className="h-[320px] min-h-0 rounded-lg border"
+        data-testid="issue-32-grid-shell"
+      >
+        <UntypedReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={deferred.promise}
+          pagination
+          skip={2}
+          limit={2}
+          virtualized={false}
+          loadingText="Fetching issue 32 rows"
+          onLoadingChange={handleLoadingChange}
+          renderLoadMask={(loadMaskProps: {
+            visible: boolean;
+            loadingText: React.ReactNode | (() => React.ReactNode);
+          }) => {
+            if (!loadMaskProps.visible) return null;
+            const loadingText =
+              typeof loadMaskProps.loadingText === "function"
+                ? loadMaskProps.loadingText()
+                : loadMaskProps.loadingText;
+
+            return (
+              <div data-testid="issue-32-custom-load-mask">{loadingText}</div>
+            );
+          }}
+          renderPaginationToolbar={() => (
+            <div data-testid="issue-32-custom-pagination-toolbar">
+              Custom pagination toolbar
+            </div>
+          )}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default function GitHubIssues31And32CompatPage() {
+  return (
+    <main className="flex flex-col gap-8 p-6">
+      <header className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          GitHub compatibility contracts
+        </p>
+        <h1 className="text-2xl font-semibold">Issues #31 and #32</h1>
+      </header>
+      <Issue31Probe />
+      <Issue32Probe />
+    </main>
+  );
+}

--- a/examples/src/GitHubIssues31And32CompatPage.tsx
+++ b/examples/src/GitHubIssues31And32CompatPage.tsx
@@ -121,7 +121,11 @@ function Issue31Probe() {
           dataSource={defaultRows}
           virtualized={false}
           className="issue-31-consumer-root"
-          style={{ scrollMarginTop: "13px" }}
+          style={{
+            height: "211px",
+            width: "calc(100% - 17px)",
+            scrollMarginTop: "13px",
+          }}
           onFocus={() =>
             setRootLifecycle((current) => ({
               ...current,

--- a/examples/src/GitHubIssues33To48CompatPage.tsx
+++ b/examples/src/GitHubIssues33To48CompatPage.tsx
@@ -1,0 +1,727 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  plugins,
+  type TypeColumns,
+  type TypeComputedProps,
+  type TypeDataGridProps,
+  type TypeFilterValue,
+  type TypeSortInfo,
+} from "../../src/main";
+import packageManifest from "../../package.json";
+
+type AuditedIssue =
+  | "33"
+  | "34"
+  | "35"
+  | "36"
+  | "37"
+  | "38"
+  | "39"
+  | "40"
+  | "41"
+  | "42"
+  | "43"
+  | "44"
+  | "45";
+
+type CompatibilityGridProps = TypeDataGridProps & Record<string, unknown>;
+
+const CompatibilityGrid =
+  ReactDataGrid as React.ComponentType<CompatibilityGridProps>;
+
+const auditedIssues = new Set<AuditedIssue>([
+  "33",
+  "34",
+  "35",
+  "36",
+  "37",
+  "38",
+  "39",
+  "40",
+  "41",
+  "42",
+  "43",
+  "44",
+  "45",
+]);
+
+const baseRows = [
+  { id: "row-1", name: "Ada Lovelace", city: "London" },
+  { id: "row-2", name: "Grace Hopper", city: "New York" },
+  { id: "row-3", name: "Katherine Johnson", city: "White Sulphur Springs" },
+];
+
+const baseColumns: TypeColumns = [
+  { name: "id", header: "ID", width: 110 },
+  { name: "name", header: "Name", width: 220 },
+  { name: "city", header: "City", width: 220 },
+];
+
+function readIssue(): AuditedIssue {
+  if (typeof window === "undefined") return "33";
+
+  const issue = new URLSearchParams(window.location.search).get("issue");
+  return auditedIssues.has(issue as AuditedIssue)
+    ? (issue as AuditedIssue)
+    : "33";
+}
+
+function GridFrame(props: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={`h-[280px] w-[620px] max-w-full min-w-0 overflow-hidden rounded-xl border bg-background ${props.className ?? ""}`}
+      data-testid="issue-grid-frame"
+    >
+      {props.children}
+    </div>
+  );
+}
+
+function Issue33ControlledSort() {
+  const rows = React.useMemo(
+    () => [
+      { id: "sort-z", name: "Zed" },
+      { id: "sort-a", name: "Ada" },
+    ],
+    []
+  );
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 120 },
+      { name: "name", header: "Name", width: 220 },
+    ],
+    []
+  );
+  const controlledSort = React.useMemo<TypeSortInfo>(
+    () => ({ name: "name", dir: 1 }),
+    []
+  );
+  const [events, setEvents] = React.useState<TypeSortInfo[]>([]);
+
+  return (
+    <>
+      <output data-testid="issue-33-sort-events">
+        {JSON.stringify(events)}
+      </output>
+      <GridFrame>
+        <CompatibilityGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          columnOrder={["id", "name"]}
+          virtualized={false}
+          enableFiltering={false}
+          sortInfo={controlledSort}
+          onSortInfoChange={(next) =>
+            setEvents((current) => [...current, next])
+          }
+        />
+      </GridFrame>
+    </>
+  );
+}
+
+function Issue34FilterAlias() {
+  const rows = React.useMemo(
+    () => [
+      { id: "filter-a", profile: { name: "Ada Lovelace" } },
+      { id: "filter-g", profile: { name: "Grace Hopper" } },
+    ],
+    []
+  );
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 120 },
+      {
+        name: "displayName",
+        header: "Display name",
+        width: 260,
+        filterable: true,
+        filterName: "profileName",
+        getFilterValue: (value: unknown) => {
+          const candidate = value as {
+            profile?: { name?: string };
+            data?: { profile?: { name?: string } };
+          };
+          return candidate.profile?.name ?? candidate.data?.profile?.name;
+        },
+        render: ({ data }: { data: (typeof rows)[number] }) =>
+          data.profile.name,
+      },
+    ],
+    []
+  );
+  const initialFilter = React.useMemo<TypeFilterValue>(
+    () => [
+      {
+        name: "profileName",
+        type: "string",
+        operator: "contains",
+        value: "Ada",
+      },
+    ],
+    []
+  );
+
+  return (
+    <GridFrame>
+      <CompatibilityGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={rows}
+        columnOrder={["id", "displayName"]}
+        virtualized={false}
+        enableFiltering
+        defaultFilterValue={initialFilter}
+        i18n={{ noRecords: "No matching alias rows" }}
+      />
+    </GridFrame>
+  );
+}
+
+function Issue35DefaultVisibility() {
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      baseColumns[0]!,
+      baseColumns[1]!,
+      {
+        name: "secret",
+        header: "Secret",
+        width: 180,
+        defaultVisible: false,
+      },
+    ],
+    []
+  );
+  const rows = React.useMemo(
+    () => baseRows.map((row) => ({ ...row, secret: `secret-${row.id}` })),
+    []
+  );
+
+  return (
+    <GridFrame>
+      <CompatibilityGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={rows}
+        columnOrder={["id", "name", "secret"]}
+        virtualized={false}
+        enableFiltering={false}
+      />
+    </GridFrame>
+  );
+}
+
+function Issue36ColumnGroups() {
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { ...baseColumns[0]!, group: "identity" },
+      { ...baseColumns[1]!, group: "identity" },
+      { ...baseColumns[2]!, group: "location" },
+    ],
+    []
+  );
+
+  return (
+    <GridFrame>
+      <CompatibilityGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={baseRows}
+        columnOrder={["id", "name", "city"]}
+        virtualized={false}
+        enableFiltering={false}
+        groups={[
+          { name: "identity", header: "Identity" },
+          { name: "location", header: "Location" },
+        ]}
+      />
+    </GridFrame>
+  );
+}
+
+function Issue37RowContextMenu() {
+  return (
+    <GridFrame>
+      <CompatibilityGrid
+        idProperty="id"
+        columns={baseColumns}
+        dataSource={baseRows}
+        columnOrder={["id", "name", "city"]}
+        virtualized={false}
+        enableFiltering={false}
+        renderRowContextMenu={() => (
+          <div
+            role="menu"
+            aria-label="Issue 37 row actions"
+            data-testid="issue-37-row-menu"
+          >
+            <button type="button" role="menuitem">
+              Inspect row
+            </button>
+          </div>
+        )}
+      />
+    </GridFrame>
+  );
+}
+
+function Issue38ActiveRowNavigation() {
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
+
+  return (
+    <>
+      <output data-testid="issue-38-active-index">
+        {activeIndex == null ? "none" : activeIndex}
+      </output>
+      <GridFrame>
+        <CompatibilityGrid
+          idProperty="id"
+          columns={baseColumns}
+          dataSource={baseRows}
+          columnOrder={["id", "name", "city"]}
+          virtualized={false}
+          enableFiltering={false}
+          enableSelection
+          enableKeyboardNavigation
+          defaultActiveIndex={0}
+          onActiveIndexChange={(next: unknown) => {
+            if (typeof next === "number") {
+              setActiveIndex(next);
+              return;
+            }
+
+            const candidate = next as {
+              activeIndex?: number;
+              index?: number;
+            } | null;
+            setActiveIndex(candidate?.activeIndex ?? candidate?.index ?? null);
+          }}
+        />
+      </GridFrame>
+    </>
+  );
+}
+
+function Issue39CellSelection() {
+  const [activeCell, setActiveCell] = React.useState<unknown>(null);
+  const [cellSelection, setCellSelection] = React.useState<
+    Record<string, boolean>
+  >({});
+
+  return (
+    <>
+      <output data-testid="issue-39-active-cell">
+        {activeCell == null ? "none" : JSON.stringify(activeCell)}
+      </output>
+      <output data-testid="issue-39-cell-selection">
+        {JSON.stringify(cellSelection)}
+      </output>
+      <GridFrame>
+        <CompatibilityGrid
+          idProperty="id"
+          columns={baseColumns}
+          dataSource={baseRows}
+          columnOrder={["id", "name", "city"]}
+          virtualized={false}
+          enableFiltering={false}
+          cellSelection={cellSelection}
+          defaultActiveCell={[0, 0]}
+          onActiveCellChange={(next: unknown) => setActiveCell(next)}
+          onCellSelectionChange={(next: unknown) =>
+            setCellSelection(next as Record<string, boolean>)
+          }
+        />
+      </GridFrame>
+    </>
+  );
+}
+
+function Issue40CellDomProps() {
+  return (
+    <GridFrame>
+      <CompatibilityGrid
+        idProperty="id"
+        columns={baseColumns}
+        dataSource={baseRows}
+        columnOrder={["id", "name", "city"]}
+        virtualized={false}
+        enableFiltering={false}
+        cellDOMProps={(cell: unknown) => {
+          const candidate = cell as {
+            data?: { id?: string };
+            name?: string;
+            rowIndex?: number;
+            columnIndex?: number;
+          };
+          return {
+            "data-issue-40-cell": JSON.stringify([
+              candidate.data?.id ?? null,
+              candidate.name ?? null,
+              candidate.rowIndex ?? null,
+              candidate.columnIndex ?? null,
+            ]),
+          };
+        }}
+      />
+    </GridFrame>
+  );
+}
+
+function Issue41EditStartValue() {
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      baseColumns[0]!,
+      {
+        ...baseColumns[1]!,
+        editable: true,
+        getEditStartValue: async () => "seeded-by-getEditStartValue",
+      },
+    ],
+    []
+  );
+
+  return (
+    <GridFrame>
+      <CompatibilityGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={baseRows}
+        columnOrder={["id", "name"]}
+        virtualized={false}
+        enableFiltering={false}
+        editable
+      />
+    </GridFrame>
+  );
+}
+
+function Issue42PerRowHeights() {
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [ready, setReady] = React.useState(false);
+  const [rowHeights, setRowHeights] = React.useState<Record<string, number>>({
+    "row-2": 88,
+  });
+  const [heightEvents, setHeightEvents] = React.useState<unknown[]>([]);
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="issue-42-set-row-height"
+        disabled={!ready}
+        onClick={() => {
+          const api = apiRef.current as
+            | (TypeComputedProps & {
+                setRowHeightById?: (
+                  rowHeight: number | null,
+                  id: string | number
+                ) => void;
+              })
+            | null;
+          api?.setRowHeightById?.(96, "row-3");
+        }}
+      >
+        Set row 3 height
+      </button>
+      <output data-testid="issue-42-height-events">
+        {JSON.stringify(heightEvents)}
+      </output>
+      <GridFrame>
+        <CompatibilityGrid
+          idProperty="id"
+          columns={baseColumns}
+          dataSource={baseRows}
+          columnOrder={["id", "name", "city"]}
+          virtualized={false}
+          enableFiltering={false}
+          rowHeight={40}
+          rowHeights={rowHeights}
+          onRowHeightsChange={(next: unknown) => {
+            setHeightEvents((current) => [...current, next]);
+            setRowHeights(next as Record<string, number>);
+          }}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+            setReady(Boolean(ref.current));
+          }}
+        />
+      </GridFrame>
+    </>
+  );
+}
+
+function Issue43InitialScroll() {
+  const columns = React.useMemo<TypeColumns>(
+    () =>
+      Array.from({ length: 6 }, (_, index) => ({
+        name: `column-${index}`,
+        header: `Column ${index}`,
+        width: 180,
+      })),
+    []
+  );
+  const rows = React.useMemo(
+    () =>
+      Array.from({ length: 40 }, (_, rowIndex) =>
+        Object.fromEntries([
+          ["id", `scroll-row-${rowIndex}`],
+          ...columns.map((column, columnIndex) => [
+            String(column.name),
+            `row-${rowIndex}-column-${columnIndex}`,
+          ]),
+        ])
+      ),
+    [columns]
+  );
+
+  return (
+    <GridFrame className="h-[260px] w-[460px]">
+      <CompatibilityGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={rows}
+        columnOrder={columns.map((column) => String(column.name))}
+        virtualized={false}
+        enableFiltering={false}
+        initialScrollTop={120}
+        initialScrollLeft={90}
+      />
+    </GridFrame>
+  );
+}
+
+type PackageExportValue =
+  | string
+  | {
+      browser?: string;
+      import?: string;
+      default?: string;
+    };
+
+type PackageProbeResult = Record<string, string>;
+
+type PackageArtifactLoader = () => Promise<unknown>;
+
+const packageModuleLoaders = import.meta.glob("../../dist/**/*.js") as Record<
+  string,
+  PackageArtifactLoader
+>;
+const packageStylesheetLoaders = import.meta.glob("../../dist/**/*.css", {
+  query: "?raw",
+  import: "default",
+}) as Record<string, PackageArtifactLoader>;
+
+function resolveBrowserExportTarget(value: PackageExportValue | undefined) {
+  if (typeof value === "string") return value;
+  return value?.browser ?? value?.import ?? value?.default;
+}
+
+function toPackageArtifactKey(target: string) {
+  return target.startsWith("./") ? `../../${target.slice(2)}` : target;
+}
+
+function Issue44PackageBrowserConsumer() {
+  const [results, setResults] = React.useState<PackageProbeResult | null>(null);
+
+  React.useEffect(() => {
+    let active = true;
+
+    void (async () => {
+      const next: PackageProbeResult = {};
+      const manifest = packageManifest as {
+        exports?: Record<string, PackageExportValue>;
+      };
+      try {
+        const moduleEntries = [
+          ".",
+          "./BoolEditor",
+          "./DateEditor",
+          "./NumericEditor",
+          "./StringFilter",
+          "./BoolFilter",
+        ];
+        const stylesheetEntries = [
+          "./index.css",
+          "./base.css",
+          "./style/theme/default-light/index.css",
+          "./style/theme/default-dark/index.css",
+        ];
+
+        for (const entry of moduleEntries) {
+          const target = resolveBrowserExportTarget(manifest.exports?.[entry]);
+          if (!target) {
+            next[entry] = "missing-export";
+            continue;
+          }
+
+          try {
+            const loader = packageModuleLoaders[toPackageArtifactKey(target)];
+            const imported = loader ? await loader() : null;
+            next[entry] =
+              imported && Object.keys(imported).length > 0
+                ? "loaded"
+                : loader
+                  ? "empty-module"
+                  : "missing-artifact";
+          } catch (error) {
+            next[entry] =
+              `load-error:${error instanceof Error ? error.name : "unknown"}`;
+          }
+        }
+
+        for (const entry of stylesheetEntries) {
+          const target = resolveBrowserExportTarget(manifest.exports?.[entry]);
+          if (!target) {
+            next[entry] = "missing-export";
+            continue;
+          }
+
+          try {
+            const loader =
+              packageStylesheetLoaders[toPackageArtifactKey(target)];
+            const css = loader ? await loader() : null;
+            next[entry] =
+              typeof css === "string" && css.trim()
+                ? "loaded"
+                : loader
+                  ? "empty-stylesheet"
+                  : "missing-artifact";
+          } catch (error) {
+            next[entry] =
+              `load-error:${error instanceof Error ? error.name : "unknown"}`;
+          }
+        }
+      } catch (error) {
+        next.manifest = `load-error:${error instanceof Error ? error.name : "unknown"}`;
+      }
+
+      if (active) setResults(next);
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <output data-testid="issue-44-package-results">
+      {results == null ? "pending" : JSON.stringify(results)}
+    </output>
+  );
+}
+
+function Issue45UnknownComputedMethod() {
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const [ready, setReady] = React.useState(false);
+  const [result, setResult] = React.useState("not-run");
+
+  return (
+    <>
+      <output data-testid="issue-45-public-plugins">
+        {JSON.stringify(
+          plugins.map((plugin) =>
+            typeof plugin === "object" &&
+            plugin != null &&
+            "name" in plugin &&
+            typeof plugin.name === "string"
+              ? plugin.name
+              : null
+          )
+        )}
+      </output>
+      <button
+        type="button"
+        data-testid="issue-45-call-unknown"
+        disabled={!ready}
+        onClick={() => {
+          const unknownMethod = (
+            apiRef.current as TypeComputedProps & {
+              getDefinitelyMissingCommunityContract?: () => unknown;
+            }
+          )?.getDefinitelyMissingCommunityContract;
+
+          if (typeof unknownMethod !== "function") {
+            setResult(`${typeof unknownMethod}:not-callable`);
+            return;
+          }
+
+          try {
+            unknownMethod();
+            setResult(`${typeof unknownMethod}:succeeded`);
+          } catch {
+            setResult(`${typeof unknownMethod}:threw`);
+          }
+        }}
+      >
+        Call unknown computed method
+      </button>
+      <output data-testid="issue-45-unknown-result">{result}</output>
+      <GridFrame>
+        <CompatibilityGrid
+          idProperty="id"
+          columns={baseColumns}
+          dataSource={baseRows}
+          columnOrder={["id", "name", "city"]}
+          virtualized={false}
+          enableFiltering={false}
+          onReady={(ref) => {
+            apiRef.current = ref.current;
+            setReady(Boolean(ref.current));
+          }}
+        />
+      </GridFrame>
+    </>
+  );
+}
+
+function IssueScenario(props: { issue: AuditedIssue }) {
+  switch (props.issue) {
+    case "33":
+      return <Issue33ControlledSort />;
+    case "34":
+      return <Issue34FilterAlias />;
+    case "35":
+      return <Issue35DefaultVisibility />;
+    case "36":
+      return <Issue36ColumnGroups />;
+    case "37":
+      return <Issue37RowContextMenu />;
+    case "38":
+      return <Issue38ActiveRowNavigation />;
+    case "39":
+      return <Issue39CellSelection />;
+    case "40":
+      return <Issue40CellDomProps />;
+    case "41":
+      return <Issue41EditStartValue />;
+    case "42":
+      return <Issue42PerRowHeights />;
+    case "43":
+      return <Issue43InitialScroll />;
+    case "44":
+      return <Issue44PackageBrowserConsumer />;
+    case "45":
+      return <Issue45UnknownComputedMethod />;
+    default:
+      return null;
+  }
+}
+
+export default function GitHubIssues33To48CompatPage() {
+  const issue = readIssue();
+
+  return (
+    <main
+      className="flex min-w-0 flex-col gap-4 rounded-2xl border bg-background p-5"
+      data-testid="github-issues-33-48-scenario"
+      data-issue={issue}
+    >
+      <h1 className="text-xl font-semibold">
+        GitHub issue #{issue} compatibility
+      </h1>
+      <IssueScenario issue={issue} />
+    </main>
+  );
+}

--- a/examples/src/router.tsx
+++ b/examples/src/router.tsx
@@ -15,6 +15,8 @@ import DefaultPropsCompatPage from "./DefaultPropsCompatPage";
 import ExampleDetailPage from "./ExampleDetailPage";
 import ExamplesOverviewPage from "./ExamplesOverviewPage";
 import FilteredRowsCountCompatPage from "./FilteredRowsCountCompatPage";
+import GitHubIssues31And32CompatPage from "./GitHubIssues31And32CompatPage";
+import GitHubIssues33To48CompatPage from "./GitHubIssues33To48CompatPage";
 import InovuaParityCompatPage from "./InovuaParityCompatPage";
 import InovuaParityExamplePage from "./InovuaParityExamplePage";
 import InovuaPendingParityCompatPage from "./InovuaPendingParityCompatPage";
@@ -312,6 +314,18 @@ const compatFilteredRowsCountRoute = createRoute({
   component: FilteredRowsCountCompatPage,
 });
 
+const compatGitHubIssues31And32Route = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/github-issues-31-32",
+  component: GitHubIssues31And32CompatPage,
+});
+
+const compatGitHubIssues33To48Route = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/github-issues-33-48",
+  component: GitHubIssues33To48CompatPage,
+});
+
 const compatMemorySafetyRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "compat/memory-safety",
@@ -349,6 +363,8 @@ const routeTree = rootRoute.addChildren([
   compatComputedPropsRoute,
   compatDefaultPropsRoute,
   compatFilteredRowsCountRoute,
+  compatGitHubIssues31And32Route,
+  compatGitHubIssues33To48Route,
   compatInovuaParityRoute,
   compatInovuaPendingParityRoute,
   compatIssue48Route,

--- a/tests/playwright/github-issues-17-32.spec.ts
+++ b/tests/playwright/github-issues-17-32.spec.ts
@@ -1,0 +1,605 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+type NaturalMeasurement = {
+  domHeight: number | null;
+  virtualHeight: number | null;
+};
+
+type EditEvent = {
+  type: "start" | "stop" | "complete" | "cancel" | "value";
+  rowId: string | number;
+  columnId: string;
+  value: unknown;
+};
+
+type FilterEvent = {
+  kind: "column" | "aggregate";
+  columnId?: string;
+  columnIndex?: number;
+  filterValue: unknown;
+  cellPropsPresent?: boolean;
+};
+
+type ResizeEvent = {
+  columnId: string;
+  width: number | null;
+  reservedViewportWidth: number | null;
+};
+
+type ColumnState = {
+  computedVirtualizeColumns: boolean | null;
+  rowStyleVirtualizeColumns: boolean | null;
+  rowStyleColumnRenderCount: number | null;
+  rowStyleTotalColumnCount: number | null;
+};
+
+type ColumnsLayout = {
+  shellHeight: number;
+  gridHeight: number;
+  viewportHeight: number;
+  gridContained: boolean;
+  viewportContained: boolean;
+  verticalScrollbarContained: boolean | null;
+  horizontalScrollbarContained: boolean | null;
+  hasVerticalOverflow: boolean;
+  hasHorizontalOverflow: boolean;
+};
+
+async function readJson<T>(locator: Locator): Promise<T> {
+  return JSON.parse((await locator.textContent())?.trim() || "null") as T;
+}
+
+function gridRow(grid: Locator, rowId: string): Locator {
+  return grid.locator(`[data-slot="grid-row"][data-row-id="${rowId}"]`);
+}
+
+function gridCell(grid: Locator, rowId: string, columnId: string): Locator {
+  return gridRow(grid, rowId).locator(`[data-column-id="${columnId}"]`);
+}
+
+async function openParityScenario(
+  page: Page,
+  scenario: string,
+  pending = false
+) {
+  const fixture = pending ? "inovua-pending-parity" : "inovua-parity";
+  const scopeTestId = pending
+    ? "inovua-pending-parity-scenario"
+    : "inovua-parity-scenario";
+
+  await page.goto(`/compat/${fixture}?scenario=${scenario}`);
+  const scope = page.getByTestId(scopeTestId);
+  await expect(scope).toHaveAttribute("data-scenario", scenario);
+  const grid = scope.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toBeVisible();
+  return { scope, grid };
+}
+
+async function rowBackground(row: Locator): Promise<string> {
+  return row.evaluate((element) => {
+    const rowColor = getComputedStyle(element).backgroundColor;
+    if (rowColor !== "rgba(0, 0, 0, 0)") return rowColor;
+
+    const firstCell = element.querySelector<HTMLElement>("td");
+    return firstCell ? getComputedStyle(firstCell).backgroundColor : rowColor;
+  });
+}
+
+async function readColumnsLayout(shell: Locator): Promise<ColumnsLayout> {
+  return shell.evaluate((element) => {
+    const grid = element.querySelector<HTMLElement>(".tdg-root");
+    const viewport = element.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+    const verticalScrollbar = element.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-scrollbar"][data-orientation="vertical"]'
+    );
+    const horizontalScrollbar = element.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-scrollbar"][data-orientation="horizontal"]'
+    );
+    if (!grid || !viewport) throw new Error("Columns grid is not rendered");
+
+    const shellRect = element.getBoundingClientRect();
+    const gridRect = grid.getBoundingClientRect();
+    const viewportRect = viewport.getBoundingClientRect();
+    const verticalRect = verticalScrollbar?.getBoundingClientRect();
+    const horizontalRect = horizontalScrollbar?.getBoundingClientRect();
+
+    return {
+      shellHeight: Math.round(shellRect.height),
+      gridHeight: Math.round(gridRect.height),
+      viewportHeight: Math.round(viewportRect.height),
+      gridContained: gridRect.bottom <= shellRect.bottom + 1,
+      viewportContained: viewportRect.bottom <= shellRect.bottom + 1,
+      verticalScrollbarContained: verticalRect
+        ? verticalRect.bottom <= shellRect.bottom + 1
+        : null,
+      horizontalScrollbarContained: horizontalRect
+        ? horizontalRect.bottom <= shellRect.bottom + 1
+        : null,
+      hasVerticalOverflow: viewport.scrollHeight > viewport.clientHeight,
+      hasHorizontalOverflow: viewport.scrollWidth > viewport.clientWidth,
+    };
+  });
+}
+
+test.describe("GitHub issue implementation audit: #17–#32", () => {
+  test("issue #17: the reported missing grid behaviors work as public browser contracts", async ({
+    page,
+  }) => {
+    test.setTimeout(75_000);
+
+    // Natural rowHeight plus minRowHeight.
+    let scenario = await openParityScenario(page, "natural-height");
+    await scenario.scope.getByTestId("capture-natural-height").click();
+    await expect
+      .poll(async () => {
+        const measurement = await readJson<NaturalMeasurement>(
+          scenario.scope.getByTestId("natural-tall-measurement")
+        );
+        return measurement.virtualHeight;
+      })
+      .not.toBeNull();
+    const tall = await readJson<NaturalMeasurement>(
+      scenario.scope.getByTestId("natural-tall-measurement")
+    );
+    const short = await readJson<NaturalMeasurement>(
+      scenario.scope.getByTestId("natural-short-measurement")
+    );
+    expect(tall.domHeight ?? 0).toBeGreaterThanOrEqual(104);
+    expect(short.domHeight ?? 0).toBeGreaterThanOrEqual(52);
+    expect(
+      Math.abs((tall.virtualHeight ?? 0) - (tall.domHeight ?? 0))
+    ).toBeLessThanOrEqual(2);
+
+    // onColumnResize emits the documented completion payload.
+    scenario = await openParityScenario(page, "resize-callback");
+    const resizeHandle = scenario.grid
+      .locator(
+        '[data-slot="grid-header-cell"][data-column-id="description"] [data-slot="column-resizer"]'
+      )
+      .first();
+    await resizeHandle.focus();
+    await resizeHandle.press("ArrowRight");
+    await expect(
+      scenario.scope.getByTestId("column-resize-event-count")
+    ).toHaveText("1");
+    expect(
+      await readJson<ResizeEvent>(
+        scenario.scope.getByTestId("column-resize-last-event")
+      )
+    ).toMatchObject({
+      columnId: "description",
+      width: expect.any(Number),
+      reservedViewportWidth: expect.any(Number),
+    });
+
+    // showZebraRows=false suppresses alternating row paint.
+    scenario = await openParityScenario(page, "zebra-disabled");
+    await expect(scenario.grid).toHaveAttribute(
+      "data-show-zebra-rows",
+      "false"
+    );
+    const zebraBackgrounds = await Promise.all([
+      rowBackground(gridRow(scenario.grid, "row-1")),
+      rowBackground(gridRow(scenario.grid, "row-2")),
+    ]);
+    expect(zebraBackgrounds[0]).toBe(zebraBackgrounds[1]);
+
+    // editable, editStartEvent, lifecycle callbacks and column.editable=false.
+    scenario = await openParityScenario(page, "editing-click");
+    const editableCell = gridCell(scenario.grid, "row-1", "name");
+    await editableCell.click();
+    const editor = editableCell.getByRole("textbox");
+    await expect(editor).toBeFocused();
+    await editor.fill("Discarded value");
+    await editor.press("Escape");
+    const editEvents = await readJson<EditEvent[]>(
+      scenario.scope.getByTestId("edit-events")
+    );
+    expect(
+      editEvents
+        .filter((event) => event.rowId === "row-1" && event.columnId === "name")
+        .map((event) => event.type)
+    ).toEqual(["start", "value", "stop", "cancel"]);
+    await gridCell(scenario.grid, "row-1", "id").click();
+    await expect(
+      gridCell(scenario.grid, "row-1", "id").getByRole("textbox")
+    ).toHaveCount(0);
+
+    // A data-dependent global rowStyle reaches the actual row element.
+    scenario = await openParityScenario(page, "row-style");
+    expect(
+      await gridRow(scenario.grid, "style-blocked").evaluate((element) => ({
+        status: element.style.getPropertyValue("--inovua-parity-row-status"),
+        minHeight: element.style.minHeight,
+        outline: element.style.outline,
+      }))
+    ).toEqual({
+      status: "blocked",
+      minHeight: "72px",
+      outline: "rgb(220, 38, 38) solid 3px",
+    });
+
+    // Per-column filtering callback ordering and payload.
+    scenario = await openParityScenario(page, "filter-callback", true);
+    await scenario.scope.getByTestId("pending-name-filter").fill("Grace");
+    await expect
+      .poll(async () => {
+        const events = await readJson<FilterEvent[]>(
+          scenario.scope.getByTestId("filter-event-log")
+        );
+        return events.map((event) => event.kind);
+      })
+      .toEqual(["column", "aggregate"]);
+    const filterEvents = await readJson<FilterEvent[]>(
+      scenario.scope.getByTestId("filter-event-log")
+    );
+    expect(filterEvents[0]).toMatchObject({
+      kind: "column",
+      columnId: "name",
+      columnIndex: 1,
+      filterValue: { value: "Grace" },
+      cellPropsPresent: true,
+    });
+
+    // Explicit selection enablement works without a checkbox column.
+    scenario = await openParityScenario(page, "selection-enable", true);
+    await gridRow(scenario.grid, "row-1").click();
+    await expect(gridRow(scenario.grid, "row-1")).toHaveAttribute(
+      "data-selected",
+      "true"
+    );
+
+    // virtualizeColumnsThreshold is inclusive and exposes matching metadata.
+    scenario = await openParityScenario(page, "columns-threshold-at", true);
+    await scenario.scope.getByTestId("capture-column-state").click();
+    const columnState = await readJson<ColumnState>(
+      scenario.scope.getByTestId("column-state")
+    );
+    expect(columnState.computedVirtualizeColumns).toBe(true);
+    expect(columnState.rowStyleVirtualizeColumns).toBe(true);
+    expect(columnState.rowStyleTotalColumnCount).toBe(20);
+    expect(columnState.rowStyleColumnRenderCount ?? 20).toBeLessThan(20);
+
+    // emptyText supports a literal override.
+    scenario = await openParityScenario(page, "empty-literal", true);
+    await expect(
+      scenario.grid.getByText("Literal empty state", { exact: true })
+    ).toBeVisible();
+
+    // The compatibility TextInput entry required by the issue is executable.
+    await page.goto("/compat/issue-48?scenario=text-input");
+    await expect(page.getByTestId("text-input-availability")).toHaveAttribute(
+      "data-available",
+      "true"
+    );
+  });
+
+  test("issue #18: ReactDataGrid.defaultProps is exported and inspectable", async ({
+    page,
+  }) => {
+    await page.goto("/compat/default-props");
+    await expect(page.getByTestId("default-props-available")).toHaveText(
+      "true"
+    );
+    await expect(page.getByTestId("default-props-keys")).toContainText(
+      "filterTypes"
+    );
+    await expect(
+      page.getByTestId("default-props-string-operators")
+    ).toContainText("contains");
+    await expect(
+      page.getByRole("cell", { name: "Ada Lovelace" })
+    ).toBeVisible();
+  });
+
+  test("issue #19: getVirtualList returns the public compatibility facade", async ({
+    page,
+  }) => {
+    await page.goto("/compat/computed-props");
+    await expect(page.getByTestId("compat-apiReady")).toContainText("true");
+    await page.getByTestId("compat-run").click();
+    await expect(page.getByTestId("compat-virtualListKeys")).toContainText(
+      "getVisibleRange,getVisibleCount,getScrollSize,getClientSize,getScrollHeight,getTotalRowHeight,getRows,scrollToIndex,smoothScrollTo,adjustHeights"
+    );
+    await expect(
+      page.getByTestId("compat-virtualListScrollWorked")
+    ).toContainText("true");
+    await expect(
+      page.getByTestId("compat-virtualListTanStackLeak")
+    ).toContainText("false");
+  });
+
+  test("issue #20: the grid follows fixed and natural container heights without clipping", async ({
+    page,
+  }) => {
+    await page.goto("/examples/columns");
+    const shell = page.getByTestId("columns-grid-shell");
+    await expect(shell.locator(".tdg-root")).toBeVisible();
+    await shell.locator('[data-slot="scroll-area"]').hover();
+
+    for (const height of [320, 760] as const) {
+      await shell.evaluate((element, nextHeight) => {
+        element.style.height = `${nextHeight}px`;
+      }, height);
+      await expect
+        .poll(async () => (await readColumnsLayout(shell)).shellHeight)
+        .toBe(height);
+
+      const layout = await readColumnsLayout(shell);
+      expect(layout.gridHeight).toBeLessThanOrEqual(height);
+      expect(layout.viewportHeight).toBeLessThan(height);
+      expect(layout.gridContained).toBe(true);
+      expect(layout.viewportContained).toBe(true);
+      // Radix mounts auto-hide scrollbar tracks lazily. When present they must
+      // stay within the shell; an unmounted track is not a height regression.
+      expect(layout.verticalScrollbarContained).not.toBe(false);
+      expect(layout.horizontalScrollbarContained).not.toBe(false);
+      expect(layout.hasVerticalOverflow).toBe(true);
+      expect(layout.hasHorizontalOverflow).toBe(true);
+    }
+
+    await shell.evaluate((element) => {
+      element.style.height = "";
+    });
+    await page.getByTestId("columns-height-toggle").click();
+    await expect
+      .poll(async () => (await readColumnsLayout(shell)).shellHeight)
+      .toBeLessThan(400);
+    const naturalLayout = await readColumnsLayout(shell);
+    expect(naturalLayout.gridContained).toBe(true);
+    expect(naturalLayout.viewportContained).toBe(true);
+    expect(naturalLayout.hasVerticalOverflow).toBe(false);
+  });
+
+  test("issue #21: missing filter and cell exports load through the public package entry", async ({
+    page,
+  }) => {
+    await page.goto("/compat/default-props");
+    await expect(page.getByTestId("issue-21-runtime-exports")).toContainText(
+      "string:contains"
+    );
+    await expect(
+      page.getByRole("cell", { name: "Ada Lovelace" })
+    ).toBeVisible();
+  });
+
+  test("issue #26: recreating filteredRowsCount does not loop remote loads", async ({
+    page,
+  }) => {
+    await page.goto("/compat/filtered-rows-count?data-source=remote");
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as typeof window & {
+                __tdgFilteredDataSourceCalls?: number;
+              }
+            ).__tdgFilteredDataSourceCalls ?? 0
+        )
+      )
+      .toBeGreaterThan(0);
+    const callsBefore = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __tdgFilteredDataSourceCalls?: number;
+          }
+        ).__tdgFilteredDataSourceCalls ?? 0
+    );
+
+    await page.getByTestId("arm-filtered-callback").click();
+    await page.getByTestId("toggle-filter-feedback").click();
+    await expect(
+      page.getByTestId("filtered-callback-settled-count")
+    ).toHaveText("1");
+    await expect(page.getByTestId("filtered-reported-row-count")).toHaveText(
+      "2"
+    );
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as typeof window & {
+                __tdgFilteredDataSourceCalls?: number;
+              }
+            ).__tdgFilteredDataSourceCalls ?? 0
+        )
+      )
+      .toBe(callsBefore + 1);
+    await page.waitForTimeout(350);
+    expect(
+      await page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __tdgFilteredDataSourceCalls?: number;
+            }
+          ).__tdgFilteredDataSourceCalls ?? 0
+      )
+    ).toBe(callsBefore + 1);
+  });
+
+  test("issue #31: core defaults, optional idProperty and DOM attributes match Inovua", async ({
+    page,
+  }) => {
+    await page.goto("/compat/github-issues-31-32");
+    const probe = page.getByTestId("github-issue-31-probe");
+    const defaultGrid = probe
+      .getByTestId("issue-31-default-grid-shell")
+      .locator(".tdg-root");
+    const inferredFilterGrid = probe
+      .getByTestId("issue-31-inferred-filter-grid-shell")
+      .locator(".tdg-root");
+    await expect(defaultGrid).toBeVisible();
+    await expect(inferredFilterGrid).toBeVisible();
+
+    await defaultGrid.locator('[data-slot="grid-row"]').first().click();
+    const defaults = await readJson<Record<string, unknown>>(
+      probe.getByTestId("issue-31-default-props")
+    );
+    const defaultGridState = await defaultGrid.evaluate((element) => {
+      const firstRow = element.querySelector<HTMLElement>(
+        '[data-slot="grid-row"]'
+      );
+      return {
+        theme: element.getAttribute("data-theme"),
+        filterRowCount: element.querySelectorAll(".tdg-filter-row").length,
+        firstRowId: firstRow?.dataset.rowId ?? null,
+        firstRowHeight: firstRow
+          ? Math.round(firstRow.getBoundingClientRect().height)
+          : null,
+        cellsUseSelectNone:
+          element.querySelectorAll('[data-slot="grid-row"] td.select-none')
+            .length > 0,
+        columnMenuTools: element.querySelectorAll(
+          'button[aria-label="Column menu"]'
+        ).length,
+        hostAttribute: element.getAttribute("data-host-attribute"),
+      };
+    });
+    const inferredFilterState = await inferredFilterGrid.evaluate((element) => {
+      const row = element.querySelector<HTMLElement>(".tdg-filter-row");
+      return {
+        filterRowCount: element.querySelectorAll(".tdg-filter-row").length,
+        filterRowHeight: row
+          ? Math.round(row.getBoundingClientRect().height)
+          : null,
+        filterOperatorButtons: element.querySelectorAll(
+          'button[aria-label="Filter"]'
+        ).length,
+      };
+    });
+
+    expect({
+      defaults,
+      defaultGrid: {
+        ...defaultGridState,
+        rootClicks: Number(
+          (
+            await probe.getByTestId("issue-31-root-clicks").textContent()
+          )?.trim()
+        ),
+      },
+      inferredFilterGrid: inferredFilterState,
+    }).toEqual({
+      defaults: {
+        idProperty: "id",
+        theme: "default-light",
+        rowHeight: 40,
+        filterRowHeight: 40,
+        enableColumnFilterContextMenu: true,
+        columnUserSelect: false,
+        showColumnMenuTool: true,
+      },
+      defaultGrid: {
+        theme: "default-light",
+        filterRowCount: 0,
+        firstRowId: "row-1",
+        firstRowHeight: 40,
+        cellsUseSelectNone: true,
+        columnMenuTools: 2,
+        hostAttribute: "forwarded",
+        rootClicks: 1,
+      },
+      inferredFilterGrid: {
+        filterRowCount: 1,
+        filterRowHeight: 40,
+        filterOperatorButtons: 1,
+      },
+    });
+  });
+
+  test("issue #32: Promise data sources own remote paging and expose loading and toolbar hooks", async ({
+    page,
+  }) => {
+    await page.goto("/compat/github-issues-31-32");
+    const probe = page.getByTestId("github-issue-32-probe");
+    const grid = probe.getByTestId("issue-32-grid-shell").locator(".tdg-root");
+    await expect(grid).toBeVisible();
+    await expect
+      .poll(async () => {
+        const custom = await probe
+          .getByTestId("issue-32-custom-load-mask")
+          .count();
+        const builtIn = await grid
+          .getByText("Loading…", { exact: true })
+          .count();
+        return custom + builtIn;
+      })
+      .toBeGreaterThan(0);
+
+    const loadingState = {
+      customLoadMask: await probe
+        .getByTestId("issue-32-custom-load-mask")
+        .count(),
+      customLoadingText:
+        (
+          await probe.getByTestId("issue-32-custom-load-mask").allTextContents()
+        )[0]?.trim() ?? null,
+      builtInLoadingText: await grid
+        .getByText("Loading…", { exact: true })
+        .count(),
+      loadingEvents: await readJson<boolean[]>(
+        probe.getByTestId("issue-32-loading-events")
+      ),
+      customPaginationToolbar: await probe
+        .getByTestId("issue-32-custom-pagination-toolbar")
+        .count(),
+    };
+    expect.soft(loadingState).toEqual({
+      customLoadMask: 1,
+      customLoadingText: "Fetching issue 32 rows",
+      builtInLoadingText: 0,
+      loadingEvents: [true],
+      customPaginationToolbar: 1,
+    });
+
+    await probe.getByTestId("issue-32-resolve-static-promise").click();
+    await expect
+      .poll(async () => {
+        const loadingCount =
+          (await probe.getByTestId("issue-32-custom-load-mask").count()) +
+          (await grid.getByText("Loading…", { exact: true }).count());
+        const rows = await grid.locator('[data-slot="grid-row"]').count();
+        const empty = await grid
+          .getByText("No records", { exact: true })
+          .count();
+        return loadingCount === 0 && (rows > 0 || empty > 0);
+      })
+      .toBe(true);
+
+    const settledState = {
+      loadingEvents: await readJson<boolean[]>(
+        probe.getByTestId("issue-32-loading-events")
+      ),
+      rowIds: await grid
+        .locator('[data-slot="grid-row"]')
+        .evaluateAll((rows) =>
+          rows.map((row) => row.getAttribute("data-row-id"))
+        ),
+      rowText: await grid.locator('[data-slot="grid-row"]').allTextContents(),
+      emptyState: await grid.getByText("No records", { exact: true }).count(),
+      customLoadMask: await probe
+        .getByTestId("issue-32-custom-load-mask")
+        .count(),
+      customPaginationToolbar: await probe
+        .getByTestId("issue-32-custom-pagination-toolbar")
+        .count(),
+    };
+    expect(settledState).toEqual({
+      loadingEvents: [true, false],
+      rowIds: ["remote-3", "remote-4"],
+      rowText: [
+        expect.stringContaining("Remote row 3"),
+        expect.stringContaining("Remote row 4"),
+      ],
+      emptyState: 0,
+      customLoadMask: 0,
+      customPaginationToolbar: 1,
+    });
+  });
+});

--- a/tests/playwright/github-issues-17-32.spec.ts
+++ b/tests/playwright/github-issues-17-32.spec.ts
@@ -448,6 +448,11 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
       const firstRow = element.querySelector<HTMLElement>(
         '[data-slot="grid-row"]'
       );
+      const surface = element.querySelector<HTMLElement>(
+        '[data-slot="grid-surface"]'
+      );
+      const rootRect = element.getBoundingClientRect();
+      const surfaceRect = surface?.getBoundingClientRect();
       return {
         theme: element.getAttribute("data-theme"),
         filterRowCount: element.querySelectorAll(".tdg-filter-row").length,
@@ -463,10 +468,17 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
         ).length,
         hasConsumerClass: element.classList.contains("issue-31-consumer-root"),
         hasInternalClass: element.classList.contains("tdg-root"),
+        rootHeight: Math.round(rootRect.height),
+        rootWidthInset: Math.round(
+          (element.parentElement?.clientWidth ?? rootRect.width) -
+            rootRect.width
+        ),
+        surfaceMatchesRoot:
+          surfaceRect != null &&
+          Math.abs(surfaceRect.width - rootRect.width) <= 0.5 &&
+          Math.abs(surfaceRect.height - rootRect.height) <= 0.5,
         rootScrollMarginTop: element.style.scrollMarginTop || null,
-        surfaceScrollMarginTop:
-          element.querySelector<HTMLElement>('[data-slot="grid-surface"]')
-            ?.style.scrollMarginTop || null,
+        surfaceScrollMarginTop: surface?.style.scrollMarginTop || null,
       };
     });
     const inferredFilterState = await inferredFilterGrid.evaluate((element) => {
@@ -513,6 +525,9 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
         columnMenuTools: 2,
         hasConsumerClass: true,
         hasInternalClass: true,
+        rootHeight: 211,
+        rootWidthInset: 17,
+        surfaceMatchesRoot: true,
         rootScrollMarginTop: "13px",
         surfaceScrollMarginTop: null,
         rootLifecycle: {

--- a/tests/playwright/github-issues-17-32.spec.ts
+++ b/tests/playwright/github-issues-17-32.spec.ts
@@ -423,7 +423,7 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
     ).toBe(callsBefore + 1);
   });
 
-  test("issue #31: core defaults, optional idProperty and DOM attributes match Inovua", async ({
+  test("issue #31: core defaults, optional idProperty and root lifecycle props match Inovua", async ({
     page,
   }) => {
     await page.goto("/compat/github-issues-31-32");
@@ -437,7 +437,10 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
     await expect(defaultGrid).toBeVisible();
     await expect(inferredFilterGrid).toBeVisible();
 
-    await defaultGrid.locator('[data-slot="grid-row"]').first().click();
+    const surface = defaultGrid.locator('[data-slot="grid-surface"]');
+    await surface.focus();
+    await page.keyboard.press("q");
+    await probe.getByTestId("issue-31-lifecycle-focus-sink").focus();
     const defaults = await readJson<Record<string, unknown>>(
       probe.getByTestId("issue-31-default-props")
     );
@@ -458,7 +461,12 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
         columnMenuTools: element.querySelectorAll(
           'button[aria-label="Column menu"]'
         ).length,
-        hostAttribute: element.getAttribute("data-host-attribute"),
+        hasConsumerClass: element.classList.contains("issue-31-consumer-root"),
+        hasInternalClass: element.classList.contains("tdg-root"),
+        rootScrollMarginTop: element.style.scrollMarginTop || null,
+        surfaceScrollMarginTop:
+          element.querySelector<HTMLElement>('[data-slot="grid-surface"]')
+            ?.style.scrollMarginTop || null,
       };
     });
     const inferredFilterState = await inferredFilterGrid.evaluate((element) => {
@@ -478,11 +486,11 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
       defaults,
       defaultGrid: {
         ...defaultGridState,
-        rootClicks: Number(
-          (
-            await probe.getByTestId("issue-31-root-clicks").textContent()
-          )?.trim()
-        ),
+        rootLifecycle: await readJson<{
+          focus: number;
+          blur: number;
+          keyDown: string[];
+        }>(probe.getByTestId("issue-31-root-lifecycle")),
       },
       inferredFilterGrid: inferredFilterState,
     }).toEqual({
@@ -492,6 +500,7 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
         rowHeight: 40,
         filterRowHeight: 40,
         enableColumnFilterContextMenu: true,
+        enableFiltering: null,
         columnUserSelect: false,
         showColumnMenuTool: true,
       },
@@ -502,8 +511,15 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
         firstRowHeight: 40,
         cellsUseSelectNone: true,
         columnMenuTools: 2,
-        hostAttribute: "forwarded",
-        rootClicks: 1,
+        hasConsumerClass: true,
+        hasInternalClass: true,
+        rootScrollMarginTop: "13px",
+        surfaceScrollMarginTop: null,
+        rootLifecycle: {
+          focus: 1,
+          blur: 1,
+          keyDown: ["q"],
+        },
       },
       inferredFilterGrid: {
         filterRowCount: 1,
@@ -511,6 +527,193 @@ test.describe("GitHub issue implementation audit: #17–#32", () => {
         filterOperatorButtons: 1,
       },
     });
+  });
+
+  test("issue #31: filtering inference follows Inovua's explicit-override precedence", async ({
+    page,
+  }) => {
+    await page.goto("/compat/github-issues-31-32");
+    const probe = page.getByTestId("github-issue-31-probe");
+
+    const cases = [
+      {
+        testId: "issue-31-filter-omitted",
+        expected: { filterRows: 0, filterEditors: 0, dataRows: 2 },
+      },
+      {
+        testId: "issue-31-filter-default-active",
+        expected: { filterRows: 1, filterEditors: 1, dataRows: 1 },
+      },
+      {
+        testId: "issue-31-filter-controlled",
+        expected: { filterRows: 1, filterEditors: 1, dataRows: 2 },
+      },
+      {
+        testId: "issue-31-filter-explicit-true",
+        expected: { filterRows: 1, filterEditors: 0, dataRows: 2 },
+      },
+      {
+        testId: "issue-31-filter-explicit-false-default",
+        expected: { filterRows: 0, filterEditors: 0, dataRows: 1 },
+      },
+      {
+        testId: "issue-31-filter-explicit-false-controlled",
+        expected: { filterRows: 0, filterEditors: 0, dataRows: 2 },
+      },
+      {
+        testId: "issue-31-filter-empty-default",
+        expected: { filterRows: 0, filterEditors: 0, dataRows: 2 },
+      },
+      {
+        testId: "issue-31-filter-inactive-default",
+        expected: { filterRows: 1, filterEditors: 1, dataRows: 2 },
+      },
+    ] as const;
+
+    // Inovua 5.10.2 separates filter-row visibility from local data
+    // transformation. In particular, controlled filterValue is display state
+    // only, while an uncontrolled defaultFilterValue still transforms local
+    // data even when enableFiltering explicitly hides the filter row.
+    for (const filterCase of cases) {
+      const grid = probe.getByTestId(filterCase.testId).locator(".tdg-root");
+      await expect(grid, filterCase.testId).toBeVisible();
+      const state = await grid.evaluate((element) => ({
+        filterRows: element.querySelectorAll(".tdg-filter-row").length,
+        filterEditors: element.querySelectorAll(".tdg-filter-row input").length,
+        dataRows: element.querySelectorAll('[data-slot="grid-row"]').length,
+      }));
+
+      expect.soft(state, filterCase.testId).toEqual(filterCase.expected);
+    }
+  });
+
+  test("issue #31: 40px rows retain complete Latin and Cyrillic glyphs", async ({
+    page,
+  }) => {
+    await page.goto("/compat/github-issues-31-32");
+    const grid = page
+      .getByTestId("issue-31-40px-glyph-grid-shell")
+      .locator(".tdg-root");
+    await expect(grid).toBeVisible();
+
+    const measurements = await grid.evaluate((element) => {
+      return [
+        { rowId: "latin", sample: "ÁÉÍ" },
+        { rowId: "cyrillic", sample: "ЙЁЩ" },
+      ].map(({ rowId, sample }) => {
+        const row = Array.from(
+          element.querySelectorAll<HTMLElement>('[data-slot="grid-row"]')
+        ).find((candidate) => candidate.textContent?.includes(sample));
+        const cell = row?.querySelector<HTMLElement>('[data-column-id="name"]');
+        const walker = cell
+          ? document.createTreeWalker(cell, NodeFilter.SHOW_TEXT)
+          : null;
+        let textNode: Node | null = null;
+        while (walker && (textNode = walker.nextNode())) {
+          if (textNode.textContent?.includes(sample)) break;
+        }
+        if (!row || !cell || !textNode) {
+          throw new Error(`Missing ${rowId} glyph measurement target`);
+        }
+
+        const range = document.createRange();
+        range.selectNodeContents(textNode);
+        const rowRect = row.getBoundingClientRect();
+        const cellRect = cell.getBoundingClientRect();
+        const textRect = range.getBoundingClientRect();
+        const cellStyle = getComputedStyle(cell);
+
+        return {
+          rowId,
+          rowHeight: rowRect.height,
+          cellHeight: cellRect.height,
+          textHeight: textRect.height,
+          textInsideRow:
+            textRect.top >= rowRect.top - 0.5 &&
+            textRect.bottom <= rowRect.bottom + 0.5,
+          textInsideCell:
+            textRect.top >= cellRect.top - 0.5 &&
+            textRect.bottom <= cellRect.bottom + 0.5,
+          cellHasNoVerticalOverflow: cell.scrollHeight <= cell.clientHeight,
+          rowHasNoVerticalOverflow: row.scrollHeight <= row.clientHeight,
+          overflowY: cellStyle.overflowY,
+        };
+      });
+    });
+
+    expect(measurements).toHaveLength(2);
+    for (const measurement of measurements) {
+      expect(measurement.rowHeight).toBeCloseTo(40, 0);
+      expect(measurement.cellHeight).toBeCloseTo(40, 0);
+      expect(measurement.textHeight).toBeGreaterThan(0);
+      expect(measurement.textInsideRow).toBe(true);
+      expect(measurement.textInsideCell).toBe(true);
+      expect(measurement.cellHasNoVerticalOverflow).toBe(true);
+      expect(measurement.rowHasNoVerticalOverflow).toBe(true);
+      expect(measurement.overflowY).not.toBe("scroll");
+    }
+  });
+
+  test("issue #31: a 40px filter row retains Cyrillic and Latin glyph metrics", async ({
+    page,
+  }) => {
+    await page.goto("/compat/github-issues-31-32");
+    const grid = page
+      .getByTestId("issue-31-40px-filter-glyph-grid-shell")
+      .locator(".tdg-root");
+    await expect(grid).toBeVisible();
+
+    const measurement = await grid.evaluate((element) => {
+      const filterRow = element.querySelector<HTMLElement>(".tdg-filter-row");
+      const input = filterRow?.querySelector<HTMLInputElement>("input");
+      const filterCell = input?.closest<HTMLElement>(".tdg-filter-cell");
+      if (!filterRow || !input || !filterCell) {
+        throw new Error("Missing 40px filter glyph measurement target");
+      }
+
+      const rowRect = filterRow.getBoundingClientRect();
+      const cellRect = filterCell.getBoundingClientRect();
+      const inputRect = input.getBoundingClientRect();
+      const inputStyle = getComputedStyle(input);
+      const canvas = document.createElement("canvas");
+      const context = canvas.getContext("2d");
+      if (!context) throw new Error("Canvas text metrics are unavailable");
+      context.font = inputStyle.font;
+      const glyphMetrics = context.measureText(input.value);
+      const glyphHeight =
+        glyphMetrics.actualBoundingBoxAscent +
+        glyphMetrics.actualBoundingBoxDescent;
+      const contentHeight =
+        input.clientHeight -
+        Number.parseFloat(inputStyle.paddingTop) -
+        Number.parseFloat(inputStyle.paddingBottom);
+
+      return {
+        value: input.value,
+        rowHeight: rowRect.height,
+        cellHeight: cellRect.height,
+        inputInsideRow:
+          inputRect.top >= rowRect.top - 0.5 &&
+          inputRect.bottom <= rowRect.bottom + 0.5,
+        inputInsideCell:
+          inputRect.top >= cellRect.top - 0.5 &&
+          inputRect.bottom <= cellRect.bottom + 0.5,
+        inputHasNoVerticalOverflow: input.scrollHeight <= input.clientHeight,
+        glyphHeight,
+        contentHeight,
+      };
+    });
+
+    expect(measurement.value).toBe("ЙЁЩЦДЪ gjpqy");
+    expect(measurement.rowHeight).toBeCloseTo(40, 0);
+    expect(measurement.cellHeight).toBeCloseTo(40, 0);
+    expect(measurement.inputInsideRow).toBe(true);
+    expect(measurement.inputInsideCell).toBe(true);
+    expect(measurement.inputHasNoVerticalOverflow).toBe(true);
+    expect(measurement.glyphHeight).toBeGreaterThan(0);
+    expect(measurement.glyphHeight).toBeLessThanOrEqual(
+      measurement.contentHeight + 0.5
+    );
   });
 
   test("issue #32: Promise data sources own remote paging and expose loading and toolbar hooks", async ({

--- a/tests/playwright/github-issues-33-48.spec.ts
+++ b/tests/playwright/github-issues-33-48.spec.ts
@@ -1,0 +1,497 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const issueFixturePath = "/compat/github-issues-33-48";
+const execFile = promisify(execFileCallback);
+
+type PackageExportValue =
+  | string
+  | Record<string, string | Record<string, string>>;
+
+function collectExportTargets(value: PackageExportValue | undefined): string[] {
+  if (typeof value === "string") return [value];
+  if (!value) return [];
+
+  return Object.values(value).flatMap((target) =>
+    typeof target === "string"
+      ? [target]
+      : Object.values(target).filter(
+          (nestedTarget): nestedTarget is string =>
+            typeof nestedTarget === "string"
+        )
+  );
+}
+
+async function openIssue(page: Page, issue: number) {
+  await page.goto(`${issueFixturePath}?issue=${issue}`);
+
+  const scope = page.getByTestId("github-issues-33-48-scenario");
+  await expect(scope).toHaveAttribute("data-issue", String(issue));
+  await expect(
+    scope.getByRole("heading", {
+      name: `GitHub issue #${issue} compatibility`,
+    })
+  ).toBeVisible();
+  return scope;
+}
+
+async function renderedRowHeight(row: Locator) {
+  return Math.round((await row.boundingBox())?.height ?? Number.NaN);
+}
+
+test("GitHub issue #33: controlled sortInfo does not reorder a local array", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 33);
+  const grid = scope.locator(".tdg-root");
+
+  await expect(
+    grid.locator('[data-slot="grid-header-cell"][data-column-id="name"]')
+  ).toHaveAttribute("aria-sort", "ascending");
+  await expect(grid.locator('[data-slot="grid-row"]')).toHaveCount(2);
+  await expect(grid.locator('[data-slot="grid-row"]').first()).toHaveAttribute(
+    "data-row-id",
+    "sort-z"
+  );
+});
+
+test("GitHub issue #34: filterName and getFilterValue resolve the same local field", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 34);
+  const grid = scope.locator(".tdg-root");
+
+  await expect(
+    grid.locator('[data-slot="grid-row"][data-row-id="filter-a"]')
+  ).toBeVisible();
+  await expect(
+    grid.locator('[data-slot="grid-row"][data-row-id="filter-g"]')
+  ).toHaveCount(0);
+});
+
+test("GitHub issue #35: defaultVisible=false initializes a hidden column", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 35);
+
+  await expect(
+    scope.locator('[data-slot="grid-header-cell"][data-column-id="secret"]')
+  ).toHaveCount(0);
+});
+
+test("GitHub issue #36: grouped columns render their shared group header", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 36);
+  const grid = scope.locator(".tdg-root");
+
+  await expect(
+    grid.getByRole("columnheader", { name: "Identity", exact: true })
+  ).toBeVisible();
+});
+
+test("GitHub issue #37: a row context menu invokes renderRowContextMenu", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 37);
+  const firstRow = scope.locator('[data-slot="grid-row"]').first();
+
+  await expect(firstRow).toBeVisible();
+  await firstRow.click({ button: "right" });
+  await expect(scope.getByTestId("issue-37-row-menu")).toBeVisible();
+  await expect(
+    scope.getByRole("menu", { name: "Issue 37 row actions" })
+  ).toBeVisible();
+});
+
+test("GitHub issue #38: ArrowDown advances defaultActiveIndex and emits the callback", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 38);
+  const surface = scope.locator('[data-slot="grid-surface"]');
+
+  await surface.focus();
+  await expect(surface).toBeFocused();
+  await page.keyboard.press("ArrowDown");
+  await expect(scope.getByTestId("issue-38-active-index")).toHaveText("1");
+});
+
+test("GitHub issue #39: clicking a cell emits the active tuple and stable id selection key", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 39);
+  const nameCell = scope
+    .locator(
+      '[data-slot="grid-row"][data-row-id="row-1"] .InovuaReactDataGrid__cell[data-column-id="name"]'
+    )
+    .first();
+
+  await nameCell.click();
+  await expect(scope.getByTestId("issue-39-active-cell")).toHaveText("[0,1]");
+  await expect(scope.getByTestId("issue-39-cell-selection")).toHaveText(
+    '{"row-1,name":true}'
+  );
+});
+
+test("GitHub issue #40: cellDOMProps are inherited by rendered cells", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 40);
+  const nameCell = scope
+    .locator(
+      '[data-slot="grid-row"][data-row-id="row-1"] .InovuaReactDataGrid__cell[data-column-id="name"]'
+    )
+    .first();
+
+  await expect(nameCell).toHaveAttribute(
+    "data-issue-40-cell",
+    '["row-1","name",0,1]'
+  );
+});
+
+test("GitHub issue #41: async getEditStartValue seeds the inline editor", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 41);
+  const nameCell = scope
+    .locator(
+      '[data-slot="grid-row"][data-row-id="row-1"] .InovuaReactDataGrid__cell[data-column-id="name"]'
+    )
+    .first();
+
+  await nameCell.dblclick();
+  await expect(nameCell.locator('[data-slot="cell-editor"]')).toHaveValue(
+    "seeded-by-getEditStartValue"
+  );
+});
+
+test("GitHub issue #42: rowHeights applies a stable per-row override map", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 42);
+  const firstRow = scope.locator('[data-slot="grid-row"][data-row-id="row-1"]');
+  const secondRow = scope.locator(
+    '[data-slot="grid-row"][data-row-id="row-2"]'
+  );
+  const thirdRow = scope.locator('[data-slot="grid-row"][data-row-id="row-3"]');
+
+  await expect(firstRow).toBeVisible();
+  await expect(secondRow).toBeVisible();
+  await expect.poll(() => renderedRowHeight(firstRow)).toBe(40);
+  await expect.poll(() => renderedRowHeight(secondRow)).toBe(88);
+
+  const updateHeight = scope.getByTestId("issue-42-set-row-height");
+  await expect(updateHeight).toBeEnabled();
+  await updateHeight.click();
+  await expect.poll(() => renderedRowHeight(thirdRow)).toBe(96);
+  await expect(scope.getByTestId("issue-42-height-events")).toContainText(
+    '"row-3":96'
+  );
+});
+
+test("GitHub issue #43: initialScrollTop and initialScrollLeft initialize the viewport", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 43);
+  const viewport = scope.locator(".tdg-body-viewport");
+
+  await expect(viewport).toBeVisible();
+  await expect
+    .poll(() =>
+      viewport.evaluate((element) => ({
+        top: element.scrollTop,
+        left: element.scrollLeft,
+      }))
+    )
+    .toEqual({ top: 120, left: 90 });
+});
+
+test("GitHub issue #44: a browser consumer loads documented module and stylesheet exports", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 44);
+  const output = scope.getByTestId("issue-44-package-results");
+  const expectedEntries = [
+    ".",
+    "./BoolEditor",
+    "./DateEditor",
+    "./NumericEditor",
+    "./StringFilter",
+    "./BoolFilter",
+    "./index.css",
+    "./base.css",
+    "./style/theme/default-light/index.css",
+    "./style/theme/default-dark/index.css",
+  ];
+
+  await expect(output).not.toHaveText("pending");
+  const results = JSON.parse((await output.textContent()) || "null") as Record<
+    string,
+    string
+  >;
+  const manifest = JSON.parse(await readFile("package.json", "utf8")) as {
+    exports?: Record<string, PackageExportValue>;
+  };
+  const { stdout } = await execFile(
+    process.platform === "win32" ? "npm.cmd" : "npm",
+    ["pack", "--dry-run", "--json"],
+    { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 }
+  );
+  const pack = JSON.parse(stdout) as Array<{
+    files?: Array<{ path: string }>;
+  }>;
+  const packedFiles = new Set(
+    (pack[0]?.files ?? []).map((file) => file.path.replace(/^package\//, ""))
+  );
+  const missingPackedTargets = expectedEntries.flatMap((entry) =>
+    collectExportTargets(manifest.exports?.[entry])
+      .map((target) => target.replace(/^\.\//, ""))
+      .filter((target) => !packedFiles.has(target))
+      .map((target) => `${entry} -> ${target}`)
+  );
+
+  expect.soft(results).toEqual({
+    ".": "loaded",
+    "./BoolEditor": "loaded",
+    "./DateEditor": "loaded",
+    "./NumericEditor": "loaded",
+    "./StringFilter": "loaded",
+    "./BoolFilter": "loaded",
+    "./index.css": "loaded",
+    "./base.css": "loaded",
+    "./style/theme/default-light/index.css": "loaded",
+    "./style/theme/default-dark/index.css": "loaded",
+  });
+  expect.soft(missingPackedTargets).toEqual([]);
+  expect.soft(packedFiles.has("LICENSE")).toBe(true);
+});
+
+test("GitHub issue #45: unknown computed API methods do not silently succeed", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 45);
+  const invoke = scope.getByTestId("issue-45-call-unknown");
+
+  await expect(scope.getByTestId("issue-45-public-plugins")).toHaveText(
+    '["sortable-columns","filters","menus","cell-selection"]'
+  );
+  await expect(invoke).toBeEnabled();
+  await invoke.click();
+  await expect(scope.getByTestId("issue-45-unknown-result")).toHaveText(
+    "undefined:not-callable"
+  );
+});
+
+test("GitHub issue #46: every Community child issue has executable release-gate evidence", async ({
+  page,
+}) => {
+  const softExpect = expect.configure({ soft: true });
+  const actual: Record<number, unknown> = {};
+
+  await page.goto("/compat/inovua-pending-parity?scenario=empty-literal");
+  const issue17Scope = page.getByTestId("inovua-pending-parity-scenario");
+  await expect(issue17Scope.locator(".tdg-root")).toBeVisible();
+  actual[17] = await issue17Scope
+    .getByText("Literal empty state", { exact: true })
+    .count();
+
+  await page.goto("/compat/github-issues-31-32");
+  const issue31Probe = page.getByTestId("github-issue-31-probe");
+  await expect(issue31Probe.locator(".tdg-root").first()).toBeVisible();
+  const issue31Defaults = JSON.parse(
+    (await issue31Probe.getByTestId("issue-31-default-props").textContent()) ||
+      "null"
+  ) as Record<string, unknown>;
+  actual[31] = {
+    idProperty: issue31Defaults.idProperty,
+    theme: issue31Defaults.theme,
+    rowHeight: issue31Defaults.rowHeight,
+    filterRowHeight: issue31Defaults.filterRowHeight,
+  };
+  actual[32] = await page
+    .getByTestId("github-issue-32-probe")
+    .getByTestId("issue-32-custom-pagination-toolbar")
+    .count();
+
+  let scope = await openIssue(page, 33);
+  actual[33] = await scope
+    .locator('[data-slot="grid-row"]')
+    .first()
+    .getAttribute("data-row-id");
+
+  scope = await openIssue(page, 34);
+  actual[34] = await scope
+    .locator('[data-slot="grid-row"]')
+    .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-row-id")));
+
+  scope = await openIssue(page, 35);
+  actual[35] = await scope
+    .locator('[data-slot="grid-header-cell"][data-column-id="secret"]')
+    .count();
+
+  scope = await openIssue(page, 36);
+  actual[36] = await scope
+    .getByRole("columnheader", { name: "Identity", exact: true })
+    .count();
+
+  scope = await openIssue(page, 37);
+  await scope
+    .locator('[data-slot="grid-row"]')
+    .first()
+    .click({ button: "right" });
+  actual[37] = await scope.getByTestId("issue-37-row-menu").count();
+
+  scope = await openIssue(page, 38);
+  await scope.locator('[data-slot="grid-surface"]').focus();
+  await page.keyboard.press("ArrowDown");
+  actual[38] = await scope.getByTestId("issue-38-active-index").textContent();
+
+  scope = await openIssue(page, 39);
+  await scope
+    .locator(
+      '[data-slot="grid-row"][data-row-id="row-1"] [data-column-id="name"]'
+    )
+    .click();
+  actual[39] = {
+    activeCell: await scope.getByTestId("issue-39-active-cell").textContent(),
+    cellSelection: await scope
+      .getByTestId("issue-39-cell-selection")
+      .textContent(),
+  };
+
+  scope = await openIssue(page, 40);
+  actual[40] = await scope
+    .locator(
+      '[data-slot="grid-row"][data-row-id="row-1"] [data-column-id="name"]'
+    )
+    .getAttribute("data-issue-40-cell");
+
+  scope = await openIssue(page, 41);
+  const issue41Cell = scope.locator(
+    '[data-slot="grid-row"][data-row-id="row-1"] [data-column-id="name"]'
+  );
+  await issue41Cell.dblclick();
+  const issue41Editor = issue41Cell.locator('[data-slot="cell-editor"]');
+  actual[41] = (await issue41Editor.count())
+    ? await issue41Editor.inputValue()
+    : "missing-editor";
+
+  scope = await openIssue(page, 42);
+  actual[42] = await renderedRowHeight(
+    scope.locator('[data-slot="grid-row"][data-row-id="row-2"]')
+  );
+
+  scope = await openIssue(page, 43);
+  actual[43] = await scope
+    .locator(".tdg-body-viewport")
+    .evaluate((element) => ({
+      top: element.scrollTop,
+      left: element.scrollLeft,
+    }));
+
+  scope = await openIssue(page, 44);
+  const issue44Output = scope.getByTestId("issue-44-package-results");
+  await expect(issue44Output).not.toHaveText("pending");
+  actual[44] = JSON.parse((await issue44Output.textContent()) || "null");
+
+  scope = await openIssue(page, 45);
+  const issue45Invoke = scope.getByTestId("issue-45-call-unknown");
+  await expect(issue45Invoke).toBeEnabled();
+  await issue45Invoke.click();
+  actual[45] = {
+    plugins: await scope.getByTestId("issue-45-public-plugins").textContent(),
+    unknownMethod: await scope
+      .getByTestId("issue-45-unknown-result")
+      .textContent(),
+  };
+
+  const expected: Record<number, unknown> = {
+    17: 1,
+    31: {
+      idProperty: "id",
+      theme: "default-light",
+      rowHeight: 40,
+      filterRowHeight: 40,
+    },
+    32: 1,
+    33: "sort-z",
+    34: ["filter-a"],
+    35: 0,
+    36: 1,
+    37: 1,
+    38: "1",
+    39: {
+      activeCell: "[0,1]",
+      cellSelection: '{"row-1,name":true}',
+    },
+    40: '["row-1","name",0,1]',
+    41: "seeded-by-getEditStartValue",
+    42: 88,
+    43: { top: 120, left: 90 },
+    44: {
+      ".": "loaded",
+      "./BoolEditor": "loaded",
+      "./DateEditor": "loaded",
+      "./NumericEditor": "loaded",
+      "./StringFilter": "loaded",
+      "./BoolFilter": "loaded",
+      "./index.css": "loaded",
+      "./base.css": "loaded",
+      "./style/theme/default-light/index.css": "loaded",
+      "./style/theme/default-dark/index.css": "loaded",
+    },
+    45: {
+      plugins: '["sortable-columns","filters","menus","cell-selection"]',
+      unknownMethod: "undefined:not-callable",
+    },
+  };
+
+  for (const issue of [
+    17,
+    ...Array.from({ length: 15 }, (_, index) => 31 + index),
+  ]) {
+    softExpect(actual[issue], `Community issue #${issue}`).toEqual(
+      expected[issue]
+    );
+  }
+});
+
+test("GitHub issue #48: TextInput, onDidMount, and adjustHeights are all available", async ({
+  page,
+}) => {
+  await page.goto("/compat/issue-48?scenario=text-input");
+  let scope = page.getByTestId("issue-48-scenario");
+  await expect(scope).toHaveAttribute("data-scenario", "text-input");
+  await expect(scope.getByTestId("text-input-availability")).toHaveAttribute(
+    "data-available",
+    "true"
+  );
+
+  await page.goto("/compat/issue-48?scenario=did-mount");
+  scope = page.getByTestId("issue-48-scenario");
+  await expect(scope).toHaveAttribute("data-scenario", "did-mount");
+  await expect(scope.getByTestId("did-mount-events")).toContainText(
+    '"type":"didMount"'
+  );
+
+  await page.goto("/compat/issue-48?scenario=adjust-fixed");
+  scope = page.getByTestId("issue-48-scenario");
+  await expect(scope).toHaveAttribute("data-scenario", "adjust-fixed");
+  await scope.getByTestId("run-adjust-heights").click();
+  const report = JSON.parse(
+    (await scope.getByTestId("adjust-heights-report").textContent()) || "null"
+  ) as {
+    methodExists: boolean;
+    returnedUndefined: boolean;
+    error: string | null;
+  };
+
+  expect(report).toMatchObject({
+    methodExists: true,
+    returnedUndefined: true,
+    error: null,
+  });
+});

--- a/tests/playwright/github-issues-4-16.spec.ts
+++ b/tests/playwright/github-issues-4-16.spec.ts
@@ -1,0 +1,680 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "@playwright/test";
+
+const PACKAGE_CSS = readFileSync(
+  resolve(process.cwd(), "dist/index.css"),
+  "utf8"
+);
+
+test("GitHub issue #4: the first feedback iteration works as one integrated grid flow", async ({
+  page,
+}) => {
+  await page.goto("/actions");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toBeVisible();
+
+  const containment = await grid.evaluate((element) => {
+    const parent = element.parentElement;
+    if (!parent) return null;
+
+    const parentRect = parent.getBoundingClientRect();
+    const gridRect = element.getBoundingClientRect();
+    return {
+      left: gridRect.left >= parentRect.left - 1,
+      right: gridRect.right <= parentRect.right + 1,
+    };
+  });
+  expect(containment).toEqual({ left: true, right: true });
+
+  // The leading checkbox column has an empty filter cell, so Sample is the
+  // first interactive filter cell in this grid.
+  const sampleFilterCell = grid.locator(".tdg-filter-cell").nth(1);
+  const sampleFilter = sampleFilterCell.getByRole("textbox");
+  await sampleFilter.fill("Northwind");
+  await expect(preview.getByTestId("actions-filtered-card")).toHaveText(
+    /Filtered rows\s*1/
+  );
+  await sampleFilterCell.getByRole("button", { name: "Clear" }).click();
+  await expect(preview.getByTestId("actions-filtered-card")).toHaveText(
+    /Filtered rows\s*5/
+  );
+
+  await grid
+    .locator('tbody [data-slot="grid-row"] [role="checkbox"]')
+    .first()
+    .click();
+  await expect(preview.getByTestId("actions-selected-card")).toHaveText(
+    /Selected rows\s*1/
+  );
+
+  await preview.getByRole("heading", { name: "Actions example" }).click();
+  await preview
+    .getByRole("button", { name: "Advance Northwind Health" })
+    .click();
+  await expect(preview.getByTestId("actions-stage-wf-201")).toHaveText(
+    "Reviewing"
+  );
+  await expect(
+    preview
+      .getByTestId("actions-log")
+      .getByText("Advanced Northwind Health to Reviewing.", { exact: true })
+  ).toHaveCount(1);
+});
+
+test("GitHub issue #5: the root remains contained by a fixed-width parent", async ({
+  page,
+}) => {
+  await page.goto("/basic");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const shell = preview.locator("section").first();
+  const grid = shell.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toBeVisible();
+
+  await shell.evaluate((element) => {
+    element.style.width = "420px";
+    element.style.minWidth = "420px";
+    element.style.maxWidth = "420px";
+  });
+
+  const layout = await shell.evaluate((element) => {
+    const grid = element.querySelector<HTMLElement>(
+      ".InovuaReactDataGrid.tdg-root"
+    );
+    const bodyViewport = element.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+    const headerViewport = element.querySelector<HTMLElement>(
+      '[data-slot="grid-header-viewport"]'
+    );
+    if (!grid || !bodyViewport || !headerViewport) return null;
+
+    const shellRect = element.getBoundingClientRect();
+    const gridRect = grid.getBoundingClientRect();
+    const bodyRect = bodyViewport.getBoundingClientRect();
+    const headerRect = headerViewport.getBoundingClientRect();
+
+    return {
+      rootWithinParent:
+        gridRect.left >= shellRect.left - 1 &&
+        gridRect.right <= shellRect.right + 1,
+      bodyWithinParent:
+        bodyRect.left >= shellRect.left - 1 &&
+        bodyRect.right <= shellRect.right + 1,
+      headerWithinParent:
+        headerRect.left >= shellRect.left - 1 &&
+        headerRect.right <= shellRect.right + 1,
+      parentHasPageLevelOverflow: element.scrollWidth > element.clientWidth + 1,
+      computedMaxWidth: getComputedStyle(grid).maxWidth,
+    };
+  });
+
+  expect(layout).not.toBeNull();
+  expect(layout?.rootWithinParent).toBe(true);
+  expect(layout?.bodyWithinParent).toBe(true);
+  expect(layout?.headerWithinParent).toBe(true);
+  expect(layout?.parentHasPageLevelOverflow).toBe(false);
+  expect(layout?.computedMaxWidth).toBe("100%");
+});
+
+test("GitHub issue #6: the selection header checkbox is centered with row checkboxes", async ({
+  page,
+}) => {
+  await page.goto("/selection");
+
+  const grid = page
+    .getByTestId("example-preview-panel")
+    .locator(".InovuaReactDataGrid.tdg-root")
+    .first();
+  const headerCell = grid.locator("thead .tdg-header-cell").first();
+  const rowCell = grid
+    .locator('tbody [data-slot="grid-row"] .InovuaReactDataGrid__cell')
+    .first();
+  await expect(headerCell).toBeVisible();
+  await expect(rowCell).toBeVisible();
+
+  const alignment = await grid.evaluate((element) => {
+    function centerDelta(cell: Element | null) {
+      const checkbox = cell?.querySelector<HTMLElement>('[role="checkbox"]');
+      if (!(cell instanceof HTMLElement) || !checkbox) return null;
+
+      const cellRect = cell.getBoundingClientRect();
+      const checkboxRect = checkbox.getBoundingClientRect();
+      return {
+        cellCenter: cellRect.left + cellRect.width / 2,
+        checkboxCenter: checkboxRect.left + checkboxRect.width / 2,
+      };
+    }
+
+    const header = centerDelta(element.querySelector("thead .tdg-header-cell"));
+    const row = centerDelta(
+      element.querySelector(
+        'tbody [data-slot="grid-row"] .InovuaReactDataGrid__cell'
+      )
+    );
+    if (!header || !row) return null;
+
+    return {
+      headerOffset: header.checkboxCenter - header.cellCenter,
+      rowOffset: row.checkboxCenter - row.cellCenter,
+      checkboxDelta: header.checkboxCenter - row.checkboxCenter,
+    };
+  });
+
+  expect(alignment).not.toBeNull();
+  expect(Math.abs(alignment?.headerOffset ?? 99)).toBeLessThan(2);
+  expect(Math.abs(alignment?.rowOffset ?? 99)).toBeLessThan(2);
+  expect(Math.abs(alignment?.checkboxDelta ?? 99)).toBeLessThan(2);
+});
+
+test("GitHub issue #7: narrow header and body cells clip long content at their boundaries", async ({
+  page,
+}) => {
+  await page.goto("/users");
+
+  const preview = page.getByTestId("example-preview-panel");
+  await preview
+    .locator('[data-slot="rdg-column-toggle-list"]')
+    .getByRole("button", { name: "Password changed", exact: true })
+    .click();
+
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const header = grid.locator(
+    '[data-slot="grid-header-cell"][data-column-id="date_pwdchanged"]'
+  );
+  const resizer = header.getByRole("button", {
+    name: "Resize Password changed",
+  });
+  await expect(resizer).toBeVisible();
+
+  for (let index = 0; index < 6; index += 1) {
+    await resizer.press("Shift+ArrowLeft");
+  }
+
+  const cell = grid
+    .locator(
+      '[data-slot="grid-row"] .InovuaReactDataGrid__cell[data-column-id="date_pwdchanged"]'
+    )
+    .first();
+  await expect(cell).toBeVisible();
+
+  const clipping = await grid.evaluate((element) => {
+    const header = element.querySelector<HTMLElement>(
+      '[data-slot="grid-header-cell"][data-column-id="date_pwdchanged"]'
+    );
+    const headerLabel = header?.querySelector<HTMLElement>(
+      ".InovuaReactDataGrid__column-header__sort-button > span"
+    );
+    const cell = element.querySelector<HTMLElement>(
+      '[data-slot="grid-row"] .InovuaReactDataGrid__cell[data-column-id="date_pwdchanged"]'
+    );
+    const content = cell?.querySelector<HTMLElement>(".tdg-cell-content");
+    if (!header || !headerLabel || !cell || !content) return null;
+
+    const headerRect = header.getBoundingClientRect();
+    const labelRect = headerLabel.getBoundingClientRect();
+    const cellRect = cell.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    const headerStyle = getComputedStyle(headerLabel);
+    const contentStyle = getComputedStyle(content);
+
+    return {
+      headerWidth: headerRect.width,
+      headerActuallyOverflows:
+        headerLabel.scrollWidth > headerLabel.clientWidth,
+      headerOverflow: headerStyle.overflow,
+      headerTextOverflow: headerStyle.textOverflow,
+      headerWithinCell:
+        labelRect.left >= headerRect.left - 1 &&
+        labelRect.right <= headerRect.right + 1,
+      bodyActuallyOverflows: content.scrollWidth > content.clientWidth,
+      bodyOverflow: contentStyle.overflow,
+      bodyWithinCell:
+        contentRect.left >= cellRect.left - 1 &&
+        contentRect.right <= cellRect.right + 1,
+    };
+  });
+
+  expect(clipping).not.toBeNull();
+  expect(clipping?.headerWidth).toBeLessThanOrEqual(52);
+  expect(clipping?.headerActuallyOverflows).toBe(true);
+  expect(clipping?.headerOverflow).toBe("hidden");
+  expect(clipping?.headerTextOverflow).toBe("ellipsis");
+  expect(clipping?.headerWithinCell).toBe(true);
+  expect(clipping?.bodyActuallyOverflows).toBe(true);
+  expect(clipping?.bodyOverflow).toBe("hidden");
+  expect(clipping?.bodyWithinCell).toBe(true);
+});
+
+test("GitHub issue #8: controlled row selection round-trips through the direct setter", async ({
+  page,
+}) => {
+  await page.goto("/selection");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const rowCheckboxes = grid.locator(
+    'tbody [data-slot="grid-row"] [role="checkbox"]'
+  );
+  const headerCheckbox = grid.locator("thead [role='checkbox']").first();
+
+  await rowCheckboxes.first().click();
+  await expect(preview.getByTestId("selection-count-card")).toHaveText(
+    /Selected accounts\s*1/
+  );
+  await expect(preview.getByTestId("selection-chip-list")).toContainText(
+    "Northwind Health"
+  );
+
+  await headerCheckbox.click();
+  await expect(preview.getByTestId("selection-count-card")).toHaveText(
+    /Selected accounts\s*8/
+  );
+
+  await page.getByRole("button", { name: "Clear selection" }).click();
+  await expect(preview.getByTestId("selection-count-card")).toHaveText(
+    /Selected accounts\s*0/
+  );
+});
+
+test("GitHub issue #9: an active filter can be cleared inline without opening its menu", async ({
+  page,
+}) => {
+  await page.goto("/examples/basic");
+
+  const cell = page.locator(".tdg-filter-cell").first();
+  const input = cell.getByRole("textbox");
+  await expect(cell.getByRole("button", { name: "Clear" })).toHaveCount(0);
+
+  await input.fill("Row 1");
+  await expect(input).toHaveValue("Row 1");
+  await expect(cell.getByRole("button", { name: "Clear" })).toBeVisible();
+  await expect(page.locator('[role="menu"]')).toHaveCount(0);
+
+  await cell.getByRole("button", { name: "Clear" }).click();
+  await expect(input).toHaveValue("");
+  await expect(cell.getByRole("button", { name: "Clear" })).toHaveCount(0);
+  await expect(page.getByTestId("basic-filtered-count")).toHaveText("1000");
+});
+
+test("GitHub issue #10: a cell action fires on the first click while the grid is unfocused", async ({
+  page,
+}) => {
+  await page.goto("/actions");
+
+  const preview = page.getByTestId("example-preview-panel");
+  await preview.getByRole("heading", { name: "Actions example" }).click();
+  await preview
+    .getByRole("button", { name: "Advance Northwind Health" })
+    .click();
+
+  await expect(preview.getByTestId("actions-stage-wf-201")).toHaveText(
+    "Reviewing"
+  );
+  await expect(
+    preview
+      .getByTestId("actions-log")
+      .getByText("Advanced Northwind Health to Reviewing.", { exact: true })
+  ).toHaveCount(1);
+});
+
+test("GitHub issue #11: Inovua-style single-argument render callbacks receive value and row data", async ({
+  page,
+}) => {
+  await page.goto("/actions");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const firstRow = grid.locator('[data-slot="grid-row"]').first();
+
+  // The stage renderer uses both `{ data, value }`; its test id is derived from
+  // `data.id`, while its label is derived from `value`.
+  await expect(preview.getByTestId("actions-stage-wf-201")).toHaveText(
+    "Queued"
+  );
+  // The opened date renderer uses the exact `render({ value })` shape reported
+  // by the issue.
+  await expect(firstRow.locator('[data-column-id="openedAt"]')).toContainText(
+    "Mar 4"
+  );
+  await expect(
+    firstRow.getByRole("button", { name: "Advance Northwind Health" })
+  ).toBeVisible();
+});
+
+test("GitHub issue #12: partial selection uses an indeterminate icon without a stale check", async ({
+  page,
+}) => {
+  await page.goto("/selection");
+  await page.getByRole("button", { name: "Ikarus Dark" }).click();
+
+  const grid = page
+    .getByTestId("example-preview-panel")
+    .locator(".InovuaReactDataGrid.tdg-root")
+    .first();
+  const headerCheckbox = grid.locator("thead [role='checkbox']").first();
+  const rowCheckboxes = grid.locator(
+    'tbody [data-slot="grid-row"] [role="checkbox"]'
+  );
+
+  await headerCheckbox.click();
+  await expect(headerCheckbox).toHaveAttribute("data-state", "checked");
+  await expect(
+    headerCheckbox.locator(".tdg-checkbox__check-icon")
+  ).toBeVisible();
+
+  await rowCheckboxes.first().click();
+  await expect(headerCheckbox).toHaveAttribute("data-state", "indeterminate");
+  await expect(
+    headerCheckbox.locator(".tdg-checkbox__indeterminate-icon")
+  ).toBeVisible();
+  await expect(headerCheckbox.locator(".tdg-checkbox__check-icon")).toHaveCount(
+    0
+  );
+});
+
+test("GitHub issue #13: the horizontal scrollbar wins hit testing and can be dragged", async ({
+  page,
+}) => {
+  await page.goto("/users");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const shell = preview.locator("section").first();
+  await shell.evaluate((element) => {
+    element.style.width = "760px";
+    element.style.minWidth = "760px";
+    element.style.maxWidth = "760px";
+  });
+
+  for (const columnName of [
+    "Failed logins",
+    "Last login",
+    "Password changed",
+    "Language",
+  ]) {
+    await preview
+      .locator('[data-slot="rdg-column-toggle-list"]')
+      .getByRole("button", { name: columnName, exact: true })
+      .click();
+  }
+
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const scrollArea = grid.locator('[data-slot="scroll-area"]').first();
+  const viewport = grid.locator('[data-slot="scroll-area-viewport"]').first();
+  const scrollbar = grid
+    .locator(
+      '[data-slot="scroll-area-scrollbar"][data-orientation="horizontal"]'
+    )
+    .first();
+  const thumb = scrollbar.locator('[data-slot="scroll-area-thumb"]').first();
+
+  await expect
+    .poll(() =>
+      viewport.evaluate((element) => element.scrollWidth > element.clientWidth)
+    )
+    .toBe(true);
+
+  const scrollAreaBox = await scrollArea.boundingBox();
+  expect(scrollAreaBox).not.toBeNull();
+  await scrollArea.hover({
+    position: {
+      x: 24,
+      y: Math.max(4, (scrollAreaBox?.height ?? 12) - 4),
+    },
+  });
+  await expect(scrollbar).toBeVisible();
+  await expect(thumb).toBeVisible();
+
+  const hitTarget = await scrollbar.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const target = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2
+    ) as HTMLElement | null;
+    return {
+      slot: target?.dataset.slot ?? null,
+      insideCell: Boolean(target?.closest(".InovuaReactDataGrid__cell")),
+    };
+  });
+  expect(hitTarget.insideCell).toBe(false);
+  expect(["scroll-area-scrollbar", "scroll-area-thumb"]).toContain(
+    hitTarget.slot
+  );
+
+  const thumbBox = await thumb.boundingBox();
+  expect(thumbBox).not.toBeNull();
+  const before = await viewport.evaluate((element) => element.scrollLeft);
+  await page.mouse.move(
+    (thumbBox?.x ?? 0) + (thumbBox?.width ?? 0) / 2,
+    (thumbBox?.y ?? 0) + (thumbBox?.height ?? 0) / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    (thumbBox?.x ?? 0) + (thumbBox?.width ?? 0) / 2 + 120,
+    (thumbBox?.y ?? 0) + (thumbBox?.height ?? 0) / 2,
+    { steps: 8 }
+  );
+  await page.mouse.up();
+
+  await expect
+    .poll(() => viewport.evaluate((element) => element.scrollLeft))
+    .toBeGreaterThan(before + 20);
+});
+
+test("GitHub issue #14: a narrow active filter preserves usable input space with compact tools", async ({
+  page,
+}) => {
+  await page.goto("/users");
+
+  const grid = page
+    .getByTestId("example-preview-panel")
+    .locator(".InovuaReactDataGrid.tdg-root")
+    .first();
+  const cell = grid.locator(".tdg-filter-cell").first();
+  const input = cell.getByRole("textbox");
+
+  await input.fill("1000");
+  await expect(input).toHaveValue("1000");
+  await expect(cell.getByRole("button", { name: "Clear" })).toBeVisible();
+
+  const geometry = await cell.evaluate((element) => {
+    const inner = element.querySelector<HTMLElement>(".tdg-filter-cell__inner");
+    const input = element.querySelector<HTMLInputElement>("input");
+    const clear = element.querySelector<HTMLElement>(
+      ".InovuaReactDataGrid__column-header__filter-clear"
+    );
+    const filter = element.querySelector<HTMLElement>(
+      ".InovuaReactDataGrid__column-header__filter-settings"
+    );
+    if (!inner || !input || !clear || !filter) return null;
+
+    const cellRect = element.getBoundingClientRect();
+    const inputRect = input.getBoundingClientRect();
+    const clearRect = clear.getBoundingClientRect();
+    const filterRect = filter.getBoundingClientRect();
+    const cellStyle = getComputedStyle(element);
+    const innerStyle = getComputedStyle(inner);
+    const inputStyle = getComputedStyle(input);
+    const usableInputWidth =
+      input.clientWidth -
+      Number.parseFloat(inputStyle.paddingLeft || "0") -
+      Number.parseFloat(inputStyle.paddingRight || "0");
+
+    return {
+      cellWidth: cellRect.width,
+      paddingLeft: Number.parseFloat(cellStyle.paddingLeft || "0"),
+      paddingRight: Number.parseFloat(cellStyle.paddingRight || "0"),
+      gap: Number.parseFloat(innerStyle.gap || "0"),
+      clearWidth: clearRect.width,
+      filterWidth: filterRect.width,
+      usableInputWidth,
+      inputBeforeClear: inputRect.right <= clearRect.left + 1,
+      clearBeforeFilter: clearRect.right <= filterRect.left + 1,
+      controlsWithinCell:
+        inputRect.left >= cellRect.left - 1 &&
+        filterRect.right <= cellRect.right + 1,
+    };
+  });
+
+  expect(geometry).not.toBeNull();
+  expect(geometry?.cellWidth).toBeLessThanOrEqual(110);
+  expect(
+    (geometry?.paddingLeft ?? 99) + (geometry?.paddingRight ?? 99)
+  ).toBeLessThanOrEqual(8);
+  expect(geometry?.gap).toBe(0);
+  expect(geometry?.clearWidth).toBeLessThanOrEqual(25);
+  expect(geometry?.filterWidth).toBeLessThanOrEqual(25);
+  expect(geometry?.usableInputWidth).toBeGreaterThan(0);
+  expect(geometry?.inputBeforeClear).toBe(true);
+  expect(geometry?.clearBeforeFilter).toBe(true);
+  expect(geometry?.controlsWithinCell).toBe(true);
+
+  await cell.getByRole("button", { name: "Clear" }).click();
+  await expect(input).toHaveValue("");
+});
+
+test("GitHub issue #15: computed props expose representative Inovua runtime methods", async ({
+  page,
+}) => {
+  await page.goto("/compat/computed-props");
+
+  await expect(page.getByTestId("compat-apiReady")).toContainText("true");
+  await page.getByTestId("compat-run").click();
+
+  await expect(page.getByTestId("compat-hasPublicApi")).toContainText("true");
+  await expect(page.getByTestId("compat-columnsMap")).toContainText(
+    "id,name,city"
+  );
+  await expect(page.getByTestId("compat-columnByName")).toContainText("name");
+  await expect(page.getByTestId("compat-cityVisible")).toContainText("false");
+  await expect(page.getByTestId("compat-sortInfo")).toContainText("name:1");
+  await expect(page.getByTestId("compat-filterValue")).toContainText("a");
+  await expect(page.getByTestId("compat-domNode")).toContainText("grid-row");
+  await expect(page.getByTestId("compat-renderRange")).not.toContainText(
+    "missing"
+  );
+  await expect(page.getByTestId("compat-scrollWorked")).toContainText("true");
+  await expect(
+    page.getByTestId("compat-virtualListTanStackLeak")
+  ).toContainText("false");
+});
+
+test("GitHub issue #16: the built stylesheet does not restyle host shadcn utilities", async ({
+  page,
+}) => {
+  await page.setContent(`
+    <style>
+      :root {
+        --font-sans: "Host Sans", sans-serif;
+        --tracking-tight: 0em;
+        --radius-md: 15px;
+        --background: rgb(10 20 30);
+        --foreground: rgb(240 244 248);
+        --border: rgb(80 96 116);
+      }
+      .bg-background { background-color: var(--background); }
+      .text-foreground { color: var(--foreground); }
+      .border { border-style: solid; border-width: 1px; }
+      .border-border { border-color: var(--border); }
+      .rounded-md { border-radius: var(--radius-md); }
+    </style>
+    <main style="--tdg-radius-md:44px;--tdg-color-background:rgb(255 0 255);--tdg-color-foreground:rgb(0 255 0);--tdg-color-border:rgb(255 128 0)">
+      <div id="host-probe" class="rounded-md border border-border bg-background text-foreground">
+        Host shadcn probe
+      </div>
+      <div class="tdg-root">
+        <div class="rounded-md border border-border bg-background text-foreground">Grid probe</div>
+      </div>
+    </main>
+  `);
+
+  const packageStyle = await page.addStyleTag({ content: PACKAGE_CSS });
+  await packageStyle.evaluate((element) => {
+    element.id = "issue-16-package-css";
+  });
+
+  const scan = await page.evaluate(() => {
+    const style = document.getElementById(
+      "issue-16-package-css"
+    ) as HTMLStyleElement | null;
+    const sheet = Array.from(document.styleSheets).find(
+      (candidate) => candidate.ownerNode === style
+    );
+    if (!sheet) return null;
+
+    const ownedMarkers = [
+      ".tdg-",
+      ".InovuaReactDataGrid",
+      ".inovua-react-toolkit",
+    ];
+    const collisionMarkers = [
+      ".bg-background",
+      ".border-border",
+      ".rounded-md",
+      ".text-foreground",
+    ];
+    const leakedSelectors: string[] = [];
+    const globalThemeSelectors: string[] = [];
+
+    function visit(rules: CSSRuleList) {
+      for (const rule of Array.from(rules)) {
+        if (rule instanceof CSSStyleRule) {
+          const selector = rule.selectorText;
+          const owned = ownedMarkers.some((marker) =>
+            selector.includes(marker)
+          );
+          if (
+            !owned &&
+            collisionMarkers.some((marker) => selector.includes(marker))
+          ) {
+            leakedSelectors.push(selector);
+          }
+          if (
+            (selector === ":root" || selector === ":host") &&
+            rule.cssText.includes("--tdg-")
+          ) {
+            globalThemeSelectors.push(selector);
+          }
+        }
+
+        if ("cssRules" in rule) {
+          visit((rule as CSSGroupingRule).cssRules);
+        }
+      }
+    }
+
+    visit(sheet.cssRules);
+    return { leakedSelectors, globalThemeSelectors };
+  });
+
+  expect(scan).not.toBeNull();
+  expect(scan?.leakedSelectors).toEqual([]);
+  expect(scan?.globalThemeSelectors).toEqual([]);
+
+  const styles = await page.locator("#host-probe").evaluate((element) => {
+    const computed = getComputedStyle(element);
+    return {
+      background: computed.backgroundColor,
+      border: computed.borderTopColor,
+      color: computed.color,
+      radius: computed.borderRadius,
+      fontSans: getComputedStyle(document.documentElement)
+        .getPropertyValue("--font-sans")
+        .trim(),
+      tracking: getComputedStyle(document.documentElement)
+        .getPropertyValue("--tracking-tight")
+        .trim(),
+    };
+  });
+  expect(styles).toEqual({
+    background: "rgb(10, 20, 30)",
+    border: "rgb(80, 96, 116)",
+    color: "rgb(240, 244, 248)",
+    radius: "15px",
+    fontSans: '"Host Sans", sans-serif',
+    tracking: "0em",
+  });
+});


### PR DESCRIPTION
# Summary

This is a test-only audit of every GitHub issue currently reported in `geo-vi/the-datagrid`.

- Adds at least one issue-numbered Playwright E2E case for each of the repository's 36 actual issues.
- Exercises only this repository's public package, examples, and browser behavior.
- Uses ordinary assertions: no `test.fail`, skips, placeholder failures, or tests that crawl external websites.
- Adds isolated compatibility fixtures for acceptance criteria that the public examples cannot exercise safely.
- Adds focused issue #31 coverage for 40px glyph safety, filtering precedence, and the exact Inovua root lifecycle contract.
- Does not change production runtime behavior or the public API.

## Audit result

| Browser result | Issues | Current conclusion |
| --- | --- | --- |
| PASS (20) | #4–#21, #26, and #48 | The reported browser contracts are implemented. |
| FAIL (16) | #31–#46 | At least one concrete acceptance contract remains missing or unsafe. |

The exact green set is **#4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #26, #48**.

The exact red set is **#31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46**.

Notably, open issues #17 and #48 pass their complete browser contracts and look like close candidates after maintainer confirmation.

## Issue #31 contract correction

The issue #31 oracle now follows the published `@inovua/reactdatagrid-community@5.10.2` runtime rather than a simplified interpretation:

- The strict root contract is merged `className`, `style` on the outer grid root, and `onFocus` / `onBlur` / `onKeyDown`. Arbitrary `data-*` and `onClick` forwarding are not claimed as Inovua parity.
- `enableFiltering` is absent from `defaultProps`. An explicit boolean controls filter-band visibility; otherwise a non-empty normalized filter model enables the band.
- `enableFiltering=true` without descriptors renders an empty filter band, not automatically-created editors.
- Uncontrolled `defaultFilterValue` transforms local array data even if `enableFiltering=false` hides the band.
- Controlled `filterValue` displays controlled state but does not transform a local array; that data transformation belongs to the consumer.
- A non-empty inactive descriptor keeps the band visible but does not filter data.
- Empty filter arrays behave like no filter model.

The 40px row-height safety cases are already green. They measure actual DOM text containment and canvas font metrics for accented Latin, Cyrillic, and descender glyphs in both data rows and filter inputs.

## Missing behavior represented by the red cases

- **#31:** Community defaults, JSX-optional `idProperty`, exact filtering semantics, root style/lifecycle placement, and default menu behavior
- **#32:** static-Promise remote data, loading lifecycle, pagination ownership, load mask, and toolbar hooks
- **#33:** controlled sort ownership
- **#34:** `filterName` / `getFilterValue` filtering aliases
- **#35:** default column visibility
- **#36:** grouped/nested column headers
- **#37:** row context-menu rendering
- **#38:** active-row keyboard navigation and callback ownership
- **#39:** cell selection and active-cell tuple behavior
- **#40:** `cellDOMProps` callback payload and DOM inheritance
- **#41:** async `getEditStartValue`
- **#42:** per-row height maps, controlled callback, and imperative row-height updates
- **#43:** initial scrolling configuration
- **#44:** packed editor/filter entrypoints, CSS/theme paths, and LICENSE artifact
- **#45:** functional plugins and truthful computed API methods
- **#46:** aggregate Community compatibility release gate covering #17 and every child issue #31–#45

## Verification

Combined issue audit:

```text
39 tests: 22 passed, 17 failed
```

The 17 failures are the acceptance gaps listed above, including the dedicated issue #31 filtering contract. There were no infrastructure or selector failures.

Additional checks completed successfully:

```text
40px data/filter glyph stress run: 10/10 passed with 3 workers
yarn tsc -p tsconfig.app.json --noEmit
targeted ESLint for the issue #31 test and fixture
targeted Prettier check
git diff --check
```

## Draft status

This PR is intentionally expected to remain red. Each ordinary assertion should turn green only when its corresponding production behavior is implemented. That makes this draft an executable implementation ledger rather than a manually maintained status document.
