### PR TITLE
Add Inovua-style locked columns and pinned actions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,23 @@ columns keep their relative `columnOrder` within the start/unlocked/end
 sections, remain mounted during column virtualization, and use the same
 header, filter-row, body, resize, and controlled-reorder geometry.
 
+This is an opt-in, Enterprise-derived compatibility extension rather than part
+of the Inovua Community 5.10.2 release gate. The implemented contract is the
+declarative `column.locked` field above. Inovua's `column.defaultLocked`,
+`column.lockable`, `column.autoLock`, root `onColumnLockedChange` and
+`showColumnMenuLockOptions`, imperative `setColumnLocked`, lock/unlock menu
+actions, and RTL edge mirroring are not implemented. Dragging may reorder
+columns inside the same locked/unlocked section, but a cross-section drop is
+rejected instead of changing the column's locked state. Declare the target
+section in the column definition up front; changing a column's locked section
+at runtime is not a supported contract yet.
+The grid groups columns only for rendering: the controlled `columnOrder` and
+remote data-source argument keep the application-owned sequence, with lock
+state carried separately by each column. Computed locked-section widths report
+the grid's logical column allocation; when an underfilled fixed-layout table is
+stretched to the viewport, browser-distributed surplus space is not added to
+those compatibility metrics.
+
 ### Filtering
 
 | Prop                            | Type                               | Default           | Description                                               |

--- a/README.md
+++ b/README.md
@@ -753,8 +753,8 @@ A `rowStyle` callback receives the live Inovua-shaped base style, including
 `height`, `width`, `minWidth`, and LTR `direction`. It may mutate that object
 and return `undefined`, or return a style object to merge. `props.id` preserves
 numeric IDs, `rowIndex` is page-local, and `remoteRowIndex` includes the current
-pagination offset. Unsupported locking is represented by fixed unlocked
-sentinels (`-1`, `false`, and `0`).
+pagination offset. Locked-column indexes, presence flags, and section widths
+reflect the live rendered geometry.
 
 `disabledRows` follows the Inovua 5.10.2 index contract. A truthy entry such as
 `{ 1: true }` disables the second row in the current sorted, filtered, and
@@ -780,6 +780,12 @@ custom cell metadata. That callback value preserves upstream’s raw shape:
 | `enableColumnAutosize` | `boolean`                   | `true`  | Estimate widths from a bounded row sample when no numeric width is supplied   |
 | `skipHeaderOnAutoSize` | `boolean`                   | `false` | Skip header text when estimating an automatic width                           |
 | `showColumnMenuTool`   | `boolean`                   | `true`  | Show the header menu tool                                                     |
+
+Set `column.locked` to `"start"` or `"end"` to keep it visible at that
+horizontal edge; `true` is the Inovua-compatible alias for `"start"`. Locked
+columns keep their relative `columnOrder` within the start/unlocked/end
+sections, remain mounted during column virtualization, and use the same
+header, filter-row, body, resize, and controlled-reorder geometry.
 
 ### Filtering
 

--- a/examples/src/ActionsGridExample.tsx
+++ b/examples/src/ActionsGridExample.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
+import { type MutableRefObject, useCallback, useMemo, useState } from "react";
 
 import ReactDataGrid, {
   type TypeColumns,
+  type TypeComputedProps,
   type TypeFilterValue,
   type TypeRowSelection,
 } from "../../src/main";
@@ -162,9 +163,12 @@ export default function ActionsGridExample() {
   const [selectedRows, setSelectedRows] = useState<TypeRowSelection>({});
   const [filteredRows, setFilteredRows] = useState(initialRows.length);
   const [eventLog, setEventLog] = useState<string[]>([
-    "Ready: use the row actions or bulk controls to mutate the queue.",
+    "Ready: scroll horizontally—the locked action column remains at the end edge.",
   ]);
   const [nextRowNumber, setNextRowNumber] = useState(206);
+  const [lockedMetadata, setLockedMetadata] = useState(
+    "Waiting for locked-column runtime metadata…"
+  );
   const [columnOrder, setColumnOrder] = useState<string[]>([
     "sample",
     "owner",
@@ -177,6 +181,22 @@ export default function ActionsGridExample() {
   const appendEvent = useCallback((message: string) => {
     setEventLog((current) => [message, ...current].slice(0, 6));
   }, []);
+  const reportLockedMetadata = useCallback(
+    (gridApiRef: MutableRefObject<TypeComputedProps | null>) => {
+      const api = gridApiRef.current;
+      const lockedEndIds = (api?.lockedEndColumns ?? []).map(
+        (column: { id?: string; name?: string }) =>
+          String(column.id ?? column.name)
+      );
+
+      setLockedMetadata(
+        api?.hasLockedEnd
+          ? `Runtime metadata: locked end contains ${lockedEndIds.join(", ")}.`
+          : "Runtime metadata: no locked-end columns."
+      );
+    },
+    []
+  );
 
   const advanceRow = useCallback(
     (rowId: string) => {
@@ -333,6 +353,7 @@ export default function ActionsGridExample() {
         filterable: false,
         textAlign: "end",
         headerAlign: "end",
+        locked: "end",
         render: ({ data }: { data: WorkflowRow }) => (
           <div className="flex items-center justify-end gap-2">
             <Button
@@ -366,7 +387,11 @@ export default function ActionsGridExample() {
         <h2 className="text-lg font-semibold">Actions example</h2>
         <p className="text-sm text-muted-foreground">
           A focused actions grid with controlled checkbox selection, row-level
-          mutations, and bulk insert/delete operations.
+          mutations, bulk insert/delete operations, and an Inovua-style
+          <code className="mx-1 rounded bg-muted px-1.5 py-0.5 text-xs">
+            locked: &quot;end&quot;
+          </code>
+          action column.
         </p>
       </div>
 
@@ -419,6 +444,13 @@ export default function ActionsGridExample() {
         </div>
       </div>
 
+      <div
+        data-testid="actions-locked-metadata"
+        className="rounded-xl border bg-muted/35 px-3 py-2 text-sm text-muted-foreground"
+      >
+        {lockedMetadata}
+      </div>
+
       <ReactDataGrid
         theme={gridTheme}
         idProperty="id"
@@ -434,12 +466,14 @@ export default function ActionsGridExample() {
         filteredRowsCount={setFilteredRows}
         onColumnOrderChange={setColumnOrder}
         virtualized
+        virtualizeColumns
         columnUserSelect
         i18n={i18n}
         showColumnMenuTool={false}
         checkboxColumn
         selected={selectedRows}
         onSelectionChange={setSelectedRows}
+        onReady={reportLockedMetadata}
         showCellBorders={showCellBorders}
       />
 

--- a/examples/src/ActionsGridExample.tsx
+++ b/examples/src/ActionsGridExample.tsx
@@ -1,4 +1,10 @@
-import { type MutableRefObject, useCallback, useMemo, useState } from "react";
+import {
+  type MutableRefObject,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import ReactDataGrid, {
   type TypeColumns,
@@ -159,6 +165,7 @@ const initialRows: WorkflowRow[] = [
 
 export default function ActionsGridExample() {
   const { gridTheme, i18n, resizable, showCellBorders } = useExamplesUi();
+  const gridApiInstanceRef = useRef<TypeComputedProps | null>(null);
   const [rows, setRows] = useState<WorkflowRow[]>(initialRows);
   const [selectedRows, setSelectedRows] = useState<TypeRowSelection>({});
   const [filteredRows, setFilteredRows] = useState(initialRows.length);
@@ -182,8 +189,9 @@ export default function ActionsGridExample() {
     setEventLog((current) => [message, ...current].slice(0, 6));
   }, []);
   const reportLockedMetadata = useCallback(
-    (gridApiRef: MutableRefObject<TypeComputedProps | null>) => {
-      const api = gridApiRef.current;
+    (apiRef: MutableRefObject<TypeComputedProps | null>) => {
+      const api = apiRef.current;
+      gridApiInstanceRef.current = api;
       const lockedEndIds = (api?.lockedEndColumns ?? []).map(
         (column: { id?: string; name?: string }) =>
           String(column.id ?? column.name)
@@ -197,6 +205,20 @@ export default function ActionsGridExample() {
     },
     []
   );
+
+  const revealOpenedColumn = useCallback(() => {
+    const api = gridApiInstanceRef.current;
+    const openedAtIndex =
+      api
+        ?.getColumnsInOrder?.()
+        .findIndex(
+          (column) => String(column.id ?? column.name) === "openedAt"
+        ) ?? -1;
+    if (!api?.scrollToColumn || openedAtIndex < 0) return;
+
+    api.scrollToColumn(openedAtIndex);
+    appendEvent("Scrolled Opened into the unlocked center viewport.");
+  }, [appendEvent]);
 
   const advanceRow = useCallback(
     (rowId: string) => {
@@ -439,6 +461,14 @@ export default function ActionsGridExample() {
         >
           Delete selected
         </Button>
+        <Button
+          type="button"
+          variant="outline"
+          data-testid="actions-reveal-opened"
+          onClick={revealOpenedColumn}
+        >
+          Reveal Opened column
+        </Button>
         <div className="flex items-center text-sm text-muted-foreground">
           First click should fire immediately, even when the grid is unfocused.
         </div>
@@ -467,10 +497,11 @@ export default function ActionsGridExample() {
         onColumnOrderChange={setColumnOrder}
         virtualized
         virtualizeColumns
+        liveColumnResize
         columnUserSelect
         i18n={i18n}
         showColumnMenuTool={false}
-        checkboxColumn
+        checkboxColumn={{ locked: "start" }}
         selected={selectedRows}
         onSelectionChange={setSelectedRows}
         onReady={reportLockedMetadata}

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -1579,11 +1579,10 @@ function createInovuaStatusPage(): DocsPage {
               includes the available Inovua row metadata: local/remote indexes,
               selection and parity state, computed columns and widths,
               row-height state, totals, editing state, and theme. Unsupported
-              grouping data is not fabricated; unsupported locking is reported
-              through the stable unlocked sentinels (<code>-1</code>,{" "}
-              <code>false</code>, and <code>0</code>) used by the compatibility
-              surface. <code>TypeColumn.style</code> remains a separate
-              cell-level API.
+              grouping data is not fabricated. Locking metadata reflects the
+              live declarative start, unlocked, and end sections, including
+              their indexes, presence flags, and logical allocated widths.{" "}
+              <code>TypeColumn.style</code> remains a separate cell-level API.
             </p>
             <p>
               The callback receives the live base style with Inovua-shaped{" "}
@@ -1776,6 +1775,18 @@ const columnSections: ReferenceSection[] = [
           </DocsRouteLink>{" "}
           for the broader compatibility audit and remaining unverified areas.
         </p>
+        <p>
+          <code>column.locked</code> is an implemented, Enterprise-derived
+          extension rather than part of the Inovua Community 5.10.2 parity gate.
+          It supports declarative <code>true</code>,{" "}
+          <code>&quot;start&quot;</code>, <code>&quot;end&quot;</code>, and{" "}
+          <code>false</code>. It does not currently implement{" "}
+          <code>defaultLocked</code>, <code>lockable</code>,{" "}
+          <code>autoLock</code>, <code>onColumnLockedChange</code>,{" "}
+          <code>showColumnMenuLockOptions</code>, <code>setColumnLocked</code>,
+          lock/unlock menu actions, cross-section lock changes through dragging,
+          or RTL edge mirroring.
+        </p>
       </Callout>
     ),
   },
@@ -1956,6 +1967,13 @@ const columnSections: ReferenceSection[] = [
         type: "boolean",
         defaultValue: "true",
         description: "Per-column resize opt-out.",
+      },
+      {
+        name: "locked",
+        type: 'true | "start" | "end" | false',
+        defaultValue: "false",
+        description:
+          'Keeps the column mounted and sticky at the horizontal start or end edge; true aliases "start". Relative order is preserved inside each locked/unlocked section. Cross-section drops are rejected. This Enterprise-derived extension does not yet include defaultLocked, lockable, autoLock, onColumnLockedChange, showColumnMenuLockOptions, setColumnLocked, lock-menu actions, or RTL mirroring.',
       },
     ],
   },
@@ -2394,12 +2412,17 @@ type TypeFilterTypes = Record<string, TypeFilterType>;`}
           </p>
           <p>
             Locked-column arrays, indexes, section widths, and presence flags
-            now reflect declarative <code>column.locked</code> geometry. Live
-            pagination and unselected tracking remain fixed compatibility
-            fields. <code>computedShowZebraRows</code> reflects the per-grid
-            prop, while <code>columnFlexes</code> and column sizes report the
-            implemented allocation; their imperative setter methods remain
-            outside the supported allowlist.
+            now reflect declarative <code>column.locked</code> and its logical
+            column allocation. In a fixed-layout table that underfills and
+            stretches to the viewport, browser-distributed surplus space is not
+            included in those compatibility widths. Live pagination and
+            unselected tracking remain fixed compatibility fields.{" "}
+            <code>computedShowZebraRows</code> reflects the per-grid prop, while{" "}
+            <code>columnFlexes</code> and column sizes report the implemented
+            allocation; their imperative setter methods remain outside the
+            supported allowlist. In particular, <code>setColumnLocked</code> may
+            look callable through the compatibility Proxy but is unsupported and
+            does not mutate lock state.
           </p>
         </Callout>
         <div className="space-y-2">
@@ -3289,6 +3312,41 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
     status: "compatible",
   },
   {
+    id: "locked-columns-extension",
+    feature: "Locked columns (Enterprise-derived extension)",
+    upstreamContract: (
+      <>
+        Inovua documents locked columns as an Enterprise feature. Its shared
+        column vocabulary accepts <code>locked</code> and{" "}
+        <code>defaultLocked</code>, supports <code>true</code> as the{" "}
+        <code>&quot;start&quot;</code> alias, and can report lock-state changes
+        when reordering crosses sections.
+      </>
+    ),
+    currentBehavior: (
+      <>
+        Declarative <code>column.locked</code> supports <code>true</code>,{" "}
+        <code>&quot;start&quot;</code>, <code>&quot;end&quot;</code>, and{" "}
+        <code>false</code>. Header, filter, and body cells use shared sticky
+        offsets; locked columns stay mounted during horizontal virtualization
+        and retain their section while resizing or reordering. Cross-section
+        drops are rejected.
+      </>
+    ),
+    requiredOutcome: (
+      <>
+        Treat this as an explicit extension outside the Community compatibility
+        gate. Do not claim complete Inovua locked-column parity until{" "}
+        <code>defaultLocked</code>, <code>lockable</code>, <code>autoLock</code>
+        , <code>onColumnLockedChange</code>,{" "}
+        <code>showColumnMenuLockOptions</code>, <code>setColumnLocked</code>,
+        lock/unlock menu actions, cross-section state transitions, and RTL edge
+        mirroring are implemented and covered.
+      </>
+    ),
+    status: "outside-public-baseline",
+  },
+  {
     id: "controlled-column-widths",
     feature: "Controlled and uncontrolled widths",
     upstreamContract: (
@@ -3892,7 +3950,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: 'column.locked: true | "start" | "end" | false',
         defaultValue: "false",
         description:
-          'true aliases "start". The rendered model groups locked-start, unlocked, and locked-end columns while preserving relative order inside each section. Cross-section drag drops are rejected; locked header, filter, and body cells share sticky offsets and remain mounted during horizontal virtualization.',
+          'true aliases "start". The rendered model groups locked-start, unlocked, and locked-end columns while preserving relative order inside each section. Cross-section drag drops are rejected; locked header, filter, and body cells share sticky offsets and remain mounted during horizontal virtualization. This is an Enterprise-derived extension, not complete Inovua locked-column parity: defaultLocked, lockable, autoLock, onColumnLockedChange, showColumnMenuLockOptions, setColumnLocked, lock-menu actions, and RTL mirroring remain unsupported.',
       },
       {
         name: "Checkbox column ordering",
@@ -5084,6 +5142,162 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
   },
   {
     group: "guides",
+    slug: "locked-columns",
+    title: "Guide: locked columns and row actions",
+    summary:
+      "Keep identity or action columns visible at a horizontal edge with the Inovua-shaped column.locked field.",
+    description:
+      "Use this opt-in extension for pinned row actions while keeping its deliberately narrower compatibility boundary explicit.",
+    tags: ["Guide", "Columns", "Actions", "Enterprise extension"],
+    sections: [
+      {
+        id: "locked-actions-example",
+        title: "Lock an actions column to the end",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              Set <code>locked: &quot;end&quot;</code> on the column itself. No
+              root grid prop or application CSS override is required.
+            </p>
+            <CodeBlock
+              code={`import ReactDataGrid, { type TypeColumns } from "@geovi/the-datagrid";
+
+const columns: TypeColumns = [
+  { name: "account", header: "Account", defaultWidth: 260 },
+  { name: "owner", header: "Owner", defaultWidth: 220 },
+  {
+    name: "actions",
+    header: "Actions",
+    defaultWidth: 180,
+    locked: "end",
+    sortable: false,
+    filterable: false,
+    render: ({ data }) => (
+      <div className="flex justify-end gap-2">
+        <button type="button" onClick={() => openAccount(data.id)}>
+          Open
+        </button>
+        <button type="button" onClick={() => archiveAccount(data.id)}>
+          Archive
+        </button>
+      </div>
+    ),
+  },
+];
+
+<ReactDataGrid
+  idProperty="id"
+  columns={columns}
+  dataSource={rows}
+  virtualized
+  virtualizeColumns
+/>;`}
+              language="tsx"
+            />
+            <p>
+              <code>true</code> is an alias for <code>&quot;start&quot;</code>.
+              Multiple locked columns are supported on either edge, and their
+              relative declaration or <code>columnOrder</code> order is
+              preserved inside that section.
+            </p>
+          </div>
+        ),
+      },
+      {
+        id: "runtime-behavior",
+        title: "Runtime behavior",
+        body: (
+          <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+            <li>
+              Locked header, filter-row, and body cells use the same computed
+              offsets and remain aligned while scrolling.
+            </li>
+            <li>
+              Horizontal column virtualization slices only the unlocked middle
+              range; locked-start and locked-end columns remain mounted.
+            </li>
+            <li>
+              Width, min/max constraints, mouse/touch/keyboard resizing, and
+              live resizing use the normal column sizing contract.
+            </li>
+            <li>
+              Drag reordering is allowed only inside the same start, unlocked,
+              or end section. A cross-section drop is rejected.
+            </li>
+            <li>
+              Computed API and <code>rowStyle</code> metadata report the live
+              locked arrays, section indexes, presence flags, and logical
+              allocated widths. Browser-distributed surplus width in an
+              underfilled stretched table is not included in those metrics.
+            </li>
+          </ul>
+        ),
+      },
+      {
+        id: "compatibility-boundary",
+        title: "Compatibility boundary",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <Callout
+              title="Enterprise-derived extension, not complete Inovua parity"
+              tone="warning"
+            >
+              <p>
+                Inovua marks locked columns as an Enterprise feature, so this
+                capability is outside this package&apos;s Community 5.10.2
+                compatibility gate. The shared Inovua vocabulary is used to make
+                migrations familiar, but only the declarative{" "}
+                <code>column.locked</code> contract is implemented today.
+              </p>
+              <p>
+                Unsupported: <code>column.defaultLocked</code>,{" "}
+                <code>column.lockable</code>, <code>column.autoLock</code>, root{" "}
+                <code>onColumnLockedChange</code> and{" "}
+                <code>showColumnMenuLockOptions</code>, imperative{" "}
+                <code>setColumnLocked</code>, lock/unlock menu actions,
+                cross-section dragging that mutates lock state, and RTL edge
+                mirroring.
+              </p>
+            </Callout>
+            <p>
+              Declare the target section in the column definition up front.
+              Changing a column&apos;s locked section at runtime is not a
+              supported contract yet, and a rejected cross-section drag does not
+              change controlled application state.
+            </p>
+            <p>
+              Lock grouping affects rendered order only. Controlled{" "}
+              <code>columnOrder</code>, its callback, and remote data-source
+              arguments retain the application-owned sequence; read each
+              column&apos;s <code>locked</code> field to determine its rendered
+              section.
+            </p>
+          </div>
+        ),
+      },
+      {
+        id: "live-example",
+        title: "Live example",
+        body: (
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              The Actions example combines a right-locked action column with a
+              filter row, horizontal virtualization, resizing, selection, and
+              real row mutations.
+            </p>
+            <Link
+              to="/examples/actions"
+              className="inline-flex rounded-full border px-3 py-1 text-xs font-medium transition-colors hover:bg-muted/60"
+            >
+              Open the locked actions example
+            </Link>
+          </div>
+        ),
+      },
+    ],
+  },
+  {
+    group: "guides",
     slug: "selection",
     title: "Guide: selection",
     summary:
@@ -5313,7 +5527,7 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
     title: "IColumn reference",
     summary: "Field-by-field reference for column definitions.",
     description:
-      "The grid uses Inovua-aligned naming for column configuration. This page covers identity, rendering, sizing, filtering, and alignment fields.",
+      "The grid uses Inovua-aligned naming for column configuration. This page covers identity, rendering, sizing, locking, filtering, and alignment fields.",
     tags: ["Reference", "Columns", "IColumn"],
     sections: columnSections,
   },

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -2393,12 +2393,13 @@ type TypeFilterTypes = Record<string, TypeFilterType>;`}
             context-menu pair is functional.
           </p>
           <p>
-            Other fixed compatibility fields include no locked columns, no
-            column virtualization/live pagination, and empty unselected
-            tracking. <code>computedShowZebraRows</code> now reflects the
-            per-grid prop, while <code>columnFlexes</code> and column sizes
-            report the implemented allocation; their imperative setter methods
-            remain outside the supported allowlist.
+            Locked-column arrays, indexes, section widths, and presence flags
+            now reflect declarative <code>column.locked</code> geometry. Live
+            pagination and unselected tracking remain fixed compatibility
+            fields. <code>computedShowZebraRows</code> reflects the per-grid
+            prop, while <code>columnFlexes</code> and column sizes report the
+            implemented allocation; their imperative setter methods remain
+            outside the supported allowlist.
           </p>
         </Callout>
         <div className="space-y-2">
@@ -3414,9 +3415,10 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
       <>
         The root rowStyle object/function is evaluated and merged on each row.
         Functions receive a mutable base style with height/width/minWidth/LTR
-        direction, typed IDs, page-local and remote indexes, and fixed unlocked
-        sentinels; returning undefined preserves in-place mutations.{" "}
-        <code>TypeColumn.style</code> remains independently cell-scoped.
+        direction, typed IDs, page-local and remote indexes, and live
+        locked/unlocked section metadata; returning undefined preserves in-place
+        mutations. <code>TypeColumn.style</code> remains independently
+        cell-scoped.
       </>
     ),
     requiredOutcome: (
@@ -3886,6 +3888,13 @@ const implementedSurfaceSections: ReferenceSection[] = [
           "A controlled parent must feed the proposed order back. If columnOrder is omitted but onColumnOrderChange exists, the grid retains its internal order and still emits proposals; no consumer array is mutated.",
       },
       {
+        name: "Locked columns",
+        type: 'column.locked: true | "start" | "end" | false',
+        defaultValue: "false",
+        description:
+          'true aliases "start". The rendered model groups locked-start, unlocked, and locked-end columns while preserving relative order inside each section. Cross-section drag drops are rejected; locked header, filter, and body cells share sticky offsets and remain mounted during horizontal virtualization.',
+      },
+      {
         name: "Checkbox column ordering",
         type: "synthetic fixed column",
         defaultValue: "44px",
@@ -4132,7 +4141,7 @@ const implementedSurfaceSections: ReferenceSection[] = [
         type: "horizontal range",
         defaultValue: "15 visible columns with numeric rowHeight",
         description:
-          "The inclusive virtualizeColumnsThreshold mounts one overscanned horizontal range shared by header, filter row, and body while preserving total scroll geometry. virtualizeColumns overrides the threshold. Functional/natural row heights and transformed mobile layout keep columns unvirtualized; far columns remain filterable and editable after scrolling.",
+          "The inclusive virtualizeColumnsThreshold mounts one overscanned unlocked range shared by header, filter row, and body while preserving total scroll geometry. Locked-start/end columns remain mounted outside that range. virtualizeColumns overrides the threshold. Functional/natural row heights and transformed mobile layout keep columns unvirtualized; far columns remain filterable and editable after scrolling.",
       },
       {
         name: "Mobile transform",

--- a/examples/src/docs/docsNavigation.ts
+++ b/examples/src/docs/docsNavigation.ts
@@ -67,6 +67,7 @@ export const docsNavigationSections: DocsNavigationSection[] = [
     items: [
       navigationItem("guides", "filtering-and-sorting", "Filtering & sorting"),
       navigationItem("guides", "selection", "Selection"),
+      navigationItem("guides", "locked-columns", "Locked columns & actions"),
     ],
   },
   {

--- a/examples/src/exampleCatalog.ts
+++ b/examples/src/exampleCatalog.ts
@@ -27,11 +27,11 @@ export const exampleCatalog: ExampleCatalogEntry[] = [
     label: "Actions",
     title: "Actions example",
     summary:
-      "A focused actions grid that exercises row buttons, controlled checkbox selection, and bulk mutations.",
+      "A focused actions grid with a right-locked action column, controlled checkbox selection, and bulk mutations.",
     details:
-      "Shows semantic cell actions that mutate the current row, plus insert and delete-selected controls wired against the same grid state the issue used.",
+      'Shows Inovua-style locked: "end" geometry across the header, filter row, virtualized body, resizing, and controlled ordering while row and bulk actions mutate the same grid state.',
     sourcePath: "examples/src/ActionsGridExample.tsx",
-    tags: ["Actions", "Selection", "Mutation"],
+    tags: ["Actions", "Locked columns", "Virtualized"],
   },
   {
     id: "basic",

--- a/skills/the-datagrid-consumer/SKILL.md
+++ b/skills/the-datagrid-consumer/SKILL.md
@@ -106,9 +106,13 @@ back through `selected`, so the direct setter pattern is valid here.
 
 ## Things to avoid
 
-- Do not claim support for grouping, pivoting, tree data, locked columns, row
-  reorder, clipboard tooling, or full Inovua plugin parity unless you verify it
-  in this repo first.
+- Do not claim support for grouping, pivoting, tree data, row reorder, clipboard
+  tooling, or full Inovua plugin parity unless you verify it in this repo first.
+- Static `column.locked` supports declarative start/end pinned columns. Do not
+  claim the full mutable Inovua Enterprise contract: `defaultLocked`,
+  `lockable`, `autoLock`, `onColumnLockedChange`,
+  `showColumnMenuLockOptions`, `setColumnLocked`, lock/unlock menu actions,
+  cross-section drag mutation, and RTL edge mirroring remain unsupported.
 - Do not add styling props just to fix layout or theming.
 - Do not assume consumers need a separate stylesheet import in normal bundler
   setups.

--- a/skills/the-datagrid-inovua-migration/SKILL.md
+++ b/skills/the-datagrid-inovua-migration/SKILL.md
@@ -57,7 +57,11 @@ Do not promise parity for these areas unless you verify them in the codebase:
 - grouping
 - pivoting
 - tree data
-- locked columns
+- mutable/full Enterprise locked-column behavior (`defaultLocked`, `lockable`,
+  `autoLock`, `onColumnLockedChange`, `showColumnMenuLockOptions`,
+  `setColumnLocked`, lock/unlock menu actions, cross-section drag mutation, and
+  RTL mirroring). Static declarative `column.locked` start/end pinning is
+  supported.
 - row reorder
 - cell selection
 - clipboard systems

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -178,6 +178,16 @@ type LiveColumnResizePreview = {
     inlineWidth: string;
     renderedWidth: number;
   }[];
+  viewport: HTMLElement | null;
+  lockedColumns: {
+    side: "start" | "end";
+    columnId: string;
+    cells: {
+      element: HTMLElement;
+      inlineOffset: string;
+      inlineViewportOffset: string;
+    }[];
+  }[];
 };
 
 type ColumnResizeSession = {
@@ -216,6 +226,42 @@ function captureLiveColumnResizePreview(
     if (table instanceof HTMLTableElement) owningTables.add(table);
   }
 
+  const lockedColumnsByKey = new Map<
+    string,
+    LiveColumnResizePreview["lockedColumns"][number]
+  >();
+  for (const element of surface.querySelectorAll<HTMLElement>(
+    ".tdg-locked-column[data-column-id]"
+  )) {
+    const lockedColumnId = element.dataset.columnId;
+    const side = element.classList.contains("tdg-locked-column--start")
+      ? "start"
+      : element.classList.contains("tdg-locked-column--end")
+        ? "end"
+        : null;
+    if (!lockedColumnId || !side) continue;
+
+    const key = `${side}:${lockedColumnId}`;
+    let lockedColumn = lockedColumnsByKey.get(key);
+    if (!lockedColumn) {
+      lockedColumn = {
+        side,
+        columnId: lockedColumnId,
+        cells: [],
+      };
+      lockedColumnsByKey.set(key, lockedColumn);
+    }
+    lockedColumn.cells.push({
+      element,
+      inlineOffset: element.style.getPropertyValue(
+        "--tdg-locked-column-offset"
+      ),
+      inlineViewportOffset: element.style.getPropertyValue(
+        "--tdg-locked-column-viewport-offset"
+      ),
+    });
+  }
+
   return {
     baseColumnWidth,
     columns,
@@ -224,7 +270,50 @@ function captureLiveColumnResizePreview(
       inlineWidth: element.style.width,
       renderedWidth: element.getBoundingClientRect().width,
     })),
+    viewport: surface.querySelector<HTMLElement>(".tdg-body-viewport"),
+    lockedColumns: Array.from(lockedColumnsByKey.values()),
   };
+}
+
+function updateLiveLockedColumnLayout(preview: LiveColumnResizePreview) {
+  const root = preview.viewport?.closest<HTMLElement>(".tdg-root");
+  const fixedWidthMode = root?.dataset.columnWidthMode === "fixed";
+  const renderedTableWidth = preview.tables.reduce(
+    (width, table) =>
+      Math.max(width, table.element.getBoundingClientRect().width),
+    0
+  );
+  const viewportOffset =
+    fixedWidthMode && preview.viewport
+      ? Math.max(0, preview.viewport.clientWidth - renderedTableWidth)
+      : 0;
+
+  const updateSide = (side: "start" | "end") => {
+    const columns = preview.lockedColumns.filter(
+      (column) => column.side === side
+    );
+    const iteration = side === "end" ? [...columns].reverse() : columns;
+    let offset = 0;
+
+    for (const column of iteration) {
+      for (const cell of column.cells) {
+        cell.element.style.setProperty(
+          "--tdg-locked-column-offset",
+          `${offset}px`
+        );
+        cell.element.style.setProperty(
+          "--tdg-locked-column-viewport-offset",
+          side === "end" ? `${viewportOffset}px` : "0px"
+        );
+      }
+
+      const representativeCell = column.cells[0]?.element;
+      offset += representativeCell?.getBoundingClientRect().width ?? 0;
+    }
+  };
+
+  updateSide("start");
+  updateSide("end");
 }
 
 function applyLiveColumnResizePreview(
@@ -240,6 +329,7 @@ function applyLiveColumnResizePreview(
   for (const { element, renderedWidth } of session.preview.tables) {
     element.style.width = `${Math.max(1, renderedWidth + widthDelta)}px`;
   }
+  updateLiveLockedColumnLayout(session.preview);
   session.appliedPreviewWidth = nextWidth;
 }
 
@@ -251,6 +341,28 @@ function restoreLiveColumnResizePreview(session: ColumnResizeSession | null) {
   }
   for (const { element, inlineWidth } of session.preview.tables) {
     element.style.width = inlineWidth;
+  }
+  for (const column of session.preview.lockedColumns) {
+    for (const cell of column.cells) {
+      if (cell.inlineOffset) {
+        cell.element.style.setProperty(
+          "--tdg-locked-column-offset",
+          cell.inlineOffset
+        );
+      } else {
+        cell.element.style.removeProperty("--tdg-locked-column-offset");
+      }
+      if (cell.inlineViewportOffset) {
+        cell.element.style.setProperty(
+          "--tdg-locked-column-viewport-offset",
+          cell.inlineViewportOffset
+        );
+      } else {
+        cell.element.style.removeProperty(
+          "--tdg-locked-column-viewport-offset"
+        );
+      }
+    }
   }
   session.appliedPreviewWidth = null;
 }
@@ -3043,6 +3155,16 @@ function ReactDataGrid(props: TypeDataGridProps) {
       table.renderedWidth =
         tableMinWidth ?? table.element.getBoundingClientRect().width;
     }
+    for (const lockedColumn of preview.lockedColumns) {
+      for (const cell of lockedColumn.cells) {
+        cell.inlineOffset = cell.element.style.getPropertyValue(
+          "--tdg-locked-column-offset"
+        );
+        cell.inlineViewportOffset = cell.element.style.getPropertyValue(
+          "--tdg-locked-column-viewport-offset"
+        );
+      }
+    }
 
     const appliedPreviewWidth = activeSession.appliedPreviewWidth;
     if (appliedPreviewWidth == null) return;
@@ -4401,25 +4523,28 @@ function ReactDataGrid(props: TypeDataGridProps) {
         index === 0 ? 0 : (columnWidthPrefixSums[index - 1] ?? 0);
       const columnEnd = columnWidthPrefixSums[index] ?? columnStart;
       const offset = config?.offset ?? 0;
+      const lockedStartWidth = lockedColumnMetrics.totalLockedStartWidth;
+      const lockedEndWidth = lockedColumnMetrics.totalLockedEndWidth;
+      const visibleStart = viewport.scrollLeft + lockedStartWidth + offset;
+      const visibleEnd =
+        viewport.scrollLeft + viewport.clientWidth - lockedEndWidth - offset;
       let nextScrollLeft = viewport.scrollLeft;
 
-      if (
-        config?.direction === "left" ||
-        columnStart < viewport.scrollLeft + offset
-      ) {
-        nextScrollLeft = columnStart - offset;
-      } else if (
-        config?.direction === "right" ||
-        columnEnd > viewport.scrollLeft + viewport.clientWidth - offset
-      ) {
-        nextScrollLeft = columnEnd - viewport.clientWidth + offset;
+      if (config?.direction === "left" || columnStart < visibleStart) {
+        nextScrollLeft = columnStart - lockedStartWidth - offset;
+      } else if (config?.direction === "right" || columnEnd > visibleEnd) {
+        nextScrollLeft =
+          columnEnd - viewport.clientWidth + lockedEndWidth + offset;
       }
 
-      viewport.scrollLeft = Math.max(0, nextScrollLeft);
+      viewport.scrollLeft = Math.min(
+        Math.max(0, viewport.scrollWidth - viewport.clientWidth),
+        Math.max(0, nextScrollLeft)
+      );
 
       callback?.();
     },
-    [columnWidthPrefixSums, visibleComputedColumns]
+    [columnWidthPrefixSums, lockedColumnMetrics, visibleComputedColumns]
   );
 
   const scrollToCellCompat = React.useCallback(

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -97,6 +97,12 @@ import { GridPagination } from "./components/GridPagination";
 import { MobileGridList } from "./components/MobileGridList";
 import { allocateColumnWidths } from "./utils/columnSizing";
 import {
+  buildGridColumnRenderItems,
+  buildLockedColumnLayout,
+  groupColumnsByLock,
+  resolveColumnLock,
+} from "./utils/lockedColumns";
+import {
   DATA_GRID_SEARCH_RUNTIME_SYMBOL,
   getDataGridSearchRuntime,
 } from "./searchRuntime";
@@ -905,7 +911,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const paginationMode = props.pagination ?? false;
   const paginationEnabled = paginationMode !== false;
 
-  const orderedColumns = React.useMemo(() => {
+  const consumerOrderedColumns = React.useMemo(() => {
     const colById = new Map<string, TypeColumn>();
     for (const c of allInputColumns) colById.set(getColumnId(c), c);
 
@@ -920,10 +926,23 @@ function ReactDataGrid(props: TypeDataGridProps) {
       if (!ordered.find((x) => getColumnId(x) === id)) ordered.push(c);
     }
 
-    return ordered.filter(
-      (column) => columnVisibilityMap[getColumnId(column)] !== false
-    );
-  }, [allInputColumns, columnVisibilityMap, effectiveColumnOrder]);
+    return ordered;
+  }, [allInputColumns, effectiveColumnOrder]);
+  const groupedColumns = React.useMemo(
+    () => groupColumnsByLock(consumerOrderedColumns),
+    [consumerOrderedColumns]
+  );
+  const orderedColumns = React.useMemo(
+    () =>
+      groupedColumns.filter(
+        (column) => columnVisibilityMap[getColumnId(column)] !== false
+      ),
+    [columnVisibilityMap, groupedColumns]
+  );
+  const renderColumnOrder = React.useMemo(
+    () => groupedColumns.map((column) => getColumnId(column)),
+    [groupedColumns]
+  );
 
   const tanstackSorting = React.useMemo(
     () => toTanStackSortingState(sortInfo, allInputColumns),
@@ -1739,7 +1758,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       sorting: tanstackSorting,
       columnFilters: tanstackColumnFilters,
       globalFilter: searchValue,
-      columnOrder: effectiveColumnOrder,
+      columnOrder: renderColumnOrder,
       columnVisibility: columnVisibilityMap,
       columnSizing: tanstackColumnSizing,
       rowSelection: tanstackRowSelection,
@@ -1767,7 +1786,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
       setFilterValue(nextFilterValue);
     },
     onColumnOrderChange: (updater) => {
-      setColumnOrder(resolveStateAction(updater, effectiveColumnOrder));
+      setColumnOrder(resolveStateAction(updater, renderColumnOrder));
     },
     onColumnVisibilityChange: (updater) => {
       const nextVisibility = resolveStateAction(updater, columnVisibilityMap);
@@ -2892,73 +2911,50 @@ function ReactDataGrid(props: TypeDataGridProps) {
       }),
     [columnWidths, visibleTableColumns]
   );
-  const columnRenderRange = (() => {
-    const totalColumnCount = columnLayout.length;
-    if (!computedVirtualizeColumns || totalColumnCount === 0) {
-      return {
-        firstIndex: 0,
-        lastIndex: totalColumnCount - 1,
-        beforeWidth: 0,
-        afterWidth: 0,
-        columnRenderCount: totalColumnCount,
-      };
-    }
-
-    const virtualColumns = columnVirtualizer.getVirtualItems();
-    const firstColumn = virtualColumns[0];
-    const lastColumn = virtualColumns[virtualColumns.length - 1];
-
-    if (!firstColumn || !lastColumn) {
-      return {
-        firstIndex: 0,
-        lastIndex: totalColumnCount - 1,
-        beforeWidth: 0,
-        afterWidth: 0,
-        columnRenderCount: totalColumnCount,
-      };
-    }
-
-    return {
-      firstIndex: firstColumn.index,
-      lastIndex: lastColumn.index,
-      beforeWidth: firstColumn.start,
-      afterWidth: Math.max(
-        0,
-        columnVirtualizer.getTotalSize() - lastColumn.end
+  const virtualColumnIndexes = computedVirtualizeColumns
+    ? columnVirtualizer
+        .getVirtualItems()
+        .map((virtualColumn) => virtualColumn.index)
+    : [];
+  const columnRenderRange = buildGridColumnRenderItems({
+    columnLayout,
+    columns: orderedColumns,
+    virtualColumnIndexes,
+    virtualizeColumns: computedVirtualizeColumns,
+  });
+  const columnRenderItems = columnRenderRange.items;
+  const lockedEndViewportOffset =
+    hasManualColumnWidths && tableMinWidth
+      ? Math.max(0, columnViewportWidth - tableMinWidth)
+      : 0;
+  const lockedColumnLayout = React.useMemo(
+    () =>
+      buildLockedColumnLayout(
+        orderedColumns,
+        Object.fromEntries(
+          columnLayout.map((column) => [column.id, column.width])
+        ),
+        lockedEndViewportOffset
       ),
-      columnRenderCount: virtualColumns.length,
-    };
-  })();
+    [columnLayout, lockedEndViewportOffset, orderedColumns]
+  );
   const renderedColumnLayout = React.useMemo(() => {
-    if (!computedVirtualizeColumns) return columnLayout;
+    return columnRenderItems.flatMap((renderItem) => {
+      if (renderItem.type === "spacer") {
+        return [
+          {
+            id: renderItem.id,
+            width: renderItem.width,
+            minWidth: renderItem.width,
+            maxWidth: renderItem.width,
+          },
+        ];
+      }
 
-    return [
-      ...(columnRenderRange.beforeWidth > 0
-        ? [
-            {
-              id: "__tdg_virtual_columns_before__",
-              width: columnRenderRange.beforeWidth,
-              minWidth: columnRenderRange.beforeWidth,
-              maxWidth: columnRenderRange.beforeWidth,
-            },
-          ]
-        : []),
-      ...columnLayout.slice(
-        columnRenderRange.firstIndex,
-        columnRenderRange.lastIndex + 1
-      ),
-      ...(columnRenderRange.afterWidth > 0
-        ? [
-            {
-              id: "__tdg_virtual_columns_after__",
-              width: columnRenderRange.afterWidth,
-              minWidth: columnRenderRange.afterWidth,
-              maxWidth: columnRenderRange.afterWidth,
-            },
-          ]
-        : []),
-    ];
-  }, [columnLayout, columnRenderRange, computedVirtualizeColumns]);
+      const column = columnLayout[renderItem.index];
+      return column ? [column] : [];
+    });
+  }, [columnLayout, columnRenderItems]);
 
   const [resizeProxyLeft, setResizeProxyLeft] = React.useState<number | null>(
     null
@@ -3710,7 +3706,21 @@ function ReactDataGrid(props: TypeDataGridProps) {
     dragIdRef.current = null;
     if (!sourceId || sourceId === targetId) return;
 
-    const next = [...effectiveColumnOrder];
+    const sourceColumn = orderedColumns.find(
+      (column) => getColumnId(column) === sourceId
+    );
+    const targetColumn = orderedColumns.find(
+      (column) => getColumnId(column) === targetId
+    );
+    if (
+      !sourceColumn ||
+      !targetColumn ||
+      resolveColumnLock(sourceColumn) !== resolveColumnLock(targetColumn)
+    ) {
+      return;
+    }
+
+    const next = [...renderColumnOrder];
     const from = next.indexOf(sourceId);
     const to = next.indexOf(targetId);
     if (from < 0 || to < 0) return;
@@ -3816,6 +3826,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
           tanstackColumnSizing[columnId] ??
           columnWidths[columnId],
         computedVisibleIndex: layout?.visibleIndex,
+        computedLocked: resolveColumnLock(column),
         index,
       };
     });
@@ -3849,6 +3860,27 @@ function ReactDataGrid(props: TypeDataGridProps) {
       visibleComputedColumns.map((column) => [getColumnId(column), column])
     );
   }, [visibleComputedColumns]);
+  const lockedStartColumns = React.useMemo(
+    () =>
+      visibleComputedColumns.filter(
+        (column) => column.computedLocked === "start"
+      ),
+    [visibleComputedColumns]
+  );
+  const lockedEndColumns = React.useMemo(
+    () =>
+      visibleComputedColumns.filter(
+        (column) => column.computedLocked === "end"
+      ),
+    [visibleComputedColumns]
+  );
+  const unlockedColumns = React.useMemo(
+    () =>
+      visibleComputedColumns.filter(
+        (column) => column.computedLocked === false
+      ),
+    [visibleComputedColumns]
+  );
   const columnWidthPrefixSums = React.useMemo(() => {
     const sums: number[] = [];
     let running = 0;
@@ -3860,6 +3892,55 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
     return sums;
   }, [columnLayout]);
+  const lockedColumnMetrics = React.useMemo(() => {
+    const lockedStartCount = visibleComputedColumns.filter(
+      (column) => column.computedLocked === "start"
+    ).length;
+    const lockedEndCount = visibleComputedColumns.filter(
+      (column) => column.computedLocked === "end"
+    ).length;
+    const firstLockedEndIndex =
+      lockedEndCount > 0 ? visibleComputedColumns.length - lockedEndCount : -1;
+    const firstUnlockedIndex =
+      visibleComputedColumns.length - lockedStartCount - lockedEndCount > 0
+        ? lockedStartCount
+        : -1;
+    const lastUnlockedIndex =
+      firstUnlockedIndex >= 0
+        ? visibleComputedColumns.length - lockedEndCount - 1
+        : -1;
+    const totalLockedStartWidth = visibleComputedColumns.reduce(
+      (total, column) =>
+        total +
+        (column.computedLocked === "start" ? (column.computedWidth ?? 0) : 0),
+      0
+    );
+    const totalLockedEndWidth = visibleComputedColumns.reduce(
+      (total, column) =>
+        total +
+        (column.computedLocked === "end" ? (column.computedWidth ?? 0) : 0),
+      0
+    );
+    const totalComputedWidth =
+      columnWidthPrefixSums[columnWidthPrefixSums.length - 1] ?? 0;
+
+    return {
+      hasLockedStart: lockedStartCount > 0,
+      hasLockedEnd: lockedEndCount > 0,
+      hasUnlocked: firstUnlockedIndex >= 0,
+      firstLockedStartIndex: lockedStartCount > 0 ? 0 : -1,
+      lastLockedStartIndex: lockedStartCount - 1,
+      firstUnlockedIndex,
+      lastUnlockedIndex,
+      firstLockedEndIndex,
+      lastLockedEndIndex:
+        lockedEndCount > 0 ? visibleComputedColumns.length - 1 : -1,
+      totalLockedStartWidth,
+      totalLockedEndWidth,
+      totalUnlockedWidth:
+        totalComputedWidth - totalLockedStartWidth - totalLockedEndWidth,
+    };
+  }, [columnWidthPrefixSums, visibleComputedColumns]);
   const columnFlexes = React.useMemo<Record<string, number>>(() => {
     return { ...columnWidthAllocation.flexWeights };
   }, [columnWidthAllocation.flexWeights]);
@@ -4312,6 +4393,10 @@ function ReactDataGrid(props: TypeDataGridProps) {
       const viewport = scrollRef.current;
       const column = visibleComputedColumns[index];
       if (!viewport || !column) return;
+      if (column.computedLocked) {
+        callback?.();
+        return;
+      }
       const columnStart =
         index === 0 ? 0 : (columnWidthPrefixSums[index - 1] ?? 0);
       const columnEnd = columnWidthPrefixSums[index] ?? columnStart;
@@ -4978,15 +5063,10 @@ function ReactDataGrid(props: TypeDataGridProps) {
       completeEdit: completeEditCompat,
       currentEditCompletePromise: currentEditCompletePromiseRef,
       computedShowEmptyRows: false,
-      hasLockedStart: false,
-      hasLockedEnd: false,
-      hasUnlocked: visibleComputedColumns.length > 0,
-      firstLockedStartIndex: -1,
-      firstLockedEndIndex: -1,
-      firstUnlockedIndex: visibleComputedColumns.length > 0 ? 0 : -1,
-      lastLockedStartIndex: -1,
-      lastUnlockedIndex: visibleComputedColumns.length - 1,
-      lastLockedEndIndex: -1,
+      lockedStartColumns,
+      unlockedColumns,
+      lockedEndColumns,
+      ...lockedColumnMetrics,
       computedOnColumnResize: ({
         index,
         diff,
@@ -5100,6 +5180,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
     loadData,
     loading,
     loadSkip,
+    lockedColumnMetrics,
+    lockedEndColumns,
+    lockedStartColumns,
     openFilterMenuColId,
     orderedColumns,
     originalData,
@@ -5140,6 +5223,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     startEditCompat,
     toggleColumnSortCompat,
     tryStartEditCompat,
+    unlockedColumns,
     scrollToCellCompat,
     scrollToColumnCompat,
     scrollToIndexCompat,
@@ -5319,8 +5403,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           filterTypes={filterTypes}
                           openFilterMenuColId={openFilterMenuColId}
                           setOpenFilterMenuColId={setOpenFilterMenuColId}
-                          virtualizeColumns={computedVirtualizeColumns}
-                          columnRenderRange={columnRenderRange}
+                          columnRenderItems={columnRenderItems}
+                          lockedColumnLayout={lockedColumnLayout}
                         />
                       </table>
                     </div>
@@ -5352,7 +5436,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
                     showVerticalCellBorders={showVerticalCellBorders}
                     virtualized={virtualized}
                     virtualizeColumns={computedVirtualizeColumns}
-                    columnRenderRange={columnRenderRange}
+                    columnRenderItems={columnRenderItems}
+                    lockedColumnLayout={lockedColumnLayout}
                     virtualItems={virtualItems}
                     paddingTop={paddingTop}
                     paddingBottom={paddingBottom}
@@ -5387,6 +5472,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
                       computedShowCellBorders: showCellBorders,
                       editable,
                       getItemId: (data) => (data as any)?.[idProperty],
+                      ...lockedColumnMetrics,
                     }}
                     showZebraRows={showZebraRows}
                     editingCell={coordinateEditingCell}

--- a/src/grid/components/FilterCell.tsx
+++ b/src/grid/components/FilterCell.tsx
@@ -51,6 +51,7 @@ import {
   normalizeEditorOutput,
 } from "../utils/gridUtils";
 import { FilterOperatorMenu } from "./FilterOperatorMenu";
+import type { TypeLockedColumnLayout } from "../utils/lockedColumns";
 
 const DEFAULT_FILTER_CELL_PADDING = "0 0.25rem";
 
@@ -64,6 +65,7 @@ export type FilterCellProps = {
   filterRowHeight: number;
 
   width?: number;
+  lockedLayout?: TypeLockedColumnLayout;
 
   enableFiltering: boolean;
   enableColumnFilterContextMenu: boolean;
@@ -148,6 +150,7 @@ export function FilterCell(props: FilterCellProps) {
     columnIndex,
     filterRowHeight,
     width,
+    lockedLayout,
     enableFiltering,
     enableColumnFilterContextMenu,
     checkboxEnabled,
@@ -328,6 +331,16 @@ export function FilterCell(props: FilterCellProps) {
       data-column-id={colId}
       className={cn(
         "tdg-filter-cell InovuaReactDataGrid__filter-cell InovuaReactDataGrid__column-header__filter-wrapper bg-[var(--tdg-filter-bg)] [color:var(--tdg-filter-color)]",
+        lockedLayout
+          ? [
+              "tdg-locked-column",
+              `tdg-locked-column--${lockedLayout.side}`,
+              `InovuaReactDataGrid__filter-cell--locked-${lockedLayout.side}`,
+              lockedLayout.boundary
+                ? `tdg-locked-column--${lockedLayout.side}-boundary`
+                : "",
+            ]
+          : "",
         showVerticalCellBorders
           ? "InovuaReactDataGrid__filter-cell--show-border-right"
           : "",
@@ -345,6 +358,12 @@ export function FilterCell(props: FilterCellProps) {
           maxWidth: col?.maxWidth,
           height: filterRowHeight,
           "--tdg-filter-cell-padding": filterCellPadding,
+          ...(lockedLayout
+            ? {
+                "--tdg-locked-column-offset": `${lockedLayout.offset}px`,
+                "--tdg-locked-column-viewport-offset": `${lockedLayout.viewportOffset}px`,
+              }
+            : {}),
         } as React.CSSProperties
       }
       onContextMenu={(e) => {

--- a/src/grid/components/GridBody.tsx
+++ b/src/grid/components/GridBody.tsx
@@ -20,6 +20,10 @@ import { cn } from "../../lib/utils";
 import { buildEditCellProps } from "../utils/editing";
 import { resolveEmptyText } from "../utils/emptyText";
 import { resolveConfiguredRowHeight } from "../utils/rowHeight";
+import type {
+  TypeGridColumnRenderItem,
+  TypeLockedColumnLayout,
+} from "../utils/lockedColumns";
 
 import { TableBody, TableCell, TableRow } from "../../components/ui/table";
 
@@ -189,13 +193,8 @@ export type GridBodyProps = {
 
   virtualized: boolean;
   virtualizeColumns: boolean;
-  columnRenderRange: {
-    firstIndex: number;
-    lastIndex: number;
-    beforeWidth: number;
-    afterWidth: number;
-    columnRenderCount: number;
-  };
+  columnRenderItems: TypeGridColumnRenderItem[];
+  lockedColumnLayout: Record<string, TypeLockedColumnLayout>;
   virtualItems: any[];
   paddingTop: number;
   paddingBottom: number;
@@ -231,6 +230,17 @@ export type GridBodyProps = {
     computedShowCellBorders: TypeShowCellBorders;
     editable: boolean;
     getItemId: (data: any) => unknown;
+    firstUnlockedIndex: number;
+    lastUnlockedIndex: number;
+    firstLockedStartIndex: number;
+    lastLockedStartIndex: number;
+    firstLockedEndIndex: number;
+    lastLockedEndIndex: number;
+    hasLockedStart: boolean;
+    hasLockedEnd: boolean;
+    totalUnlockedWidth: number;
+    totalLockedStartWidth: number;
+    totalLockedEndWidth: number;
   };
   showZebraRows: boolean;
 
@@ -260,7 +270,8 @@ export function GridBody(props: GridBodyProps) {
     showVerticalCellBorders,
     virtualized,
     virtualizeColumns,
-    columnRenderRange,
+    columnRenderItems,
+    lockedColumnLayout,
     virtualItems,
     paddingTop,
     paddingBottom,
@@ -294,11 +305,7 @@ export function GridBody(props: GridBodyProps) {
     },
     [measureElement]
   );
-  const renderedTableColumnCount = virtualizeColumns
-    ? columnRenderRange.columnRenderCount +
-      (columnRenderRange.beforeWidth > 0 ? 1 : 0) +
-      (columnRenderRange.afterWidth > 0 ? 1 : 0)
-    : orderedColumns.length;
+  const renderedTableColumnCount = columnRenderItems.length;
 
   function getRowThemeClasses(
     rowIndex: number,
@@ -401,21 +408,21 @@ export function GridBody(props: GridBodyProps) {
               columnsMap: rowStyleMetadata.columnsMap,
               columnRenderCount: rowStyleMetadata.columnRenderCount,
               totalColumnCount: rowStyleMetadata.totalColumnCount,
-              firstUnlockedIndex: rowStyleMetadata.columns.length > 0 ? 0 : -1,
-              lastUnlockedIndex: rowStyleMetadata.columns.length - 1,
-              firstLockedStartIndex: -1,
-              lastLockedStartIndex: -1,
-              firstLockedEndIndex: -1,
-              lastLockedEndIndex: -1,
-              hasLockedStart: false,
-              hasLockedEnd: false,
+              firstUnlockedIndex: rowStyleMetadata.firstUnlockedIndex,
+              lastUnlockedIndex: rowStyleMetadata.lastUnlockedIndex,
+              firstLockedStartIndex: rowStyleMetadata.firstLockedStartIndex,
+              lastLockedStartIndex: rowStyleMetadata.lastLockedStartIndex,
+              firstLockedEndIndex: rowStyleMetadata.firstLockedEndIndex,
+              lastLockedEndIndex: rowStyleMetadata.lastLockedEndIndex,
+              hasLockedStart: rowStyleMetadata.hasLockedStart,
+              hasLockedEnd: rowStyleMetadata.hasLockedEnd,
               availableWidth: rowStyleMetadata.availableWidth,
               width: rowStyleMetadata.totalComputedWidth,
               minWidth: rowStyleMetadata.totalComputedWidth,
               totalComputedWidth: rowStyleMetadata.totalComputedWidth,
-              totalUnlockedWidth: rowStyleMetadata.totalComputedWidth,
-              totalLockedStartWidth: 0,
-              totalLockedEndWidth: 0,
+              totalUnlockedWidth: rowStyleMetadata.totalUnlockedWidth,
+              totalLockedStartWidth: rowStyleMetadata.totalLockedStartWidth,
+              totalLockedEndWidth: rowStyleMetadata.totalLockedEndWidth,
               totalDataCount: rowStyleMetadata.dataSourceArray.length,
               maxVisibleRows: rowStyleMetadata.maxVisibleRows,
               rowHeight: resolvedHeight ?? minRowHeight,
@@ -668,35 +675,34 @@ export function GridBody(props: GridBodyProps) {
         : undefined;
 
     const allCells = row.getVisibleCells();
-    const renderedCells = virtualizeColumns
-      ? allCells.slice(
-          columnRenderRange.firstIndex,
-          columnRenderRange.lastIndex + 1
-        )
-      : allCells;
-
     return (
       <>
-        {columnRenderRange.beforeWidth > 0 && virtualizeColumns ? (
-          <TableCell
-            aria-hidden="true"
-            className="pointer-events-none !p-0"
-            style={{
-              width: columnRenderRange.beforeWidth,
-              minWidth: columnRenderRange.beforeWidth,
-              maxWidth: columnRenderRange.beforeWidth,
-            }}
-          />
-        ) : null}
-        {renderedCells.map((cell: any, renderedIndex: number) => {
-          const cellIndex = virtualizeColumns
-            ? columnRenderRange.firstIndex + renderedIndex
-            : renderedIndex;
+        {columnRenderItems.map((renderItem) => {
+          if (renderItem.type === "spacer") {
+            return (
+              <TableCell
+                key={renderItem.id}
+                aria-hidden="true"
+                className="pointer-events-none !p-0"
+                style={{
+                  width: renderItem.width,
+                  minWidth: renderItem.width,
+                  maxWidth: renderItem.width,
+                }}
+              />
+            );
+          }
+
+          const cellIndex = renderItem.index;
+          const cell = allCells[cellIndex];
+          if (!cell) return null;
+
           const columnId = cell.column.id;
           const column = (cell.column.columnDef as any)?.meta?.__column as
             | TypeColumn
             | undefined;
           const width = cell.column.getSize();
+          const lockedLayout = lockedColumnLayout[columnId];
           const cellKey = `${String(row.id)}\u0000${columnId}`;
           const align = column?.textAlign;
           const isLastCell = cellIndex === allCells.length - 1;
@@ -771,6 +777,16 @@ export function GridBody(props: GridBodyProps) {
                 userSelectClass,
                 "InovuaReactDataGrid__cell",
                 "InovuaReactDataGrid__cell--direction-ltr",
+                lockedLayout
+                  ? [
+                      "tdg-locked-column",
+                      `tdg-locked-column--${lockedLayout.side}`,
+                      `InovuaReactDataGrid__cell--locked-${lockedLayout.side}`,
+                      lockedLayout.boundary
+                        ? `tdg-locked-column--${lockedLayout.side}-boundary`
+                        : "",
+                    ]
+                  : "",
                 showHorizontalCellBorders
                   ? "InovuaReactDataGrid__cell--show-border-bottom"
                   : "",
@@ -796,6 +812,12 @@ export function GridBody(props: GridBodyProps) {
                 maxWidth: column?.maxWidth,
                 ...(typeof column?.style === "object" && column?.style
                   ? column.style
+                  : {}),
+                ...(lockedLayout
+                  ? ({
+                      "--tdg-locked-column-offset": `${lockedLayout.offset}px`,
+                      "--tdg-locked-column-viewport-offset": `${lockedLayout.viewportOffset}px`,
+                    } as React.CSSProperties)
                   : {}),
                 ...(isEditingThisCell && rowHeight == null
                   ? {
@@ -844,17 +866,6 @@ export function GridBody(props: GridBodyProps) {
             </TableCell>
           );
         })}
-        {columnRenderRange.afterWidth > 0 && virtualizeColumns ? (
-          <TableCell
-            aria-hidden="true"
-            className="pointer-events-none !p-0"
-            style={{
-              width: columnRenderRange.afterWidth,
-              minWidth: columnRenderRange.afterWidth,
-              maxWidth: columnRenderRange.afterWidth,
-            }}
-          />
-        ) : null}
       </>
     );
   }

--- a/src/grid/components/GridHeader.tsx
+++ b/src/grid/components/GridHeader.tsx
@@ -13,6 +13,10 @@ import type {
 import { TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { HeaderCell } from "./HeaderCell";
 import { FilterCell } from "./FilterCell";
+import type {
+  TypeGridColumnRenderItem,
+  TypeLockedColumnLayout,
+} from "../utils/lockedColumns";
 
 export type GridHeaderProps = {
   headerGroups: any[];
@@ -62,13 +66,8 @@ export type GridHeaderProps = {
   openFilterMenuColId: string | null;
   setOpenFilterMenuColId: (id: string | null) => void;
 
-  virtualizeColumns: boolean;
-  columnRenderRange: {
-    firstIndex: number;
-    lastIndex: number;
-    beforeWidth: number;
-    afterWidth: number;
-  };
+  columnRenderItems: TypeGridColumnRenderItem[];
+  lockedColumnLayout: Record<string, TypeLockedColumnLayout>;
 };
 
 function ColumnSpacerHeader(props: { width: number }) {
@@ -123,8 +122,8 @@ export function GridHeader(props: GridHeaderProps) {
     filterTypes,
     openFilterMenuColId,
     setOpenFilterMenuColId,
-    virtualizeColumns,
-    columnRenderRange,
+    columnRenderItems,
+    lockedColumnLayout,
   } = props;
 
   return (
@@ -136,68 +135,66 @@ export function GridHeader(props: GridHeaderProps) {
           className="tdg-header-row InovuaReactDataGrid__header-row bg-[var(--tdg-header-bg)]"
           style={{ height: headerHeight }}
         >
-          <ColumnSpacerHeader
-            width={virtualizeColumns ? columnRenderRange.beforeWidth : 0}
-          />
-          {hg.headers
-            .slice(
-              virtualizeColumns ? columnRenderRange.firstIndex : 0,
-              virtualizeColumns
-                ? columnRenderRange.lastIndex + 1
-                : hg.headers.length
-            )
-            .map((h: any, renderedIndex: number) => {
-              const columnIndex = virtualizeColumns
-                ? columnRenderRange.firstIndex + renderedIndex
-                : renderedIndex;
-              const colDef = h.column.columnDef as any;
-              const col: TypeColumn | undefined = colDef?.meta?.__column;
-              const colId = h.column.id;
-
-              const width = h.getSize();
-
-              const canDrag =
-                allowColumnReorder &&
-                (!checkboxEnabled || colId !== checkboxColId) &&
-                (col?.draggable ?? true);
-              const canResize =
-                allowColumnResize &&
-                (!checkboxEnabled || colId !== checkboxColId) &&
-                (col?.resizable ?? true);
-
+          {columnRenderItems.map((renderItem) => {
+            if (renderItem.type === "spacer") {
               return (
-                <HeaderCell
-                  key={h.id}
-                  header={h}
-                  col={col}
-                  colId={colId}
-                  columnIndex={columnIndex}
-                  width={width}
-                  headerHeight={headerHeight}
-                  sortInfo={sortInfo}
-                  setSortInfo={setSortInfo}
-                  setSkip={setSkip}
-                  allowUnsort={allowUnsort}
-                  defaultSortDir={defaultSortDir}
-                  showColumnMenuTool={showColumnMenuTool}
-                  showHorizontalCellBorders={showHorizontalCellBorders}
-                  showVerticalCellBorders={showVerticalCellBorders}
-                  i18n={i18n}
-                  canDrag={Boolean(canDrag)}
-                  onDragStart={onHeaderDragStart}
-                  onDragOver={onHeaderDragOver}
-                  onDrop={onHeaderDrop}
-                  canResize={canResize}
-                  isResizing={resizingColumnId === colId}
-                  onResizeStart={onColumnResizeStart}
-                  onResizeBy={onColumnResizeBy}
-                  onAutoResize={onColumnAutoResize}
+                <ColumnSpacerHeader
+                  key={`${hg.id}-${renderItem.id}`}
+                  width={renderItem.width}
                 />
               );
-            })}
-          <ColumnSpacerHeader
-            width={virtualizeColumns ? columnRenderRange.afterWidth : 0}
-          />
+            }
+
+            const h = hg.headers[renderItem.index];
+            if (!h) return null;
+
+            const columnIndex = renderItem.index;
+            const colDef = h.column.columnDef as any;
+            const col: TypeColumn | undefined = colDef?.meta?.__column;
+            const colId = h.column.id;
+
+            const width = h.getSize();
+
+            const canDrag =
+              allowColumnReorder &&
+              (!checkboxEnabled || colId !== checkboxColId) &&
+              (col?.draggable ?? true);
+            const canResize =
+              allowColumnResize &&
+              (!checkboxEnabled || colId !== checkboxColId) &&
+              (col?.resizable ?? true);
+
+            return (
+              <HeaderCell
+                key={h.id}
+                header={h}
+                col={col}
+                colId={colId}
+                columnIndex={columnIndex}
+                width={width}
+                lockedLayout={lockedColumnLayout[colId]}
+                headerHeight={headerHeight}
+                sortInfo={sortInfo}
+                setSortInfo={setSortInfo}
+                setSkip={setSkip}
+                allowUnsort={allowUnsort}
+                defaultSortDir={defaultSortDir}
+                showColumnMenuTool={showColumnMenuTool}
+                showHorizontalCellBorders={showHorizontalCellBorders}
+                showVerticalCellBorders={showVerticalCellBorders}
+                i18n={i18n}
+                canDrag={Boolean(canDrag)}
+                onDragStart={onHeaderDragStart}
+                onDragOver={onHeaderDragOver}
+                onDrop={onHeaderDrop}
+                canResize={canResize}
+                isResizing={resizingColumnId === colId}
+                onResizeStart={onColumnResizeStart}
+                onResizeBy={onColumnResizeBy}
+                onAutoResize={onColumnAutoResize}
+              />
+            );
+          })}
         </TableRow>
       ))}
 
@@ -209,61 +206,57 @@ export function GridHeader(props: GridHeaderProps) {
             className="tdg-filter-row InovuaReactDataGrid__filter-row bg-[var(--tdg-filter-bg)]"
             style={{ height: filterRowHeight }}
           >
-            <ColumnSpacerHeader
-              width={virtualizeColumns ? columnRenderRange.beforeWidth : 0}
-            />
-            {hg.headers
-              .slice(
-                virtualizeColumns ? columnRenderRange.firstIndex : 0,
-                virtualizeColumns
-                  ? columnRenderRange.lastIndex + 1
-                  : hg.headers.length
-              )
-              .map((h: any, renderedIndex: number) => {
-                const columnIndex = virtualizeColumns
-                  ? columnRenderRange.firstIndex + renderedIndex
-                  : renderedIndex;
-                const colDef = h.column.columnDef as any;
-                const col: TypeColumn | undefined = colDef?.meta?.__column;
-                const colId = h.column.id;
-
-                const width = h.getSize();
-
+            {columnRenderItems.map((renderItem) => {
+              if (renderItem.type === "spacer") {
                 return (
-                  <FilterCell
-                    key={`${h.id}-filter`}
-                    header={h}
-                    col={col}
-                    colId={colId}
-                    columnIndex={columnIndex}
-                    width={width}
-                    headerHeight={headerHeight}
-                    filterRowHeight={filterRowHeight}
-                    enableFiltering={enableFiltering}
-                    enableColumnFilterContextMenu={
-                      enableColumnFilterContextMenu
-                    }
-                    checkboxEnabled={checkboxEnabled}
-                    checkboxColId={checkboxColId}
-                    filterControlled={filterControlled}
-                    filterValue={filterValue}
-                    draftFilterValue={draftFilterValue}
-                    setFilterValue={setFilterValue}
-                    setDraftFilterValue={setDraftFilterValue}
-                    onColumnFilterValueChange={onColumnFilterValueChange}
-                    setSkip={setSkip}
-                    filterTypes={filterTypes}
-                    i18n={i18n}
-                    showHorizontalCellBorders={showHorizontalCellBorders}
-                    showVerticalCellBorders={showVerticalCellBorders}
-                    openFilterMenuColId={openFilterMenuColId}
-                    setOpenFilterMenuColId={setOpenFilterMenuColId}
+                  <ColumnSpacerHeader
+                    key={`${hg.id}-filters-${renderItem.id}`}
+                    width={renderItem.width}
                   />
                 );
-              })}
-            <ColumnSpacerHeader
-              width={virtualizeColumns ? columnRenderRange.afterWidth : 0}
-            />
+              }
+
+              const h = hg.headers[renderItem.index];
+              if (!h) return null;
+
+              const columnIndex = renderItem.index;
+              const colDef = h.column.columnDef as any;
+              const col: TypeColumn | undefined = colDef?.meta?.__column;
+              const colId = h.column.id;
+
+              const width = h.getSize();
+
+              return (
+                <FilterCell
+                  key={`${h.id}-filter`}
+                  header={h}
+                  col={col}
+                  colId={colId}
+                  columnIndex={columnIndex}
+                  width={width}
+                  lockedLayout={lockedColumnLayout[colId]}
+                  headerHeight={headerHeight}
+                  filterRowHeight={filterRowHeight}
+                  enableFiltering={enableFiltering}
+                  enableColumnFilterContextMenu={enableColumnFilterContextMenu}
+                  checkboxEnabled={checkboxEnabled}
+                  checkboxColId={checkboxColId}
+                  filterControlled={filterControlled}
+                  filterValue={filterValue}
+                  draftFilterValue={draftFilterValue}
+                  setFilterValue={setFilterValue}
+                  setDraftFilterValue={setDraftFilterValue}
+                  onColumnFilterValueChange={onColumnFilterValueChange}
+                  setSkip={setSkip}
+                  filterTypes={filterTypes}
+                  i18n={i18n}
+                  showHorizontalCellBorders={showHorizontalCellBorders}
+                  showVerticalCellBorders={showVerticalCellBorders}
+                  openFilterMenuColId={openFilterMenuColId}
+                  setOpenFilterMenuColId={setOpenFilterMenuColId}
+                />
+              );
+            })}
           </TableRow>
         ))}
     </TableHeader>

--- a/src/grid/components/HeaderCell.tsx
+++ b/src/grid/components/HeaderCell.tsx
@@ -16,6 +16,7 @@ import { t } from "../../utils/helpers";
 import { getColumnSortName } from "../../utils/column";
 import { isInteractiveClickTarget } from "../utils/gridUtils";
 import { getSortDir, toggleSortInfo } from "../../sorting/utils";
+import type { TypeLockedColumnLayout } from "../utils/lockedColumns";
 
 import { Button } from "../../components/ui/button";
 import {
@@ -92,6 +93,7 @@ export type HeaderCellProps = {
 
   headerHeight: number;
   width?: number;
+  lockedLayout?: TypeLockedColumnLayout;
 
   sortInfo: TypeSortInfo;
   setSortInfo: (s: TypeSortInfo) => void;
@@ -126,6 +128,7 @@ export function HeaderCell(props: HeaderCellProps) {
     columnIndex,
     headerHeight,
     width,
+    lockedLayout,
     sortInfo,
     setSortInfo,
     setSkip,
@@ -184,6 +187,16 @@ export function HeaderCell(props: HeaderCellProps) {
       className={cn(
         "tdg-header-cell InovuaReactDataGrid__column-header bg-[var(--tdg-header-bg)] [color:var(--tdg-header-color)] [font-size:var(--tdg-header-font-size)] [font-weight:var(--tdg-header-font-weight)]",
         "InovuaReactDataGrid__column-header--direction-ltr",
+        lockedLayout
+          ? [
+              "tdg-locked-column",
+              `tdg-locked-column--${lockedLayout.side}`,
+              `InovuaReactDataGrid__column-header--locked-${lockedLayout.side}`,
+              lockedLayout.boundary
+                ? `tdg-locked-column--${lockedLayout.side}-boundary`
+                : "",
+            ]
+          : "",
         headerAlignClass,
         canSort
           ? "cursor-default select-none outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
@@ -207,6 +220,12 @@ export function HeaderCell(props: HeaderCellProps) {
         maxWidth: col?.maxWidth,
         height: headerHeight,
         ...col?.headerProps?.style,
+        ...(lockedLayout
+          ? ({
+              "--tdg-locked-column-offset": `${lockedLayout.offset}px`,
+              "--tdg-locked-column-viewport-offset": `${lockedLayout.viewportOffset}px`,
+            } as React.CSSProperties)
+          : {}),
       }}
       draggable={Boolean(canDrag)}
       onDragStart={(e) => {

--- a/src/grid/utils/lockedColumns.ts
+++ b/src/grid/utils/lockedColumns.ts
@@ -1,0 +1,242 @@
+import type { TypeColumn } from "../../types";
+import { getColumnId } from "../../utils/column";
+
+export type TypeResolvedColumnLock = "start" | "end" | false;
+
+export type TypeLockedColumnLayout = {
+  side: Exclude<TypeResolvedColumnLock, false>;
+  offset: number;
+  viewportOffset: number;
+  boundary: boolean;
+};
+
+export type TypeGridColumnRenderItem =
+  | {
+      type: "column";
+      id: string;
+      index: number;
+    }
+  | {
+      type: "spacer";
+      id: string;
+      width: number;
+    };
+
+type TypeColumnLayoutItem = {
+  id: string;
+  width: number;
+};
+
+export function resolveColumnLock(
+  column: Pick<TypeColumn, "locked">
+): TypeResolvedColumnLock {
+  if (column.locked === true || column.locked === "start") return "start";
+  if (column.locked === "end") return "end";
+  return false;
+}
+
+/**
+ * Inovua renders locked-start, unlocked, and locked-end sections in that
+ * order while preserving the consumer's relative order inside each section.
+ */
+export function groupColumnsByLock(
+  columns: readonly TypeColumn[]
+): TypeColumn[] {
+  const lockedStart: TypeColumn[] = [];
+  const unlocked: TypeColumn[] = [];
+  const lockedEnd: TypeColumn[] = [];
+
+  for (const column of columns) {
+    const locked = resolveColumnLock(column);
+    if (locked === "start") lockedStart.push(column);
+    else if (locked === "end") lockedEnd.push(column);
+    else unlocked.push(column);
+  }
+
+  return [...lockedStart, ...unlocked, ...lockedEnd];
+}
+
+export function buildLockedColumnLayout(
+  columns: readonly TypeColumn[],
+  columnWidths: Readonly<Record<string, number>>,
+  lockedEndViewportOffset = 0
+): Record<string, TypeLockedColumnLayout> {
+  const result: Record<string, TypeLockedColumnLayout> = {};
+  const lockedStart = columns.filter(
+    (column) => resolveColumnLock(column) === "start"
+  );
+  const lockedEnd = columns.filter(
+    (column) => resolveColumnLock(column) === "end"
+  );
+
+  let startOffset = 0;
+  lockedStart.forEach((column, index) => {
+    const columnId = getColumnId(column);
+    result[columnId] = {
+      side: "start",
+      offset: startOffset,
+      viewportOffset: 0,
+      boundary: index === lockedStart.length - 1,
+    };
+    startOffset += columnWidths[columnId] ?? 0;
+  });
+
+  let endOffset = 0;
+  for (let index = lockedEnd.length - 1; index >= 0; index -= 1) {
+    const column = lockedEnd[index]!;
+    const columnId = getColumnId(column);
+    result[columnId] = {
+      side: "end",
+      offset: endOffset,
+      viewportOffset: lockedEndViewportOffset,
+      boundary: index === 0,
+    };
+    endOffset += columnWidths[columnId] ?? 0;
+  }
+
+  return result;
+}
+
+function sumWidths(
+  columns: readonly TypeColumnLayoutItem[],
+  from: number,
+  to: number
+): number {
+  let result = 0;
+  for (let index = from; index < to; index += 1) {
+    result += columns[index]?.width ?? 0;
+  }
+  return result;
+}
+
+export function buildGridColumnRenderItems(args: {
+  columnLayout: readonly TypeColumnLayoutItem[];
+  columns: readonly TypeColumn[];
+  virtualColumnIndexes: readonly number[];
+  virtualizeColumns: boolean;
+}): {
+  items: TypeGridColumnRenderItem[];
+  firstIndex: number;
+  lastIndex: number;
+  beforeWidth: number;
+  afterWidth: number;
+  columnRenderCount: number;
+} {
+  const { columnLayout, columns, virtualColumnIndexes, virtualizeColumns } =
+    args;
+  const totalColumnCount = columnLayout.length;
+
+  if (
+    !virtualizeColumns ||
+    totalColumnCount === 0 ||
+    virtualColumnIndexes.length === 0
+  ) {
+    return {
+      items: columnLayout.map((column, index) => ({
+        type: "column",
+        id: column.id,
+        index,
+      })),
+      firstIndex: 0,
+      lastIndex: totalColumnCount - 1,
+      beforeWidth: 0,
+      afterWidth: 0,
+      columnRenderCount: totalColumnCount,
+    };
+  }
+
+  let lockedStartCount = 0;
+  while (
+    lockedStartCount < columns.length &&
+    resolveColumnLock(columns[lockedStartCount]!) === "start"
+  ) {
+    lockedStartCount += 1;
+  }
+
+  let lockedEndStartIndex = columns.length;
+  while (
+    lockedEndStartIndex > lockedStartCount &&
+    resolveColumnLock(columns[lockedEndStartIndex - 1]!) === "end"
+  ) {
+    lockedEndStartIndex -= 1;
+  }
+
+  const unlockedCount = lockedEndStartIndex - lockedStartCount;
+  const unlockedVirtualIndexes = virtualColumnIndexes.filter(
+    (index) => index >= lockedStartCount && index < lockedEndStartIndex
+  );
+
+  // A very wide locked section can consume the virtualizer's initial range.
+  // Keep the nearest unlocked boundary mounted so horizontal navigation can
+  // advance into that section without waiting for an empty intermediate pass.
+  if (unlockedCount > 0 && unlockedVirtualIndexes.length === 0) {
+    const lastVirtualIndex =
+      virtualColumnIndexes[virtualColumnIndexes.length - 1] ?? -1;
+    unlockedVirtualIndexes.push(
+      lastVirtualIndex < lockedStartCount
+        ? lockedStartCount
+        : lockedEndStartIndex - 1
+    );
+  }
+
+  const firstIndex =
+    unlockedVirtualIndexes[0] ?? Math.min(lockedStartCount, totalColumnCount);
+  const lastIndex =
+    unlockedVirtualIndexes[unlockedVirtualIndexes.length - 1] ?? firstIndex - 1;
+  const beforeWidth =
+    unlockedCount > 0
+      ? sumWidths(columnLayout, lockedStartCount, firstIndex)
+      : 0;
+  const afterWidth =
+    unlockedCount > 0
+      ? sumWidths(columnLayout, lastIndex + 1, lockedEndStartIndex)
+      : 0;
+  const items: TypeGridColumnRenderItem[] = [];
+
+  for (let index = 0; index < lockedStartCount; index += 1) {
+    const column = columnLayout[index];
+    if (column) {
+      items.push({ type: "column", id: column.id, index });
+    }
+  }
+
+  if (beforeWidth > 0) {
+    items.push({
+      type: "spacer",
+      id: "__tdg_virtual_columns_before__",
+      width: beforeWidth,
+    });
+  }
+
+  for (let index = firstIndex; index <= lastIndex; index += 1) {
+    if (index < lockedStartCount || index >= lockedEndStartIndex) continue;
+    const column = columnLayout[index];
+    if (column) {
+      items.push({ type: "column", id: column.id, index });
+    }
+  }
+
+  if (afterWidth > 0) {
+    items.push({
+      type: "spacer",
+      id: "__tdg_virtual_columns_after__",
+      width: afterWidth,
+    });
+  }
+
+  for (let index = lockedEndStartIndex; index < totalColumnCount; index += 1) {
+    const column = columnLayout[index];
+    if (column) {
+      items.push({ type: "column", id: column.id, index });
+    }
+  }
+
+  return {
+    items,
+    firstIndex,
+    lastIndex,
+    beforeWidth,
+    afterWidth,
+    columnRenderCount: items.filter((item) => item.type === "column").length,
+  };
+}

--- a/src/runtime.css
+++ b/src/runtime.css
@@ -916,6 +916,53 @@
   position: relative !important;
 }
 
+/*
+ * Locked columns use the Inovua column contract (`locked: true | "start" |
+ * "end"`). Offsets are numeric layout data supplied by the grid; color and
+ * elevation continue to come from the shadcn-aligned theme tokens.
+ */
+.tdg-root .tdg-locked-column {
+  position: sticky !important;
+  z-index: 2 !important;
+  background: inherit !important;
+  background-clip: padding-box !important;
+}
+
+.tdg-root .tdg-header-cell.tdg-locked-column {
+  z-index: 4 !important;
+  background: var(--tdg-header-bg) !important;
+}
+
+.tdg-root .tdg-filter-cell.tdg-locked-column {
+  z-index: 3 !important;
+  background: var(--tdg-filter-bg) !important;
+}
+
+.tdg-root .tdg-locked-column--start {
+  right: auto !important;
+  left: var(--tdg-locked-column-offset, 0px) !important;
+}
+
+.tdg-root .tdg-locked-column--end {
+  right: var(--tdg-locked-column-offset, 0px) !important;
+  left: auto !important;
+  transform: translateX(
+    var(--tdg-locked-column-viewport-offset, 0px)
+  ) !important;
+}
+
+.tdg-root .tdg-locked-column--start-boundary {
+  box-shadow:
+    1px 0 0 var(--tdg-grid-border-color),
+    8px 0 12px -12px var(--tdg-color-foreground) !important;
+}
+
+.tdg-root .tdg-locked-column--end-boundary {
+  box-shadow:
+    -1px 0 0 var(--tdg-grid-border-color),
+    -8px 0 12px -12px var(--tdg-color-foreground) !important;
+}
+
 .tdg-root .InovuaReactDataGrid__column-header__sort-button {
   display: flex !important;
   min-width: 0 !important;

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,19 +325,19 @@ export type TypeRowStyleProps = Record<string, unknown> & {
   totalColumnCount: number;
   firstUnlockedIndex: number;
   lastUnlockedIndex: number;
-  firstLockedStartIndex: -1;
-  lastLockedStartIndex: -1;
-  firstLockedEndIndex: -1;
-  lastLockedEndIndex: -1;
-  hasLockedStart: false;
-  hasLockedEnd: false;
+  firstLockedStartIndex: number;
+  lastLockedStartIndex: number;
+  firstLockedEndIndex: number;
+  lastLockedEndIndex: number;
+  hasLockedStart: boolean;
+  hasLockedEnd: boolean;
   availableWidth: number;
   width: number;
   minWidth: number;
   totalComputedWidth: number;
   totalUnlockedWidth: number;
-  totalLockedStartWidth: 0;
-  totalLockedEndWidth: 0;
+  totalLockedStartWidth: number;
+  totalLockedEndWidth: number;
   totalDataCount: number;
   maxVisibleRows: number;
   rowHeight: number;
@@ -424,6 +424,13 @@ export interface IColumn {
   hideable?: boolean;
   draggable?: boolean;
   resizable?: boolean;
+  /**
+   * Keeps the column visible at a horizontal edge.
+   *
+   * Inovua compatibility: `true` is an alias for `"start"`, while `"end"`
+   * pins action-style columns to the trailing edge.
+   */
+  locked?: "start" | "end" | true | false;
 
   sortable?: boolean;
   sortName?: string;
@@ -486,6 +493,7 @@ export type TypeGetColumnByParam =
 export type TypeComputedColumn = TypeColumn & {
   computedWidth?: number;
   computedVisibleIndex?: number;
+  computedLocked?: "start" | "end" | false;
   index?: number;
 };
 
@@ -662,6 +670,21 @@ export type TypeComputedProps = {
   visibleColumnsMap?: TypeComputedColumnsMap;
   allColumns?: TypeComputedColumn[];
   visibleColumns?: TypeComputedColumn[];
+  lockedStartColumns?: TypeComputedColumn[];
+  unlockedColumns?: TypeComputedColumn[];
+  lockedEndColumns?: TypeComputedColumn[];
+  hasLockedStart?: boolean;
+  hasLockedEnd?: boolean;
+  hasUnlocked?: boolean;
+  firstLockedStartIndex?: number;
+  lastLockedStartIndex?: number;
+  firstUnlockedIndex?: number;
+  lastUnlockedIndex?: number;
+  firstLockedEndIndex?: number;
+  lastLockedEndIndex?: number;
+  totalLockedStartWidth?: number;
+  totalUnlockedWidth?: number;
+  totalLockedEndWidth?: number;
   getColumnsInOrder?: () => TypeComputedColumn[];
   getColumnBy?: (
     column: TypeGetColumnByParam,

--- a/tests/playwright/actions-single-click.spec.ts
+++ b/tests/playwright/actions-single-click.spec.ts
@@ -1,8 +1,98 @@
 import { expect, test } from "@playwright/test";
 
+import type { TypeColumns } from "../../src/types";
+import {
+  buildGridColumnRenderItems,
+  buildLockedColumnLayout,
+  groupColumnsByLock,
+  resolveColumnLock,
+} from "../../src/grid/utils/lockedColumns";
+
+test("locked-column helpers normalize both start forms and accumulate offsets on each edge", () => {
+  const columns: TypeColumns = [
+    { name: "middle-a" },
+    { name: "end-a", locked: "end" },
+    { name: "start-alias", locked: true },
+    { name: "middle-b", locked: false },
+    { name: "start-explicit", locked: "start" },
+    { name: "end-b", locked: "end" },
+  ];
+  const grouped = groupColumnsByLock(columns);
+
+  expect(grouped.map((column) => column.name)).toEqual([
+    "start-alias",
+    "start-explicit",
+    "middle-a",
+    "middle-b",
+    "end-a",
+    "end-b",
+  ]);
+  expect(resolveColumnLock(grouped[0]!)).toBe("start");
+  expect(resolveColumnLock(grouped[1]!)).toBe("start");
+
+  const widths = {
+    "start-alias": 70,
+    "start-explicit": 90,
+    "middle-a": 120,
+    "middle-b": 130,
+    "end-a": 80,
+    "end-b": 100,
+  };
+  const layout = buildLockedColumnLayout(grouped, widths, 17);
+
+  expect(layout).toEqual({
+    "start-alias": {
+      side: "start",
+      offset: 0,
+      viewportOffset: 0,
+      boundary: false,
+    },
+    "start-explicit": {
+      side: "start",
+      offset: 70,
+      viewportOffset: 0,
+      boundary: true,
+    },
+    "end-a": {
+      side: "end",
+      offset: 100,
+      viewportOffset: 17,
+      boundary: true,
+    },
+    "end-b": {
+      side: "end",
+      offset: 0,
+      viewportOffset: 17,
+      boundary: false,
+    },
+  });
+
+  const renderItems = buildGridColumnRenderItems({
+    columns: grouped,
+    columnLayout: grouped.map((column) => ({
+      id: String(column.name),
+      width: widths[column.name as keyof typeof widths],
+    })),
+    virtualColumnIndexes: [2],
+    virtualizeColumns: true,
+  });
+
+  expect(
+    renderItems.items
+      .filter((item) => item.type === "column")
+      .map((item) => item.id)
+  ).toEqual(["start-alias", "start-explicit", "middle-a", "end-a", "end-b"]);
+  expect(renderItems.items).toContainEqual({
+    type: "spacer",
+    id: "__tdg_virtual_columns_after__",
+    width: 130,
+  });
+});
+
 test("actions example keeps the locked-end column mounted and aligned while horizontally virtualized", async ({
   page,
 }) => {
+  await page.setViewportSize({ width: 650, height: 900 });
   await page.goto("/actions");
 
   const preview = page.getByTestId("example-preview-panel");
@@ -15,11 +105,25 @@ test("actions example keeps the locked-end column mounted and aligned while hori
       'tbody [data-slot="grid-row"] .InovuaReactDataGrid__cell[data-column-id="actions"]'
     )
     .first();
+  const unlockedHeader = grid.locator(
+    '.tdg-header-cell[data-column-id="sample"]'
+  );
+  const unlockedFilter = grid.locator(
+    '.tdg-filter-cell[data-column-id="sample"]'
+  );
+  const unlockedCell = grid
+    .locator(
+      'tbody [data-slot="grid-row"] .InovuaReactDataGrid__cell[data-column-id="sample"]'
+    )
+    .first();
 
   await expect(grid).toBeVisible();
   await expect(header).toBeVisible();
   await expect(filter).toBeVisible();
   await expect(firstActionCell).toBeVisible();
+  await expect(unlockedHeader).toBeVisible();
+  await expect(unlockedFilter).toBeVisible();
+  await expect(unlockedCell).toBeVisible();
   await expect(header).toHaveCSS("position", "sticky");
   await expect(filter).toHaveCSS("position", "sticky");
   await expect(firstActionCell).toHaveCSS("position", "sticky");
@@ -59,15 +163,30 @@ test("actions example keeps the locked-end column mounted and aligned while hori
     );
   }
 
+  const initialScrollGeometry = await viewport.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+    scrollLeft: element.scrollLeft,
+  }));
+  expect(initialScrollGeometry.scrollWidth).toBeGreaterThan(
+    initialScrollGeometry.clientWidth
+  );
+  expect(initialScrollGeometry.scrollLeft).toBe(0);
+
   await viewport.evaluate((element) => {
     element.scrollLeft = element.scrollWidth;
     element.dispatchEvent(new Event("scroll", { bubbles: true }));
   });
-  await page.waitForTimeout(50);
+  await expect
+    .poll(() => viewport.evaluate((element) => element.scrollLeft))
+    .toBeGreaterThan(0);
 
   await expect(header).toBeVisible();
   await expect(filter).toBeVisible();
   await expect(firstActionCell).toBeVisible();
+  await expect(unlockedHeader).toHaveCount(0);
+  await expect(unlockedFilter).toHaveCount(0);
+  await expect(unlockedCell).toHaveCount(0);
 
   const scrolledGeometry = await Promise.all([
     viewport.boundingBox(),
@@ -109,6 +228,114 @@ test("actions example keeps the locked-end column mounted and aligned while hori
   await expect(preview.getByTestId("actions-stage-wf-201")).toHaveText(
     "Reviewing"
   );
+});
+
+test("imperative column scrolling reveals unlocked cells between both locked sections", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 650, height: 900 });
+  await page.goto("/actions");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const viewport = grid.locator(".tdg-body-viewport");
+  const lockedStart = grid.locator(
+    '.tdg-header-cell[data-column-id="__checkbox__"]'
+  );
+  const openedHeader = grid.locator(
+    '.tdg-header-cell[data-column-id="openedAt"]'
+  );
+  const lockedEnd = grid.locator('.tdg-header-cell[data-column-id="actions"]');
+
+  await expect(grid).toBeVisible();
+  await expect(lockedStart).toHaveCSS("position", "sticky");
+  await expect(lockedEnd).toHaveCSS("position", "sticky");
+  await preview.getByTestId("actions-reveal-opened").click();
+
+  await expect(openedHeader).toBeVisible();
+  await expect
+    .poll(() => viewport.evaluate((element) => element.scrollLeft))
+    .toBeGreaterThan(0);
+
+  const [startBox, openedBox, endBox] = await Promise.all([
+    lockedStart.boundingBox(),
+    openedHeader.boundingBox(),
+    lockedEnd.boundingBox(),
+  ]);
+  expect(startBox).not.toBeNull();
+  expect(openedBox).not.toBeNull();
+  expect(endBox).not.toBeNull();
+  expect(openedBox!.x).toBeGreaterThanOrEqual(
+    startBox!.x + startBox!.width - 2
+  );
+  expect(openedBox!.x + openedBox!.width).toBeLessThanOrEqual(endBox!.x + 2);
+});
+
+test("live resize keeps a fixed-width locked-end column aligned before pointer release", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1500, height: 900 });
+  await page.goto("/actions");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const viewport = grid.locator(".tdg-body-viewport");
+  const bodyTable = grid.locator(".tdg-body-table");
+  const actionsHeader = grid.locator(
+    '.tdg-header-cell[data-column-id="actions"]'
+  );
+  const resizer = actionsHeader.getByRole("button", {
+    name: "Resize Actions",
+  });
+
+  await expect(grid).toBeVisible();
+  await expect(grid).toHaveAttribute("data-column-width-mode", "stretch");
+
+  // The keyboard proposal enters deterministic fixed-width mode with a table
+  // narrower than this viewport, exercising the trailing viewport offset.
+  await resizer.press("ArrowLeft");
+  await expect(grid).toHaveAttribute("data-column-width-mode", "fixed");
+  await expect
+    .poll(async () => {
+      const [tableBox, viewportWidth] = await Promise.all([
+        bodyTable.boundingBox(),
+        viewport.evaluate((element) => element.clientWidth),
+      ]);
+      return viewportWidth - (tableBox?.width ?? viewportWidth);
+    })
+    .toBeGreaterThan(20);
+
+  const rightEdgeDrift = async () => {
+    const [viewportBox, headerBox] = await Promise.all([
+      viewport.boundingBox(),
+      actionsHeader.boundingBox(),
+    ]);
+    return Math.abs(
+      headerBox!.x + headerBox!.width - (viewportBox!.x + viewportBox!.width)
+    );
+  };
+  await expect.poll(rightEdgeDrift).toBeLessThan(3);
+
+  const initialWidth = (await actionsHeader.boundingBox())!.width;
+  const resizerBox = await resizer.boundingBox();
+  expect(resizerBox).not.toBeNull();
+  const startX = resizerBox!.x + resizerBox!.width / 2;
+  const startY = resizerBox!.y + resizerBox!.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await expect(grid).toHaveAttribute("data-column-resizing", "true");
+  await page.mouse.move(startX - 40, startY, { steps: 8 });
+  await expect
+    .poll(async () => (await actionsHeader.boundingBox())!.width)
+    .toBeLessThan(initialWidth - 25);
+
+  // This assertion runs while the pointer is still down. The locked action
+  // column must not drift and then snap back only at commit time.
+  await expect.poll(rightEdgeDrift).toBeLessThan(3);
+  await page.mouse.up();
+  await expect(grid).toHaveAttribute("data-column-resizing", "false");
+  await expect.poll(rightEdgeDrift).toBeLessThan(3);
 });
 
 test("actions example fires row actions on the first click and supports bulk mutations", async ({

--- a/tests/playwright/actions-single-click.spec.ts
+++ b/tests/playwright/actions-single-click.spec.ts
@@ -1,5 +1,116 @@
 import { expect, test } from "@playwright/test";
 
+test("actions example keeps the locked-end column mounted and aligned while horizontally virtualized", async ({
+  page,
+}) => {
+  await page.goto("/actions");
+
+  const preview = page.getByTestId("example-preview-panel");
+  const grid = preview.locator(".InovuaReactDataGrid.tdg-root").first();
+  const viewport = grid.locator(".tdg-body-viewport");
+  const header = grid.locator('.tdg-header-cell[data-column-id="actions"]');
+  const filter = grid.locator('.tdg-filter-cell[data-column-id="actions"]');
+  const firstActionCell = grid
+    .locator(
+      'tbody [data-slot="grid-row"] .InovuaReactDataGrid__cell[data-column-id="actions"]'
+    )
+    .first();
+
+  await expect(grid).toBeVisible();
+  await expect(header).toBeVisible();
+  await expect(filter).toBeVisible();
+  await expect(firstActionCell).toBeVisible();
+  await expect(header).toHaveCSS("position", "sticky");
+  await expect(filter).toHaveCSS("position", "sticky");
+  await expect(firstActionCell).toHaveCSS("position", "sticky");
+  await expect(header).toHaveAttribute(
+    "class",
+    /InovuaReactDataGrid__column-header--locked-end/
+  );
+  await expect(filter).toHaveAttribute(
+    "class",
+    /InovuaReactDataGrid__filter-cell--locked-end/
+  );
+  await expect(firstActionCell).toHaveAttribute(
+    "class",
+    /InovuaReactDataGrid__cell--locked-end/
+  );
+  await expect(preview.getByTestId("actions-locked-metadata")).toHaveText(
+    "Runtime metadata: locked end contains actions."
+  );
+
+  const initialGeometry = await Promise.all([
+    viewport.boundingBox(),
+    header.boundingBox(),
+    filter.boundingBox(),
+    firstActionCell.boundingBox(),
+  ]);
+  const [initialViewport, initialHeader, initialFilter, initialCell] =
+    initialGeometry;
+  expect(initialViewport).not.toBeNull();
+  expect(initialHeader).not.toBeNull();
+  expect(initialFilter).not.toBeNull();
+  expect(initialCell).not.toBeNull();
+
+  const initialRight = initialViewport!.x + initialViewport!.width;
+  for (const lockedBox of [initialHeader!, initialFilter!, initialCell!]) {
+    expect(Math.abs(lockedBox.x + lockedBox.width - initialRight)).toBeLessThan(
+      3
+    );
+  }
+
+  await viewport.evaluate((element) => {
+    element.scrollLeft = element.scrollWidth;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await page.waitForTimeout(50);
+
+  await expect(header).toBeVisible();
+  await expect(filter).toBeVisible();
+  await expect(firstActionCell).toBeVisible();
+
+  const scrolledGeometry = await Promise.all([
+    viewport.boundingBox(),
+    header.boundingBox(),
+    filter.boundingBox(),
+    firstActionCell.boundingBox(),
+  ]);
+  const [scrolledViewport, scrolledHeader, scrolledFilter, scrolledCell] =
+    scrolledGeometry;
+  const scrolledRight = scrolledViewport!.x + scrolledViewport!.width;
+  for (const lockedBox of [scrolledHeader!, scrolledFilter!, scrolledCell!]) {
+    expect(
+      Math.abs(lockedBox.x + lockedBox.width - scrolledRight)
+    ).toBeLessThan(3);
+  }
+
+  const widthBeforeResize = (await header.boundingBox())!.width;
+  await header
+    .getByRole("button", { name: "Resize Actions" })
+    .press("ArrowRight");
+  await expect
+    .poll(async () => (await header.boundingBox())?.width)
+    .not.toBe(widthBeforeResize);
+  await expect
+    .poll(async () => {
+      const [resizedViewport, resizedHeader] = await Promise.all([
+        viewport.boundingBox(),
+        header.boundingBox(),
+      ]);
+      return Math.abs(
+        resizedHeader!.x +
+          resizedHeader!.width -
+          (resizedViewport!.x + resizedViewport!.width)
+      );
+    })
+    .toBeLessThan(3);
+
+  await page.getByRole("button", { name: "Advance Northwind Health" }).click();
+  await expect(preview.getByTestId("actions-stage-wf-201")).toHaveText(
+    "Reviewing"
+  );
+});
+
 test("actions example fires row actions on the first click and supports bulk mutations", async ({
   page,
 }) => {
@@ -17,9 +128,7 @@ test("actions example fires row actions on the first click and supports bulk mut
   ).toBeVisible();
 
   await preview.getByRole("heading", { name: "Actions example" }).click();
-  await page
-    .getByRole("button", { name: "Advance Northwind Health" })
-    .click();
+  await page.getByRole("button", { name: "Advance Northwind Health" }).click();
 
   await expect(preview.getByTestId("actions-stage-wf-201")).toHaveText(
     "Reviewing"

--- a/tests/types/type-locked-columns.ts
+++ b/tests/types/type-locked-columns.ts
@@ -1,0 +1,26 @@
+import type { TypeColumns, TypeComputedColumn } from "@geovi/the-datagrid";
+
+export const lockedColumns: TypeColumns = [
+  { name: "selection", locked: true },
+  { name: "account", locked: "start" },
+  { name: "owner", locked: false },
+  { name: "actions", locked: "end" },
+];
+
+export const computedLockedEnd: TypeComputedColumn = {
+  name: "actions",
+  computedLocked: "end",
+};
+
+export const computedUnlocked: TypeComputedColumn = {
+  name: "owner",
+  computedLocked: false,
+};
+
+export const invalidLockedColumn: TypeColumns = [
+  {
+    name: "actions",
+    // @ts-expect-error Inovua accepts start/end/boolean, not arbitrary edges.
+    locked: "right",
+  },
+];


### PR DESCRIPTION
## Summary

- add the Inovua-shaped `column.locked` contract (`true`/`"start"`/`"end"`/`false`) without adding a root grid prop
- group visible columns into locked-start, unlocked, and locked-end render sections while preserving relative `columnOrder` inside each section
- keep locked columns mounted through horizontal column virtualization and align header, filter, and body cells with shared sticky geometry
- make imperative column/cell scrolling reveal unlocked targets between both locked edges
- keep right-locked geometry aligned throughout `liveColumnResize`, including fixed-width underflow
- expose locked-column computed API and `rowStyle` metadata instead of fixed unlocked sentinels
- upgrade the Actions example with locked-start selection, locked-end actions, live resize, and an imperative reveal control
- add a public guide, API/compatibility reference coverage, README guidance, AI-skill guidance, and focused regression tests

## Compatibility boundary

Inovua documents locked columns as an Enterprise feature, so this is an opt-in compatibility extension outside the Community 5.10.2 parity gate. The supported contract is static/declarative `column.locked`; `true` aliases `"start"`.

Not implemented: `column.defaultLocked`, `column.lockable`, `column.autoLock`, root `onColumnLockedChange`, root `showColumnMenuLockOptions`, imperative `setColumnLocked`, lock/unlock menu actions, cross-section drag mutation, runtime lock-section changes, and RTL edge mirroring. Cross-section drops are rejected. Controlled `columnOrder` and remote data-source arguments retain the application-owned sequence; locking groups render order only. Locked-section compatibility widths report logical allocated widths, not browser-distributed surplus in an underfilled stretched table.

## Inovua and issue audit

I reviewed the open issue set. There is no dedicated open Community-parity issue for pinned/locked columns. Issues #43 and #46 classify locked columns as an Enterprise-only exclusion from the current Community parity scope. This PR deliberately extends the grid using Inovua's established column vocabulary while keeping the existing ReactDataGrid prop surface unchanged.

## Validation

- `yarn build` ✅ (type tests, TypeScript, library bundles, declarations, packed-type checks, CSS scope and optional-boundary checks)
- `yarn tsc -p tsconfig.app.json --noEmit` ✅
- Actions locked-column E2E ✅ (5/5: real overflow/virtualization, start/end geometry, imperative reveal, live-resize alignment, row actions)
- existing live-column-resize E2E ✅ (6/6)
- docs/routing/provider E2E ✅ (11/11)
- Prettier and `git diff --check` ✅

## Existing baseline notes

The repository-wide lint command still reports pre-existing `no-explicit-any` and Fast Refresh violations in large legacy files. Before this final push, the full Playwright CI baseline also remained red in unrelated issue-audit/default expectation tests; the focused locked-column, resize, docs, and build/type checks above pass. The latest GitHub Actions run is allowed to report those baseline failures rather than masking them.
