### PR TITLE
Complete active-row navigation and row selection parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,11 +846,27 @@ Disable are explicit menu actions, and Clear All emits one aggregate update.
 | `checkboxColumn`               | `boolean \| IColumn`                            | `false`                          | Enable or customize the checkbox column                                         |
 | `selected`                     | `TypeRowSelection`                              | -                                | Controlled selection                                                            |
 | `defaultSelected`              | `TypeRowSelection`                              | `{}` for multi-select, else null | Uncontrolled initial selection                                                  |
+| `unselected`                   | `{ [rowId: string]: boolean }`                  | -                                | Controlled exclusions while `selected === true`                                 |
+| `defaultUnselected`            | `{ [rowId: string]: boolean }`                  | -                                | Initial uncontrolled select-all exclusions                                      |
 | `onSelectionChange`            | `(config: TypeOnSelectionChangeArg) => void`    | -                                | Fired with the next selection and row metadata                                  |
 | `multiSelect`                  | `boolean`                                       | `true` with `checkboxColumn`     | Enable multi-row selection semantics                                            |
-| `checkboxOnlyRowSelect`        | `boolean`                                       | `true` with `checkboxColumn`     | Require the checkbox instead of a plain row click                               |
+| `checkboxOnlyRowSelect`        | `boolean`                                       | `false`                          | Require the checkbox instead of a plain row click                               |
 | `checkboxSelectEnableShiftKey` | `boolean`                                       | `false`                          | Enable Shift-range selection through the checkbox column                        |
+| `toggleRowSelectOnClick`       | `boolean`                                       | `false`                          | Toggle off the sole selected row on an unmodified click                         |
+| `activeIndex`                  | `number`                                        | -                                | Controlled active-row index                                                     |
+| `defaultActiveIndex`           | `number`                                        | `-1`                             | Initial uncontrolled active-row index                                           |
+| `onActiveIndexChange`          | `(index: number) => void`                       | -                                | Fired when pointer, keyboard, or focus changes the active row                   |
+| `enableKeyboardNavigation`     | `boolean`                                       | `true`                           | Enable Arrow, Home, End, Page, Enter, and optional Tab row navigation           |
+| `activateRowOnFocus`           | `boolean`                                       | `true`                           | Restore the last active row when grid focus returns                             |
+| `keyPageStep`                  | `number`                                        | `10`                             | Row distance for Page Up and Page Down                                          |
+| `allowRowTabNavigation`        | `boolean`                                       | `false`                          | Move the active row with Tab while another row remains available                |
 | `disabledRows`                 | `{ [displayedIndex: string]: boolean } \| null` | -                                | Block pointer interaction by current view index without excluding API selection |
+
+Shift-click selects an inclusive range from the previous row anchor. Ctrl/Cmd
+click toggles one row, while an unmodified multi-select click selects only that
+row. Enter applies the same selection rules to the active row. Focus leaving
+the grid clears the live active index and restores the last index when focus
+returns; virtualized navigation scrolls the active row into view.
 
 ### Editing
 

--- a/examples/src/GitHubIssues33To48CompatPage.tsx
+++ b/examples/src/GitHubIssues33To48CompatPage.tsx
@@ -269,37 +269,103 @@ function Issue37RowContextMenu() {
 
 function Issue38ActiveRowNavigation() {
   const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
+  const [controlledActiveIndex, setControlledActiveIndex] = React.useState(0);
+  const [selected, setSelected] = React.useState<TypeDataGridProps["selected"]>(
+    {}
+  );
+  const [unselected, setUnselected] = React.useState<Record<string, boolean>>(
+    {}
+  );
+  const rows = React.useMemo(
+    () =>
+      Array.from({ length: 40 }, (_, index) => ({
+        id: `active-${index}`,
+        name: `Person ${index}`,
+        city: `City ${index}`,
+      })),
+    []
+  );
+  const selectionSummary =
+    selected === true
+      ? {
+          selected: true,
+          unselected: Object.keys(unselected).sort(),
+        }
+      : {
+          selected:
+            selected && typeof selected === "object"
+              ? Object.keys(selected).sort()
+              : selected,
+          unselected: [],
+        };
+  const controlledActiveMode =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("activeMode") ===
+      "controlled";
 
   return (
     <>
       <output data-testid="issue-38-active-index">
         {activeIndex == null ? "none" : activeIndex}
       </output>
+      <output data-testid="issue-38-selection">
+        {JSON.stringify(selectionSummary)}
+      </output>
       <GridFrame>
-        <CompatibilityGrid
+        <ReactDataGrid
           idProperty="id"
           columns={baseColumns}
-          dataSource={baseRows}
+          dataSource={rows}
           columnOrder={["id", "name", "city"]}
-          virtualized={false}
+          virtualized
+          rowHeight={36}
           enableFiltering={false}
           enableSelection
+          multiSelect
+          checkboxColumn
+          checkboxSelectEnableShiftKey
+          selected={selected}
+          unselected={unselected}
+          onSelectionChange={(change) => {
+            setSelected(change.selected);
+            setUnselected(
+              change.unselected &&
+                typeof change.unselected === "object" &&
+                !Array.isArray(change.unselected)
+                ? (change.unselected as Record<string, boolean>)
+                : {}
+            );
+          }}
           enableKeyboardNavigation
+          activeIndex={controlledActiveMode ? controlledActiveIndex : undefined}
           defaultActiveIndex={0}
-          onActiveIndexChange={(next: unknown) => {
-            if (typeof next === "number") {
-              setActiveIndex(next);
-              return;
+          activeIndexThrottle={controlledActiveMode ? 40 : undefined}
+          keyPageStep={5}
+          allowRowTabNavigation
+          rowFocusClassName="issue-38-row-focused"
+          focusedClassName="issue-38-grid-focused"
+          activeRowIndicatorClassName="issue-38-active-indicator"
+          onActiveIndexChange={(nextActiveIndex) => {
+            setActiveIndex(nextActiveIndex);
+            if (controlledActiveMode) {
+              setControlledActiveIndex(nextActiveIndex);
             }
-
-            const candidate = next as {
-              activeIndex?: number;
-              index?: number;
-            } | null;
-            setActiveIndex(candidate?.activeIndex ?? candidate?.index ?? null);
           }}
         />
       </GridFrame>
+      <button
+        type="button"
+        data-testid="issue-38-select-all-mode"
+        onClick={() => {
+          setSelected(true);
+          setUnselected({});
+        }}
+      >
+        Use selected=true
+      </button>
+      <button type="button" data-testid="issue-38-outside-focus">
+        Outside grid
+      </button>
     </>
   );
 }

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -1086,11 +1086,18 @@ const reactDataGridPropSections: ReferenceSection[] = [
         description: "Initial uncontrolled selection state.",
       },
       {
+        name: "unselected / defaultUnselected",
+        type: "TypeBoolMap",
+        defaultValue: "-",
+        description:
+          "Controlled or uncontrolled exclusions used while selected is true.",
+      },
+      {
         name: "onSelectionChange",
         type: "(config: TypeOnSelectionChangeArg) => void",
         defaultValue: "-",
         description:
-          "Observes enabled selection but does not enable it by itself. Emissions contain selected and originalData; UI actions also include the relevant row(s) in data. unselected is optional and built-in toggles do not currently populate it. Direct React setter wiring is supported.",
+          "Observes enabled selection but does not enable it by itself. Emissions contain selected and originalData; UI actions also include the relevant row(s) in data. selected=true toggles emit unselected exclusions. Direct React setter wiring is supported.",
       },
       {
         name: "multiSelect",
@@ -1102,7 +1109,7 @@ const reactDataGridPropSections: ReferenceSection[] = [
       {
         name: "checkboxOnlyRowSelect",
         type: "boolean",
-        defaultValue: "checkboxColumn ? true : false",
+        defaultValue: "false",
         description:
           "Prevents plain row clicks from toggling selection when true.",
       },
@@ -1112,6 +1119,41 @@ const reactDataGridPropSections: ReferenceSection[] = [
         defaultValue: "false",
         description:
           "Allows shift-range selection through the checkbox column.",
+      },
+      {
+        name: "toggleRowSelectOnClick",
+        type: "boolean",
+        defaultValue: "false",
+        description:
+          "Makes an unmodified click on the sole selected row toggle it off.",
+      },
+      {
+        name: "activeIndex / defaultActiveIndex",
+        type: "number",
+        defaultValue: "-1",
+        description:
+          "Controlled or uncontrolled active-row index used by focus and keyboard navigation.",
+      },
+      {
+        name: "enableKeyboardNavigation",
+        type: "boolean",
+        defaultValue: "true",
+        description:
+          "Enables Arrow, Home, End, Page, Enter, and optional Tab row navigation.",
+      },
+      {
+        name: "activateRowOnFocus / keyPageStep",
+        type: "boolean / number",
+        defaultValue: "true / 10",
+        description:
+          "Restores an active row when focus enters and controls Page Up/Down distance.",
+      },
+      {
+        name: "row focus styling",
+        type: "class-name hooks",
+        defaultValue: "active indicator on",
+        description:
+          "focusedClassName, rowFocusClassName, showActiveRowIndicator, and activeRowIndicatorClassName expose focus styling hooks.",
       },
       {
         name: "disabledRows",
@@ -2405,24 +2447,27 @@ type TypeFilterTypes = Record<string, TypeFilterType>;`}
             are supported.
           </p>
           <p>
-            Column/row context-menu methods, flex and column-size setters,
-            active-row/navigation setters, and reserved-viewport setters are
-            explicit no-ops or fixed placeholders. Only the filter operator
-            context-menu pair is functional.
+            Column/row context-menu methods, flex and column-size setters, and
+            reserved-viewport setters are explicit no-ops or fixed placeholders.
+            Active-row/navigation state and the filter operator context-menu
+            pair are functional.
           </p>
           <p>
             Locked-column arrays, indexes, section widths, and presence flags
             now reflect declarative <code>column.locked</code> and its logical
             column allocation. In a fixed-layout table that underfills and
             stretches to the viewport, browser-distributed surplus space is not
-            included in those compatibility widths. Live pagination and
-            unselected tracking remain fixed compatibility fields.{" "}
+            included in those compatibility widths. Live pagination remains a
+            fixed compatibility field; <code>selected === true</code> and
+            unselected exclusions are tracked by built-in selection.{" "}
             <code>computedShowZebraRows</code> reflects the per-grid prop, while{" "}
             <code>columnFlexes</code> and column sizes report the implemented
             allocation; their imperative setter methods remain outside the
-            supported allowlist. In particular, <code>setColumnLocked</code> may
-            look callable through the compatibility Proxy but is unsupported and
-            does not mutate lock state.
+            supported allowlist. Active index, active item, focus state, and
+            row-navigation methods report and update live state. In particular,{" "}
+            <code>setColumnLocked</code> may look callable through the
+            compatibility Proxy but is unsupported and does not mutate lock
+            state.
           </p>
         </Callout>
         <div className="space-y-2">
@@ -3641,9 +3686,9 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
     currentBehavior: (
       <>
         A substantial documented subset works, but column/row context menus,
-        flex/size setters, and active-row/navigation entries are no-ops or fixed
-        placeholders. The Proxy also fabricates no-op functions for many unknown
-        method-like names.
+        flex/size setters, and reserved-viewport mutation remain no-ops or fixed
+        placeholders. Active-row/navigation entries are live. The Proxy also
+        fabricates no-op functions for many unknown method-like names.
       </>
     ),
     requiredOutcome: (
@@ -4129,9 +4174,9 @@ const implementedSurfaceSections: ReferenceSection[] = [
       {
         name: "Selection ranges and payload",
         type: "current loaded rows/page",
-        defaultValue: "shift range off",
+        defaultValue: "row Shift-range on",
         description:
-          "When enabled, Shift check/uncheck applies the inclusive last-anchor range. Header select-all preserves off-page map entries. Emissions always include selected/originalData, usually data, while unselected is optional and not populated by built-ins.",
+          "Shift-click applies the inclusive last-anchor range; checkbox Shift-ranges require checkboxSelectEnableShiftKey. Local select-all emits the loaded row map, while paginated or remote select-all uses selected=true plus unselected exclusions. Emissions always include selected/originalData and usually data.",
       },
     ],
   },
@@ -5319,9 +5364,9 @@ const columns: TypeColumns = [
                 persist only the raw selection map.
               </p>
               <p>
-                The supported long-term model is the row-id object map. Inovua's{" "}
+                Row-id object maps and Inovua&apos;s{" "}
                 <code>selected === true</code> plus <code>unselected</code>{" "}
-                pattern is not the primary path in this library.
+                exclusions are both supported.
               </p>
             </Callout>
           </div>
@@ -5336,19 +5381,19 @@ const columns: TypeColumns = [
               enableSelection has explicit precedence. When omitted, selected,
               defaultSelected, or checkboxColumn enables selection;
               onSelectionChange alone does not. With checkboxColumn enabled,
-              multiSelect and checkboxOnlyRowSelect default to true; without it,
-              both default false unless inferred or explicitly enabled.
+              multiSelect defaults to true for uncontrolled state, while
+              checkboxOnlyRowSelect defaults to false.
             </li>
             <li>
-              checkboxSelectEnableShiftKey enables contiguous range selection
-              from the most recent checkbox anchor through the current row,
-              inclusive, in the currently loaded row model/page.
+              Shift-click selects the contiguous range from the most recent row
+              anchor through the current row. checkboxSelectEnableShiftKey
+              enables the same behavior through the checkbox column.
             </li>
             <li>
-              Header select-all and imperative selectAll operate on the current
-              loaded page while preserving off-page map entries. The header
-              reports checked, indeterminate, and disabled state to a custom
-              renderCheckbox.
+              Local select-all emits the loaded row map. Paginated and remote
+              select-all use selected=true, with later toggles recorded in
+              unselected. The header reports checked, indeterminate, and
+              disabled state to a custom renderCheckbox.
             </li>
             <li>
               Buttons, links, inputs, and other interactive descendants do not
@@ -5371,7 +5416,7 @@ const columns: TypeColumns = [
             <li>
               onSelectionChange always includes selected and originalData; UI
               actions normally include the affected row(s) in data. unselected
-              is optional and built-in toggles do not populate it.
+              contains exclusions while selected is true.
             </li>
           </ul>
         ),
@@ -6424,9 +6469,12 @@ const columns: TypeColumns = [
               38&apos;s <code>disabledRows</code> contract is implemented for
               desktop, virtualized, locally paginated, sorted, and transformed
               mobile rows, including callback metadata and pointer-only
-              disabling. Other ledger entries remain gaps or under verification,
-              and the inventory is not exhaustive until the remaining Community
-              API has been audited surface by surface.
+              disabling. Issue 38 also includes controlled/uncontrolled active
+              index state, keyboard and page navigation, focus restoration,
+              virtualized active-row scrolling, pointer/keyboard selection, and
+              Shift ranges. Other ledger entries remain gaps or under
+              verification, and the inventory is not exhaustive until the
+              remaining Community API has been audited surface by surface.
             </p>
           </div>
         ),

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -18,6 +18,7 @@ import type {
   TypeGetColumnByParam,
   TypeSingleFilterValue,
   TypeFilterValue,
+  TypeOnSelectionChangeArg,
   TypeRowSelection,
   TypeStartEditArgs,
   TypeSortInfo,
@@ -133,7 +134,13 @@ type ReactDataGridDefaultPropName =
   | "editStartEvent"
   | "emptyText"
   | "headerHeight"
-  | "filterRowHeight";
+  | "filterRowHeight"
+  | "enableKeyboardNavigation"
+  | "activateRowOnFocus"
+  | "keyPageStep"
+  | "allowRowTabNavigation"
+  | "toggleRowSelectOnClick"
+  | "showActiveRowIndicator";
 
 type ReactDataGridDefaultProps = Required<
   Pick<TypeDataGridProps, ReactDataGridDefaultPropName>
@@ -161,6 +168,12 @@ const REACT_DATA_GRID_DEFAULT_PROPS: ReactDataGridDefaultProps = {
   emptyText: "noRecords",
   headerHeight: 40,
   filterRowHeight: 40,
+  enableKeyboardNavigation: true,
+  activateRowOnFocus: true,
+  keyPageStep: 10,
+  allowRowTabNavigation: false,
+  toggleRowSelectOnClick: false,
+  showActiveRowIndicator: true,
 };
 
 type ReactDataGridComponent = React.FunctionComponent<TypeDataGridProps> & {
@@ -619,12 +632,25 @@ function ReactDataGrid(props: TypeDataGridProps) {
     headerHeight = REACT_DATA_GRID_DEFAULT_PROPS.headerHeight,
     filterRowHeight = REACT_DATA_GRID_DEFAULT_PROPS.filterRowHeight,
     disabledRows,
+    activeIndex: controlledActiveIndex,
+    defaultActiveIndex,
+    onActiveIndexChange,
+    activeIndexThrottle,
+    enableKeyboardNavigation = REACT_DATA_GRID_DEFAULT_PROPS.enableKeyboardNavigation,
+    activateRowOnFocus = REACT_DATA_GRID_DEFAULT_PROPS.activateRowOnFocus,
+    keyPageStep = REACT_DATA_GRID_DEFAULT_PROPS.keyPageStep,
+    allowRowTabNavigation = REACT_DATA_GRID_DEFAULT_PROPS.allowRowTabNavigation,
+    toggleRowSelectOnClick = REACT_DATA_GRID_DEFAULT_PROPS.toggleRowSelectOnClick,
+    rowFocusClassName,
+    focusedClassName,
+    showActiveRowIndicator = REACT_DATA_GRID_DEFAULT_PROPS.showActiveRowIndicator,
+    activeRowIndicatorClassName,
 
     className,
     style,
-    onKeyDown,
-    onFocus,
-    onBlur,
+    onKeyDown: onKeyDownProp,
+    onFocus: onFocusProp,
+    onBlur: onBlurProp,
   } = props;
   const disabledRowsRef = React.useRef(disabledRows);
   disabledRowsRef.current = disabledRows;
@@ -742,11 +768,14 @@ function ReactDataGrid(props: TypeDataGridProps) {
     props.checkboxColumn;
   const checkboxEnabled = Boolean(checkboxColumnProp);
   const controlledSelected = props.selected !== undefined;
+  const controlledUnselected = props.unselected !== undefined;
   const selectionEnabled =
     props.enableSelection !== undefined
       ? Boolean(props.enableSelection)
       : controlledSelected ||
         props.defaultSelected !== undefined ||
+        controlledUnselected ||
+        props.defaultUnselected !== undefined ||
         checkboxEnabled;
 
   const checkboxColId = React.useMemo(() => {
@@ -766,7 +795,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         typeof selectionValue === "boolean" ||
         (!controlledSelected && checkboxEnabled)))
     : false;
-  const checkboxOnlyRowSelect = props.checkboxOnlyRowSelect ?? checkboxEnabled;
+  const checkboxOnlyRowSelect = props.checkboxOnlyRowSelect ?? false;
   const checkboxSelectEnableShiftKey =
     props.checkboxSelectEnableShiftKey ?? false;
 
@@ -781,32 +810,89 @@ function ReactDataGrid(props: TypeDataGridProps) {
       ? (props.selected as TypeRowSelection)
       : internalSelected
     : null;
-  const selectedMap = React.useMemo(() => toSelectionMap(selected), [selected]);
+  const normalizedSelected = unwrapSelectionState(selected);
+  const selectedWrapper =
+    selected &&
+    typeof selected === "object" &&
+    "selected" in selected &&
+    ("data" in selected ||
+      "unselected" in selected ||
+      "originalData" in selected)
+      ? (selected as TypeOnSelectionChangeArg)
+      : null;
+  const selectedWrapperUnselected = selectedWrapper?.unselected as
+    | Record<string, boolean>
+    | null
+    | undefined;
+
+  const [internalUnselected, setInternalUnselected] = React.useState<Record<
+    string,
+    boolean
+  > | null>(() => props.defaultUnselected ?? null);
+  const unselected =
+    selectionEnabled && multiSelect
+      ? controlledUnselected
+        ? (props.unselected ?? null)
+        : selectedWrapperUnselected !== undefined
+          ? selectedWrapperUnselected
+          : internalUnselected
+      : null;
+
+  const [activeIndexState, setActiveIndexState] = useControllableState<number>({
+    value: controlledActiveIndex,
+    defaultValue: defaultActiveIndex ?? -1,
+    onChange: onActiveIndexChange,
+  });
+  const [gridFocused, setGridFocused] = React.useState(false);
+  const lastActiveIndexRef = React.useRef<number | null>(null);
+  const pendingActiveIndexRef = React.useRef<number | null>(null);
+  const activeIndexThrottleTimerRef = React.useRef<number | null>(null);
+
+  React.useEffect(
+    () => () => {
+      if (activeIndexThrottleTimerRef.current != null) {
+        window.clearTimeout(activeIndexThrottleTimerRef.current);
+      }
+    },
+    []
+  );
 
   const lastSelectedIndexRef = React.useRef<number | null>(null);
+  const selectionRangeBaseRef = React.useRef<Record<string, any> | null>(null);
   const lastPointerRef = React.useRef<{ shiftKey: boolean }>({
     shiftKey: false,
   });
 
   const emitSelectionChange = React.useCallback(
     (
-      nextMap: Record<string, any>,
+      nextSelected: TypeRowSelection,
       meta?: { data?: unknown; unselected?: TypeRowSelection }
     ) => {
       if (!selectionEnabled) return;
 
-      const nextSelected: TypeRowSelection = nextMap;
+      const nextUnselected =
+        nextSelected === true
+          ? ((meta?.unselected as Record<string, boolean> | null | undefined) ??
+            null)
+          : null;
 
       if (!controlledSelected) setInternalSelected(nextSelected);
+      if (!controlledUnselected) setInternalUnselected(nextUnselected);
 
       props.onSelectionChange?.({
         selected: nextSelected,
         data: meta?.data,
-        unselected: meta?.unselected,
+        unselected: nextUnselected,
         originalData: dataSource,
       });
     },
-    [controlledSelected, dataSource, props, selectionEnabled]
+    [
+      controlledSelected,
+      controlledUnselected,
+      dataSource,
+      props,
+      selectionEnabled,
+    ]
   );
 
   /** ---------------- filter types ---------------- */
@@ -1064,15 +1150,37 @@ function ReactDataGrid(props: TypeDataGridProps) {
     () => toTanStackColumnFiltersState(filterValue, allInputColumns),
     [allInputColumns, filterValue]
   );
-  const tanstackRowSelection = React.useMemo(
-    () => toTanStackRowSelectionState(selected),
-    [selected]
-  );
 
   /** ---------------- data loading ---------------- */
 
   const [rows, setRows] = React.useState<any[]>([]);
   const [count, setCount] = React.useState<number>(0);
+  const getRowKey = React.useCallback(
+    (row: any, index: number) => {
+      const value = row?.[idProperty];
+      return value == null ? String(index) : String(value);
+    },
+    [idProperty]
+  );
+  const selectedMap = React.useMemo(() => {
+    if (!selectionEnabled) return {};
+
+    if (normalizedSelected === true) {
+      const result: Record<string, any> = {};
+      rows.forEach((row, index) => {
+        const rowId = getRowKey(row, index);
+        if (!unselected?.[rowId]) result[rowId] = row;
+      });
+      return result;
+    }
+    if (normalizedSelected === false || normalizedSelected == null) return {};
+
+    return toSelectionMap(normalizedSelected);
+  }, [getRowKey, normalizedSelected, rows, selectionEnabled, unselected]);
+  const tanstackRowSelection = React.useMemo(
+    () => toTanStackRowSelectionState(selectedMap),
+    [selectedMap]
+  );
   const [internalLoading, setInternalLoading] = React.useState(false);
   const [loadingOverride, setLoadingOverride] = React.useState<boolean | null>(
     null
@@ -1506,38 +1614,252 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   /** ---------------- selection helpers ---------------- */
 
-  const getRowKey = React.useCallback(
-    (row: any, index: number) => {
-      const v = row?.[idProperty];
-      return v == null ? String(index) : String(v);
+  const normalizedActiveIndex =
+    enableKeyboardNavigation && rows.length > 0
+      ? clamp(activeIndexState, -1, rows.length - 1)
+      : -1;
+
+  const setActiveIndexCompat = React.useCallback(
+    (nextActiveIndex: number) => {
+      if (!enableKeyboardNavigation || Number.isNaN(nextActiveIndex)) return;
+
+      const normalized =
+        rows.length === 0
+          ? -1
+          : nextActiveIndex < 0
+            ? -1
+            : clamp(Math.trunc(nextActiveIndex), 0, rows.length - 1);
+      pendingActiveIndexRef.current = normalized;
+      if (normalized === normalizedActiveIndex) return;
+      setActiveIndexState(normalized);
     },
-    [idProperty]
+    [
+      enableKeyboardNavigation,
+      normalizedActiveIndex,
+      rows.length,
+      setActiveIndexState,
+    ]
   );
 
-  const handleRowClick = React.useCallback(
-    (rowId: string, rowData: any, e: React.MouseEvent) => {
-      if (!selectionEnabled) return;
-      if (checkboxOnlyRowSelect) return;
-      if (isInteractiveClickTarget(e.target as any)) return;
+  const incrementActiveIndex = React.useCallback(
+    (increment: number) => {
+      if (!enableKeyboardNavigation || rows.length === 0) return;
 
-      const next = { ...selectedMap };
+      const base = pendingActiveIndexRef.current ?? normalizedActiveIndex;
+      const next = clamp(base + increment, 0, rows.length - 1);
+      const delay =
+        typeof activeIndexThrottle === "number" &&
+        Number.isFinite(activeIndexThrottle)
+          ? Math.max(0, activeIndexThrottle)
+          : 0;
 
-      if (multiSelect) {
-        if (next[rowId]) delete next[rowId];
-        else next[rowId] = rowData;
-      } else {
-        Object.keys(next).forEach((k) => delete next[k]);
-        next[rowId] = rowData;
+      pendingActiveIndexRef.current = next;
+      if (delay === 0) {
+        setActiveIndexCompat(next);
+        return;
       }
 
-      emitSelectionChange(next, { data: rowData });
+      if (activeIndexThrottleTimerRef.current != null) return;
+      activeIndexThrottleTimerRef.current = window.setTimeout(() => {
+        activeIndexThrottleTimerRef.current = null;
+        const pending = pendingActiveIndexRef.current;
+        if (pending != null) setActiveIndexCompat(pending);
+      }, delay);
+    },
+    [
+      activeIndexThrottle,
+      enableKeyboardNavigation,
+      normalizedActiveIndex,
+      rows.length,
+      setActiveIndexCompat,
+    ]
+  );
+
+  React.useEffect(() => {
+    pendingActiveIndexRef.current = normalizedActiveIndex;
+  }, [normalizedActiveIndex]);
+
+  const clearSelectionRange = React.useCallback(() => {
+    selectionRangeBaseRef.current = null;
+  }, []);
+
+  const commitRowSelection = React.useCallback(
+    (
+      rowIndex: number,
+      options: {
+        checked?: boolean;
+        ctrlKey?: boolean;
+        metaKey?: boolean;
+        shiftKey?: boolean;
+        fromCheckbox?: boolean;
+      } = {}
+    ) => {
+      if (!selectionEnabled) return;
+      const row = rows[rowIndex];
+      if (!row) return;
+
+      const rowId = getRowKey(row, rowIndex);
+      const isSelected = Boolean(selectedMap[rowId]);
+      const ctrlKey = Boolean(options.ctrlKey || options.metaKey);
+      const shiftKey = Boolean(options.shiftKey);
+
+      if (!multiSelect) {
+        const shouldSelect =
+          options.checked ??
+          (isSelected && (ctrlKey || toggleRowSelectOnClick) ? false : true);
+        emitSelectionChange(shouldSelect ? rowId : null, { data: row });
+        lastSelectedIndexRef.current = shouldSelect ? rowIndex : null;
+        clearSelectionRange();
+        return;
+      }
+
+      if (
+        shiftKey &&
+        lastSelectedIndexRef.current != null &&
+        (!options.fromCheckbox || checkboxSelectEnableShiftKey)
+      ) {
+        const base = selectionRangeBaseRef.current ?? { ...selectedMap };
+        selectionRangeBaseRef.current = { ...base };
+        const next = { ...base };
+        const from = Math.min(lastSelectedIndexRef.current, rowIndex);
+        const to = Math.max(lastSelectedIndexRef.current, rowIndex);
+        const checked = options.checked ?? true;
+
+        for (let index = from; index <= to; index += 1) {
+          const rangeRow = rows[index];
+          if (!rangeRow) continue;
+          const rangeId = getRowKey(rangeRow, index);
+          if (checked) next[rangeId] = rangeRow;
+          else delete next[rangeId];
+        }
+
+        emitSelectionChange(next, {
+          data: rows.slice(from, to + 1),
+        });
+        return;
+      }
+
+      clearSelectionRange();
+      lastSelectedIndexRef.current = rowIndex;
+
+      const shouldToggle =
+        options.checked === undefined &&
+        (ctrlKey ||
+          (toggleRowSelectOnClick &&
+            Object.keys(selectedMap).length === 1 &&
+            isSelected));
+      const shouldSelect =
+        options.checked ?? (shouldToggle ? !isSelected : true);
+
+      if (normalizedSelected === true && (ctrlKey || options.fromCheckbox)) {
+        const nextUnselected = { ...(unselected ?? {}) };
+        if (shouldSelect) delete nextUnselected[rowId];
+        else nextUnselected[rowId] = true;
+        emitSelectionChange(true, {
+          data: row,
+          unselected: nextUnselected,
+        });
+        return;
+      }
+
+      const next =
+        shouldToggle || options.fromCheckbox ? { ...selectedMap } : {};
+      if (shouldSelect) next[rowId] = row;
+      else delete next[rowId];
+      emitSelectionChange(next, { data: row });
+    },
+    [
+      checkboxSelectEnableShiftKey,
+      clearSelectionRange,
+      emitSelectionChange,
+      getRowKey,
+      multiSelect,
+      rows,
+      normalizedSelected,
+      selectedMap,
+      selectionEnabled,
+      toggleRowSelectOnClick,
+      unselected,
+    ]
+  );
+
+  const selectAllRows = React.useCallback(() => {
+    if (!selectionEnabled || rows.length === 0) return;
+
+    if (!multiSelect) {
+      emitSelectionChange(getRowKey(rows[0], 0), { data: rows[0] });
+      return;
+    }
+
+    clearSelectionRange();
+    if (paginationMode !== false || !Array.isArray(dataSource)) {
+      emitSelectionChange(true, { data: rows, unselected: null });
+      return;
+    }
+
+    const next: Record<string, any> = {};
+    rows.forEach((row, index) => {
+      next[getRowKey(row, index)] = row;
+    });
+    emitSelectionChange(next, { data: rows });
+  }, [
+    clearSelectionRange,
+    dataSource,
+    emitSelectionChange,
+    getRowKey,
+    multiSelect,
+    paginationMode,
+    rows,
+    selectionEnabled,
+  ]);
+
+  const deselectAllRows = React.useCallback(() => {
+    if (!selectionEnabled) return;
+    clearSelectionRange();
+    lastSelectedIndexRef.current = null;
+    emitSelectionChange(multiSelect ? {} : null, {
+      data: rows,
+      unselected: null,
+    });
+  }, [
+    clearSelectionRange,
+    emitSelectionChange,
+    multiSelect,
+    rows,
+    selectionEnabled,
+  ]);
+
+  const handleRowClick = React.useCallback(
+    (
+      rowId: string,
+      rowData: any,
+      rowIndex: number,
+      event: React.MouseEvent
+    ) => {
+      void rowId;
+      void rowData;
+
+      const interactiveTarget = isInteractiveClickTarget(event.target as any);
+      if (!interactiveTarget) {
+        surfaceRef.current?.focus({ preventScroll: true });
+      }
+      setActiveIndexCompat(rowIndex);
+
+      if (!selectionEnabled || checkboxOnlyRowSelect || interactiveTarget) {
+        return;
+      }
+
+      commitRowSelection(rowIndex, {
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        shiftKey: event.shiftKey,
+      });
     },
     [
       checkboxOnlyRowSelect,
-      emitSelectionChange,
-      multiSelect,
-      selectedMap,
+      commitRowSelection,
       selectionEnabled,
+      setActiveIndexCompat,
     ]
   );
 
@@ -1558,18 +1880,22 @@ function ReactDataGrid(props: TypeDataGridProps) {
     selectedMap,
     selectionEnabled,
     multiSelect,
-    checkboxSelectEnableShiftKey,
     getRowKey,
-    emitSelectionChange,
+    commitRowSelection,
+    selectAllRows,
+    deselectAllRows,
+    setActiveIndexCompat,
   });
   selectionRuntimeRef.current = {
     rows,
     selectedMap,
     selectionEnabled,
     multiSelect,
-    checkboxSelectEnableShiftKey,
     getRowKey,
-    emitSelectionChange,
+    commitRowSelection,
+    selectAllRows,
+    deselectAllRows,
+    setActiveIndexCompat,
   };
 
   const columnDefs = React.useMemo<ColumnDef<any, any>[]>(() => {
@@ -1621,26 +1947,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
               const current = selectionRuntimeRef.current;
               if (!current.selectionEnabled) return;
 
-              if (!current.multiSelect) {
-                const next: Record<string, any> = {};
-                if (checked && current.rows[0]) {
-                  next[current.getRowKey(current.rows[0], 0)] = current.rows[0];
-                }
-                current.emitSelectionChange(next, { data: current.rows[0] });
-                return;
-              }
-
-              const next = { ...current.selectedMap };
-              if (checked) {
-                current.rows.forEach((r, idx) => {
-                  next[current.getRowKey(r, idx)] = r;
-                });
-              } else {
-                current.rows.forEach((r, idx) => {
-                  delete next[current.getRowKey(r, idx)];
-                });
-              }
-              current.emitSelectionChange(next, { data: current.rows });
+              if (checked) current.selectAllRows();
+              else current.deselectAllRows();
             };
 
             const checkboxProps: TypeCheckboxProps = {
@@ -1696,41 +2004,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
             const onChange = (checked: boolean) => {
               const current = selectionRuntimeRef.current;
               if (!current.selectionEnabled) return;
-
-              const shiftKey =
-                current.checkboxSelectEnableShiftKey &&
-                lastPointerRef.current.shiftKey === true;
-              const next = { ...current.selectedMap };
-
-              const rowModel = ctx.table.getRowModel().rows;
-
-              if (
-                shiftKey &&
-                current.multiSelect &&
-                lastSelectedIndexRef.current != null
-              ) {
-                const from = Math.min(lastSelectedIndexRef.current, rowIndex);
-                const to = Math.max(lastSelectedIndexRef.current, rowIndex);
-
-                for (let i = from; i <= to; i++) {
-                  const r = rowModel[i];
-                  if (!r) continue;
-                  if (checked) next[r.id] = r.original;
-                  else delete next[r.id];
-                }
-              } else {
-                if (checked) {
-                  if (!current.multiSelect) {
-                    Object.keys(next).forEach((k) => delete next[k]);
-                  }
-                  next[rowId] = rowData;
-                } else {
-                  delete next[rowId];
-                }
-              }
-
-              lastSelectedIndexRef.current = rowIndex;
-              current.emitSelectionChange(next, { data: rowData });
+              current.setActiveIndexCompat(rowIndex);
+              current.commitRowSelection(rowIndex, {
+                checked,
+                shiftKey: lastPointerRef.current.shiftKey,
+                fromCheckbox: true,
+              });
             };
 
             const checkboxProps: TypeCheckboxProps = {
@@ -4380,54 +4659,40 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   const setSelectedCompat = React.useCallback(
     (nextSelected: TypeRowSelection) => {
-      emitSelectionChange(toSelectionMap(unwrapSelectionState(nextSelected)));
+      const normalized = unwrapSelectionState(nextSelected);
+      emitSelectionChange(normalized, {
+        unselected: normalized === true ? unselected : null,
+      });
     },
-    [emitSelectionChange]
+    [emitSelectionChange, unselected]
   );
 
-  const selectAllCompat = React.useCallback(() => {
-    const next: Record<string, any> = {};
-
-    if (!multiSelect) {
-      if (rows[0]) {
-        next[getRowKey(rows[0], 0)] = rows[0];
-      }
-    } else {
-      rows.forEach((row, index) => {
-        next[getRowKey(row, index)] = row;
-      });
-    }
-
-    emitSelectionChange(next, { data: rows });
-  }, [emitSelectionChange, getRowKey, multiSelect, rows]);
-
-  const deselectAllCompat = React.useCallback(() => {
-    emitSelectionChange({}, { data: rows });
-  }, [emitSelectionChange, rows]);
+  const selectAllCompat = selectAllRows;
+  const deselectAllCompat = deselectAllRows;
 
   const setSelectedByIdCompat = React.useCallback(
     (id: string, nextSelected: boolean) => {
-      const row = rows.find(
+      const rowIndex = rows.findIndex(
         (candidate, index) => getRowKey(candidate, index) === id
       );
-      const next = multiSelect ? { ...selectedMap } : {};
-
-      if (nextSelected && row) next[id] = row;
-      else delete next[id];
-
-      emitSelectionChange(next, { data: row });
+      if (rowIndex < 0) return;
+      commitRowSelection(rowIndex, {
+        checked: nextSelected,
+        fromCheckbox: true,
+      });
     },
-    [emitSelectionChange, getRowKey, multiSelect, rows, selectedMap]
+    [commitRowSelection, getRowKey, rows]
   );
 
   const setSelectedAtCompat = React.useCallback(
     (index: number, nextSelected: boolean) => {
-      const row = rows[index];
-      if (!row) return;
-
-      setSelectedByIdCompat(getRowKey(row, index), nextSelected);
+      if (!rows[index]) return;
+      commitRowSelection(index, {
+        checked: nextSelected,
+        fromCheckbox: true,
+      });
     },
-    [getRowKey, rows, setSelectedByIdCompat]
+    [commitRowSelection, rows]
   );
 
   const getItemIndexByIdCompat = React.useCallback(
@@ -4480,9 +4745,24 @@ function ReactDataGrid(props: TypeDataGridProps) {
       if (index < 0) return;
 
       if (virtualized) {
-        rowVirtualizer.scrollToIndex(index, {
-          align: config?.direction === "bottom" ? "end" : "start",
-        });
+        const viewport = scrollRef.current;
+        if (
+          viewport &&
+          typeof rowHeight === "number" &&
+          Number.isFinite(rowHeight)
+        ) {
+          const resolvedHeight = resolveRowHeight(index);
+          viewport.scrollTop =
+            config?.direction === "bottom"
+              ? stickyHeaderOffset +
+                (index + 1) * resolvedHeight -
+                viewport.clientHeight
+              : index * resolvedHeight;
+        } else {
+          rowVirtualizer.scrollToIndex(index, {
+            align: config?.direction === "bottom" ? "end" : "start",
+          });
+        }
       } else {
         const rowNode = surfaceRef.current?.querySelector<HTMLElement>(
           `[data-slot="grid-row"][data-row-index="${index}"]`
@@ -4498,7 +4778,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
       callback?.();
     },
-    [rowVirtualizer, virtualized]
+    [
+      resolveRowHeight,
+      rowHeight,
+      rowVirtualizer,
+      stickyHeaderOffset,
+      virtualized,
+    ]
   );
 
   const scrollToColumnCompat = React.useCallback(
@@ -4612,6 +4898,170 @@ function ReactDataGrid(props: TypeDataGridProps) {
       rowRect.top >= viewportRect.top && rowRect.bottom <= viewportRect.bottom
     );
   }, []);
+
+  const handleGridFocus = React.useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      onFocusProp?.(event);
+      if (event.defaultPrevented) return;
+
+      const relatedTarget = event.relatedTarget;
+      if (
+        relatedTarget instanceof Node &&
+        rootRef.current?.contains(relatedTarget)
+      ) {
+        return;
+      }
+
+      setGridFocused(true);
+      if (
+        enableKeyboardNavigation &&
+        activateRowOnFocus &&
+        normalizedActiveIndex < 0 &&
+        rows.length > 0
+      ) {
+        const visibleIndex = getRenderRangeCompat().from;
+        const restoredIndex = lastActiveIndexRef.current;
+        setActiveIndexCompat(
+          restoredIndex != null &&
+            restoredIndex >= 0 &&
+            restoredIndex < rows.length
+            ? restoredIndex
+            : clamp(visibleIndex, 0, rows.length - 1)
+        );
+      }
+    },
+    [
+      activateRowOnFocus,
+      enableKeyboardNavigation,
+      getRenderRangeCompat,
+      normalizedActiveIndex,
+      onFocusProp,
+      rows.length,
+      setActiveIndexCompat,
+    ]
+  );
+
+  const handleGridBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      const relatedTarget = event.relatedTarget;
+      if (
+        relatedTarget instanceof Node &&
+        rootRef.current?.contains(relatedTarget)
+      ) {
+        return;
+      }
+
+      onBlurProp?.(event);
+      if (event.defaultPrevented) return;
+
+      if (normalizedActiveIndex >= 0) {
+        lastActiveIndexRef.current = normalizedActiveIndex;
+      }
+      setGridFocused(false);
+      setActiveIndexCompat(-1);
+    },
+    [normalizedActiveIndex, onBlurProp, setActiveIndexCompat]
+  );
+
+  const handleGridKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDownProp?.(event);
+      if (
+        event.defaultPrevented ||
+        !enableKeyboardNavigation ||
+        rows.length === 0 ||
+        isInteractiveClickTarget(event.target as HTMLElement | null)
+      ) {
+        return;
+      }
+
+      const currentIndex =
+        normalizedActiveIndex < 0 ? 0 : normalizedActiveIndex;
+      const pageStep =
+        typeof keyPageStep === "number" && Number.isFinite(keyPageStep)
+          ? Math.max(1, Math.trunc(keyPageStep))
+          : REACT_DATA_GRID_DEFAULT_PROPS.keyPageStep;
+      let handled = true;
+
+      switch (event.key) {
+        case "ArrowUp":
+          incrementActiveIndex(-1);
+          break;
+        case "ArrowDown":
+          incrementActiveIndex(1);
+          break;
+        case "Home":
+          setActiveIndexCompat(0);
+          break;
+        case "End":
+          setActiveIndexCompat(rows.length - 1);
+          break;
+        case "PageUp":
+          setActiveIndexCompat(currentIndex - pageStep);
+          break;
+        case "PageDown":
+          setActiveIndexCompat(currentIndex + pageStep);
+          break;
+        case "Enter":
+          commitRowSelection(currentIndex, {
+            ctrlKey: event.ctrlKey,
+            metaKey: event.metaKey,
+            shiftKey: event.shiftKey,
+          });
+          break;
+        case "Tab": {
+          if (!allowRowTabNavigation) {
+            handled = false;
+            break;
+          }
+
+          const nextIndex = currentIndex + (event.shiftKey ? -1 : 1);
+          if (nextIndex < 0 || nextIndex >= rows.length) {
+            handled = false;
+            break;
+          }
+          setActiveIndexCompat(nextIndex);
+          break;
+        }
+        default:
+          handled = false;
+      }
+
+      if (handled) event.preventDefault();
+    },
+    [
+      allowRowTabNavigation,
+      commitRowSelection,
+      enableKeyboardNavigation,
+      incrementActiveIndex,
+      keyPageStep,
+      normalizedActiveIndex,
+      onKeyDownProp,
+      rows.length,
+      setActiveIndexCompat,
+    ]
+  );
+
+  const previousScrolledActiveIndexRef = React.useRef(-1);
+  React.useLayoutEffect(() => {
+    if (!gridFocused || normalizedActiveIndex < 0) return;
+
+    const previousIndex = previousScrolledActiveIndexRef.current;
+    previousScrolledActiveIndexRef.current = normalizedActiveIndex;
+    if (isRowFullyVisibleCompat(normalizedActiveIndex)) return;
+
+    scrollToIndexCompat(normalizedActiveIndex, {
+      direction:
+        previousIndex >= 0 && normalizedActiveIndex < previousIndex
+          ? "top"
+          : "bottom",
+    });
+  }, [
+    gridFocused,
+    isRowFullyVisibleCompat,
+    normalizedActiveIndex,
+    scrollToIndexCompat,
+  ]);
 
   // Non-virtual rows still participate in Inovua's virtual-list compatibility
   // API. Keep their explicit DOM measurements outside React state: the table
@@ -5077,7 +5527,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
       getRowIndexById: (rowId, data) => getItemIndexByIdCompat(rowId, data),
       getItemIndexById: (rowId, data) => getItemIndexByIdCompat(rowId, data),
       computedSelected: selected,
-      computedUnselected: {},
+      computedUnselected: unselected,
+      computedRowSelectionEnabled: selectionEnabled,
+      computedRowMultiSelectionEnabled: Boolean(multiSelect),
       getSelectedMap: () => ({ ...selectedMap }),
       setSelected: setSelectedCompat,
       selectAll: selectAllCompat,
@@ -5090,18 +5542,23 @@ function ReactDataGrid(props: TypeDataGridProps) {
         const rowId = (value as any)?.[idProperty];
         return rowId == null ? false : Boolean(selectedMap[String(rowId)]);
       },
-      getSelectedCount: (selectionArg) =>
-        selectionEnabled
-          ? Object.keys(
-              toSelectionMap(
-                unwrapSelectionState(
-                  selectionArg ?? selected
-                ) as TypeRowSelection
-              )
-            ).length
-          : 0,
-      computedSelectedCount: Object.keys(selectedMap).length,
-      computedUnselectedCount: 0,
+      getSelectedCount: (selectionArg, unselectedArg) => {
+        if (!selectionEnabled) return 0;
+        const normalized = unwrapSelectionState(selectionArg ?? selected);
+        if (normalized === true) {
+          return Math.max(
+            0,
+            count -
+              Object.keys(toSelectionMap(unselectedArg ?? unselected)).length
+          );
+        }
+        return Object.keys(toSelectionMap(normalized)).length;
+      },
+      computedSelectedCount:
+        unwrapSelectionState(selected) === true
+          ? Math.max(0, count - Object.keys(unselected ?? {}).length)
+          : Object.keys(selectedMap).length,
+      computedUnselectedCount: Object.keys(unselected ?? {}).length,
       setSelectedById: setSelectedByIdCompat,
       setSelectedAt: setSelectedAtCompat,
       setRowSelected: setSelectedAtCompat,
@@ -5168,12 +5625,19 @@ function ReactDataGrid(props: TypeDataGridProps) {
           }
         : undefined,
       paginationCount: pageCount,
-      computedActiveIndex: -1,
-      computedLastActiveIndex: null,
-      doSetLastActiveIndex: () => undefined,
-      computedActiveItem: null,
-      getActiveItem: () => null,
-      computedHasRowNavigation: false,
+      computedActiveIndex: normalizedActiveIndex,
+      computedLastActiveIndex: lastActiveIndexRef.current,
+      doSetLastActiveIndex: (index: number | null) => {
+        lastActiveIndexRef.current = index;
+      },
+      computedActiveItem:
+        normalizedActiveIndex >= 0 ? rows[normalizedActiveIndex] : null,
+      getActiveItem: () =>
+        normalizedActiveIndex >= 0 ? rows[normalizedActiveIndex] : null,
+      computedHasRowNavigation: enableKeyboardNavigation && rows.length > 0,
+      computedFocused: gridFocused,
+      setActiveIndex: setActiveIndexCompat,
+      incrementActiveIndex,
       computedShowHoverRows: true,
       computedShowZebraRows: showZebraRows,
       setShowZebraRows,
@@ -5228,8 +5692,6 @@ function ReactDataGrid(props: TypeDataGridProps) {
       columnSizes,
       setColumnFlexes: () => undefined,
       setColumnSizes: () => undefined,
-      setActiveIndex: () => undefined,
-      incrementActiveIndex: () => undefined,
       setReservedViewportWidth: (nextValue: React.SetStateAction<number>) => {
         const nextReservedViewportWidth = resolveStateAction(
           nextValue,
@@ -5280,6 +5742,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     editable,
     editStartEvent,
     editingCell,
+    enableKeyboardNavigation,
     enableFiltering,
     effectiveEnableFiltering,
     filterControlled,
@@ -5292,11 +5755,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
     getRenderRangeCompat,
     getRowKey,
     getScrollingElement,
+    gridFocused,
     cancelEditCompat,
     completeEditCompat,
     getCurrentEditInfoCompat,
     i18n,
     idProperty,
+    incrementActiveIndex,
     incrementScrollLeftCompat,
     incrementScrollTopCompat,
     isRowFullyVisibleCompat,
@@ -5308,6 +5773,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
     lockedColumnMetrics,
     lockedEndColumns,
     lockedStartColumns,
+    multiSelect,
+    normalizedActiveIndex,
     openFilterMenuColId,
     orderedColumns,
     originalData,
@@ -5321,6 +5788,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     selected,
     selectedMap,
     selectionEnabled,
+    unselected,
     showZebraRows,
     setColumnFilterValueCompat,
     setColumnOrderCompat,
@@ -5331,6 +5799,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     setSelectedAtCompat,
     setSelectedByIdCompat,
     setSelectedCompat,
+    setActiveIndexCompat,
     setShowZebraRows,
     setSkip,
     setSortInfoAndResetPage,
@@ -5387,6 +5856,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
 
   /** ---------------- render ---------------- */
 
+  const rowIdPrefix = `tdg-grid-${gridIdRef.current}-row`;
+
   return (
     <div
       ref={attachRootRef}
@@ -5398,6 +5869,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
         themeBase === "dark" ? "dark" : "",
         showVerticalCellBorders ? "InovuaReactDataGrid--show-border-right" : "",
         effectiveEnableFiltering ? "InovuaReactDataGrid--filterable" : "",
+        gridFocused
+          ? cn(
+              "tdg-root--focused InovuaReactDataGrid--focused",
+              focusedClassName
+            )
+          : "",
         className
       )}
       data-theme={themeName}
@@ -5406,10 +5883,14 @@ function ReactDataGrid(props: TypeDataGridProps) {
       data-column-width-mode={hasManualColumnWidths ? "fixed" : "stretch"}
       data-show-zebra-rows={showZebraRows ? "true" : "false"}
       data-layout={mobileTransformActive ? "mobile-list" : "table"}
+      data-focused={gridFocused ? "true" : "false"}
+      data-active-index={
+        normalizedActiveIndex >= 0 ? normalizedActiveIndex : "none"
+      }
       style={style}
-      onKeyDown={onKeyDown}
-      onFocus={onFocus}
-      onBlur={onBlur}
+      onKeyDown={handleGridKeyDown}
+      onFocus={handleGridFocus}
+      onBlur={handleGridBlur}
     >
       <DatagridThemeProvider
         theme={themeName}
@@ -5424,7 +5905,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
             ref={surfaceRef}
             className="tdg-surface relative flex min-h-0 w-full min-w-0 max-w-full flex-1 flex-col bg-[var(--tdg-grid-bg)] text-foreground"
             data-slot="grid-surface"
-            tabIndex={-1}
+            tabIndex={enableKeyboardNavigation ? 0 : -1}
+            aria-label="Data grid"
           >
             {!liveColumnResize && resizeProxyLeft != null ? (
               <div
@@ -5444,6 +5926,13 @@ function ReactDataGrid(props: TypeDataGridProps) {
                 checkboxColumnId={checkboxColId}
                 loading={loading}
                 selectedMap={selectedMap}
+                activeIndex={normalizedActiveIndex}
+                gridFocused={gridFocused}
+                selectionEnabled={selectionEnabled}
+                rowIdPrefix={rowIdPrefix}
+                rowFocusClassName={rowFocusClassName}
+                showActiveRowIndicator={showActiveRowIndicator}
+                activeRowIndicatorClassName={activeRowIndicatorClassName}
                 isRowDisabled={isRowDisabled}
                 i18n={i18n}
                 emptyText={props.emptyText}
@@ -5454,8 +5943,8 @@ function ReactDataGrid(props: TypeDataGridProps) {
                 authoritativeResultCount={searchConnected ? count : undefined}
                 onSortInfoChange={setSortInfoAndResetPage}
                 onFilteredRowsCountChange={notifyFilteredRowsCount}
-                onRowClick={(id, data, event) =>
-                  handleRowClick(id, data, event)
+                onRowClick={(id, data, rowIndex, event) =>
+                  handleRowClick(id, data, rowIndex, event)
                 }
               />
             ) : (
@@ -5571,8 +6060,17 @@ function ReactDataGrid(props: TypeDataGridProps) {
                     i18n={i18n}
                     emptyText={props.emptyText}
                     selectedMap={selectedMap}
+                    activeIndex={normalizedActiveIndex}
+                    gridFocused={gridFocused}
+                    selectionEnabled={selectionEnabled}
+                    rowIdPrefix={rowIdPrefix}
+                    rowFocusClassName={rowFocusClassName}
+                    showActiveRowIndicator={showActiveRowIndicator}
+                    activeRowIndicatorClassName={activeRowIndicatorClassName}
                     getDisabledRowState={getDisabledRowState}
-                    onRowClick={(id, data, e) => handleRowClick(id, data, e)}
+                    onRowClick={(id, data, rowIndex, e) =>
+                      handleRowClick(id, data, rowIndex, e)
+                    }
                     rowHeight={rowHeight}
                     minRowHeight={computedMinRowHeight}
                     maxRowHeight={computedMaxRowHeight}

--- a/src/grid/components/GridBody.tsx
+++ b/src/grid/components/GridBody.tsx
@@ -205,8 +205,20 @@ export type GridBodyProps = {
   emptyText: TypeDataGridProps["emptyText"];
 
   selectedMap: Record<string, any>;
+  activeIndex: number;
+  gridFocused: boolean;
+  selectionEnabled: boolean;
+  rowIdPrefix: string;
+  rowFocusClassName?: string;
+  showActiveRowIndicator: boolean;
+  activeRowIndicatorClassName?: string;
   getDisabledRowState: (rowIndex: number) => boolean | null | undefined;
-  onRowClick?: (rowId: string, rowData: any, e: React.MouseEvent) => void;
+  onRowClick?: (
+    rowId: string,
+    rowData: any,
+    rowIndex: number,
+    e: React.MouseEvent
+  ) => void;
 
   rowHeight: number | ((rowIndex: number) => number) | null;
   minRowHeight: number;
@@ -280,6 +292,13 @@ export function GridBody(props: GridBodyProps) {
     i18n,
     emptyText,
     selectedMap,
+    activeIndex,
+    gridFocused,
+    selectionEnabled,
+    rowIdPrefix,
+    rowFocusClassName,
+    showActiveRowIndicator,
+    activeRowIndicatorClassName,
     getDisabledRowState,
     onRowClick,
     rowHeight,
@@ -310,7 +329,8 @@ export function GridBody(props: GridBodyProps) {
   function getRowThemeClasses(
     rowIndex: number,
     rowIsSelected: boolean,
-    rowIsDisabled: boolean
+    rowIsDisabled: boolean,
+    rowIsActive: boolean
   ): string {
     const odd = rowIndex % 2 === 0;
     return cn(
@@ -323,9 +343,17 @@ export function GridBody(props: GridBodyProps) {
       rowIsSelected
         ? showZebraRows
           ? odd
-            ? "tdg-row--selected InovuaReactDataGrid__row--selected tdg-row--active InovuaReactDataGrid__row--active bg-[var(--tdg-row-odd-selected-bg)] [color:var(--tdg-row-active-color)] hover:bg-[var(--tdg-row-odd-selected-hover-bg)] hover:[color:var(--tdg-row-active-color)]"
-            : "tdg-row--selected InovuaReactDataGrid__row--selected tdg-row--active InovuaReactDataGrid__row--active bg-[var(--tdg-row-even-selected-bg)] [color:var(--tdg-row-active-color)] hover:bg-[var(--tdg-row-even-selected-hover-bg)] hover:[color:var(--tdg-row-active-color)]"
-          : "tdg-row--selected InovuaReactDataGrid__row--selected tdg-row--active InovuaReactDataGrid__row--active bg-[var(--tdg-row-selected-bg)] [color:var(--tdg-row-active-color)] hover:bg-[var(--tdg-row-selected-hover-bg)]"
+            ? "tdg-row--selected InovuaReactDataGrid__row--selected bg-[var(--tdg-row-odd-selected-bg)] [color:var(--tdg-row-active-color)] hover:bg-[var(--tdg-row-odd-selected-hover-bg)] hover:[color:var(--tdg-row-active-color)]"
+            : "tdg-row--selected InovuaReactDataGrid__row--selected bg-[var(--tdg-row-even-selected-bg)] [color:var(--tdg-row-active-color)] hover:bg-[var(--tdg-row-even-selected-hover-bg)] hover:[color:var(--tdg-row-active-color)]"
+          : "tdg-row--selected InovuaReactDataGrid__row--selected bg-[var(--tdg-row-selected-bg)] [color:var(--tdg-row-active-color)] hover:bg-[var(--tdg-row-selected-hover-bg)]"
+        : "",
+      rowIsActive ? "tdg-row--active InovuaReactDataGrid__row--active" : "",
+      rowIsActive && gridFocused
+        ? cn(
+            "tdg-row--focused InovuaReactDataGrid__row--focused",
+            rowFocusClassName,
+            showActiveRowIndicator ? activeRowIndicatorClassName : ""
+          )
         : "",
       rowIsDisabled
         ? "tdg-row--disabled InovuaReactDataGrid__row--disabled pointer-events-none opacity-50"
@@ -334,9 +362,11 @@ export function GridBody(props: GridBodyProps) {
   }
 
   function getRowThemeStyle(
-    rowIsSelected: boolean
+    rowIsActive: boolean
   ): React.CSSProperties | undefined {
-    if (!rowIsSelected) return undefined;
+    if (!rowIsActive || !gridFocused || !showActiveRowIndicator) {
+      return undefined;
+    }
 
     return {
       outline:
@@ -360,6 +390,7 @@ export function GridBody(props: GridBodyProps) {
     row: any,
     rowIndex: number,
     rowIsSelected: boolean,
+    rowIsActive: boolean,
     disabledRow: boolean | null | undefined,
     virtualSize?: number
   ): React.CSSProperties {
@@ -381,7 +412,7 @@ export function GridBody(props: GridBodyProps) {
       Number.isFinite(maxRowHeight)
         ? { maxHeight: maxRowHeight }
         : {}),
-      ...getRowThemeStyle(rowIsSelected),
+      ...getRowThemeStyle(rowIsActive),
     };
 
     const configuredStyle =
@@ -946,6 +977,7 @@ export function GridBody(props: GridBodyProps) {
           {virtualItems.map((vi) => {
             const row = rowModel[vi.index]!;
             const rowIsSelected = Boolean(selectedMap[row.id]);
+            const rowIsActive = vi.index === activeIndex;
             const disabledRow = getDisabledRowState(vi.index);
             const rowIsDisabled = Boolean(disabledRow);
 
@@ -954,13 +986,20 @@ export function GridBody(props: GridBodyProps) {
                 ref={rowHeight == null ? measureNaturalRow : undefined}
                 key={row.id}
                 className={cn(
-                  getRowThemeClasses(vi.index, rowIsSelected, rowIsDisabled),
+                  getRowThemeClasses(
+                    vi.index,
+                    rowIsSelected,
+                    rowIsDisabled,
+                    rowIsActive
+                  ),
                   showHorizontalCellBorders
                     ? "InovuaReactDataGrid__row--show-horizontal-borders"
                     : "",
                   vi.index === 0 ? "InovuaReactDataGrid__row--first" : ""
                 )}
+                id={`${rowIdPrefix}-${vi.index}`}
                 data-selected={rowIsSelected ? "true" : "false"}
+                data-active={rowIsActive ? "true" : "false"}
                 data-disabled={rowIsDisabled ? "true" : undefined}
                 data-row-parity={vi.index % 2 === 0 ? "odd" : "even"}
                 data-row-id={row.id}
@@ -968,17 +1007,20 @@ export function GridBody(props: GridBodyProps) {
                 data-index={vi.index}
                 data-slot="grid-row"
                 aria-disabled={rowIsDisabled || undefined}
+                aria-current={rowIsActive ? "true" : undefined}
+                aria-selected={selectionEnabled ? rowIsSelected : undefined}
                 style={getRowStyle(
                   row,
                   vi.index,
                   rowIsSelected,
+                  rowIsActive,
                   disabledRow,
                   vi.size
                 )}
                 onClick={
                   rowIsDisabled
                     ? undefined
-                    : (e) => onRowClick?.(row.id, row.original, e)
+                    : (e) => onRowClick?.(row.id, row.original, vi.index, e)
                 }
               >
                 {renderCells(row, vi.index, vi.size)}
@@ -1007,6 +1049,7 @@ export function GridBody(props: GridBodyProps) {
           ) : null}
           {rowModel.map((row, displayIndex) => {
             const rowIsSelected = Boolean(selectedMap[row.id]);
+            const rowIsActive = displayIndex === activeIndex;
             const disabledRow = getDisabledRowState(displayIndex);
             const rowIsDisabled = Boolean(disabledRow);
 
@@ -1017,30 +1060,36 @@ export function GridBody(props: GridBodyProps) {
                   getRowThemeClasses(
                     displayIndex,
                     rowIsSelected,
-                    rowIsDisabled
+                    rowIsDisabled,
+                    rowIsActive
                   ),
                   showHorizontalCellBorders
                     ? "InovuaReactDataGrid__row--show-horizontal-borders"
                     : "",
                   displayIndex === 0 ? "InovuaReactDataGrid__row--first" : ""
                 )}
+                id={`${rowIdPrefix}-${displayIndex}`}
                 data-selected={rowIsSelected ? "true" : "false"}
+                data-active={rowIsActive ? "true" : "false"}
                 data-disabled={rowIsDisabled ? "true" : undefined}
                 data-row-parity={displayIndex % 2 === 0 ? "odd" : "even"}
                 data-row-id={row.id}
                 data-row-index={displayIndex}
                 data-slot="grid-row"
                 aria-disabled={rowIsDisabled || undefined}
+                aria-current={rowIsActive ? "true" : undefined}
+                aria-selected={selectionEnabled ? rowIsSelected : undefined}
                 style={getRowStyle(
                   row,
                   displayIndex,
                   rowIsSelected,
+                  rowIsActive,
                   disabledRow
                 )}
                 onClick={
                   rowIsDisabled
                     ? undefined
-                    : (e) => onRowClick?.(row.id, row.original, e)
+                    : (e) => onRowClick?.(row.id, row.original, displayIndex, e)
                 }
               >
                 {renderCells(row, displayIndex)}

--- a/src/grid/components/MobileGridList.tsx
+++ b/src/grid/components/MobileGridList.tsx
@@ -44,6 +44,13 @@ type MobileGridListProps = {
   checkboxColumnId: string;
   loading: boolean;
   selectedMap: Record<string, unknown>;
+  activeIndex: number;
+  gridFocused: boolean;
+  selectionEnabled: boolean;
+  rowIdPrefix: string;
+  rowFocusClassName?: string;
+  showActiveRowIndicator: boolean;
+  activeRowIndicatorClassName?: string;
   isRowDisabled: (rowIndex: number) => boolean;
   i18n: TypeDataGridProps["i18n"];
   emptyText: TypeDataGridProps["emptyText"];
@@ -57,6 +64,7 @@ type MobileGridListProps = {
   onRowClick: (
     id: string,
     data: Record<string, unknown>,
+    rowIndex: number,
     event: React.MouseEvent
   ) => void;
 };
@@ -77,6 +85,13 @@ export function MobileGridList({
   checkboxColumnId,
   loading,
   selectedMap,
+  activeIndex,
+  gridFocused,
+  selectionEnabled,
+  rowIdPrefix,
+  rowFocusClassName,
+  showActiveRowIndicator,
+  activeRowIndicatorClassName,
   isRowDisabled,
   i18n,
   emptyText,
@@ -329,6 +344,16 @@ export function MobileGridList({
     virtualizer.scrollToOffset(0);
   }, [deferredQuery, virtualizer]);
 
+  React.useLayoutEffect(() => {
+    if (!gridFocused || activeIndex < 0) return;
+    const displayIndex = filteredRows.findIndex(
+      (row) => row.index === activeIndex
+    );
+    if (displayIndex >= 0) {
+      virtualizer.scrollToIndex(displayIndex, { align: "auto" });
+    }
+  }, [activeIndex, filteredRows, gridFocused, virtualizer]);
+
   const emptyContent =
     !loading && filteredRows.length === 0
       ? resolveEmptyText(emptyText, i18n)
@@ -547,7 +572,10 @@ export function MobileGridList({
           >
             {virtualizer.getVirtualItems().map((virtualRow) => {
               const row = filteredRows[virtualRow.index]!;
-              const rowIsDisabled = isRowDisabled(virtualRow.index);
+              const rowIndex = row.index;
+              const rowIsDisabled = isRowDisabled(rowIndex);
+              const rowIsSelected = Boolean(selectedMap[row.id]);
+              const rowIsActive = rowIndex === activeIndex;
               const cells = row.getVisibleCells();
               const checkboxCell = cells.find(
                 (cell) => cell.column.id === checkboxColumnId
@@ -589,18 +617,38 @@ export function MobileGridList({
                   <article
                     className={cn(
                       "rounded-md border bg-background p-4 shadow-sm [border-color:var(--tdg-grid-border-color)]",
-                      Boolean(selectedMap[row.id]) && "ring-2 ring-ring",
+                      rowIsSelected && "ring-2 ring-ring",
+                      rowIsActive &&
+                        "tdg-row--active InovuaReactDataGrid__row--active",
+                      rowIsActive &&
+                        gridFocused &&
+                        cn(
+                          "tdg-row--focused InovuaReactDataGrid__row--focused",
+                          rowFocusClassName,
+                          showActiveRowIndicator &&
+                            "outline outline-2 outline-offset-[-2px] outline-ring",
+                          showActiveRowIndicator
+                            ? activeRowIndicatorClassName
+                            : ""
+                        ),
                       rowIsDisabled &&
                         "tdg-row--disabled InovuaReactDataGrid__row--disabled pointer-events-none opacity-50"
                     )}
+                    id={`${rowIdPrefix}-${rowIndex}`}
+                    data-slot="grid-row"
                     data-row-id={row.id}
-                    data-row-index={virtualRow.index}
+                    data-row-index={rowIndex}
+                    data-selected={rowIsSelected ? "true" : "false"}
+                    data-active={rowIsActive ? "true" : "false"}
                     data-disabled={rowIsDisabled ? "true" : undefined}
                     aria-disabled={rowIsDisabled || undefined}
+                    aria-current={rowIsActive ? "true" : undefined}
+                    aria-selected={selectionEnabled ? rowIsSelected : undefined}
                     onClick={
                       rowIsDisabled
                         ? undefined
-                        : (event) => onRowClick(row.id, row.original, event)
+                        : (event) =>
+                            onRowClick(row.id, row.original, rowIndex, event)
                     }
                   >
                     <header className="flex min-w-0 items-start gap-3">

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ export type {
   TypeColumnResizeInfo,
   TypePaginationMode,
   TypeShowCellBorders,
+  TypeBoolMap,
   TypeRowSelection,
   TypeRowStyle,
   TypeRowStyleArgs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -476,6 +476,8 @@ export type TypeRowSelection =
   | { [key: string]: any }
   | null;
 
+export type TypeBoolMap = { [key: string]: boolean };
+
 export type TypeOnSelectionChangeArg = {
   selected: TypeRowSelection;
   data?: unknown;
@@ -751,7 +753,9 @@ export type TypeComputedProps = {
   getItemIndexById?: (rowId: string | number, data?: unknown[]) => number;
 
   computedSelected?: TypeRowSelection;
-  computedUnselected?: Record<string, boolean>;
+  computedUnselected?: TypeBoolMap | null;
+  computedRowSelectionEnabled?: boolean;
+  computedRowMultiSelectionEnabled?: boolean;
   getSelectedMap?: () => Record<string, unknown>;
   setSelected?: (selected: TypeRowSelection, ...args: unknown[]) => void;
   selectAll?: () => void;
@@ -766,6 +770,15 @@ export type TypeComputedProps = {
   setSelectedById?: (id: string, selected: boolean) => void;
   setSelectedAt?: (index: number, selected: boolean) => void;
   setRowSelected?: (index: number, selected: boolean, event?: unknown) => void;
+
+  computedActiveIndex?: number;
+  computedLastActiveIndex?: number | null;
+  computedActiveItem?: unknown;
+  computedHasRowNavigation?: boolean;
+  computedFocused?: boolean;
+  setActiveIndex?: (activeIndex: number) => void;
+  incrementActiveIndex?: (increment: number) => void;
+  getActiveItem?: () => unknown;
 
   setScrollLeft?: (scrollLeft: number) => void;
   incrementScrollLeft?: (scrollLeft: number) => void;
@@ -1023,11 +1036,27 @@ export type TypeDataGridProps = {
 
   selected?: TypeRowSelection;
   defaultSelected?: TypeRowSelection;
+  unselected?: TypeBoolMap;
+  defaultUnselected?: TypeBoolMap;
   onSelectionChange?: (config: TypeOnSelectionChangeArg) => void;
 
   multiSelect?: boolean;
   checkboxOnlyRowSelect?: boolean;
   checkboxSelectEnableShiftKey?: boolean;
+  toggleRowSelectOnClick?: boolean;
+
+  activeIndex?: number;
+  defaultActiveIndex?: number;
+  onActiveIndexChange?: (activeIndex: number) => void;
+  activeIndexThrottle?: number;
+  enableKeyboardNavigation?: boolean;
+  activateRowOnFocus?: boolean;
+  keyPageStep?: number;
+  allowRowTabNavigation?: boolean;
+  rowFocusClassName?: string;
+  focusedClassName?: string;
+  showActiveRowIndicator?: boolean;
+  activeRowIndicatorClassName?: string;
 
   /**
    * Disables pointer interaction for rows at the specified zero-based

--- a/tests/playwright/github-issues-33-48.spec.ts
+++ b/tests/playwright/github-issues-33-48.spec.ts
@@ -25,8 +25,10 @@ function collectExportTargets(value: PackageExportValue | undefined): string[] {
   );
 }
 
-async function openIssue(page: Page, issue: number) {
-  await page.goto(`${issueFixturePath}?issue=${issue}`);
+async function openIssue(page: Page, issue: number, query = "") {
+  await page.goto(
+    `${issueFixturePath}?issue=${issue}${query ? `&${query}` : ""}`
+  );
 
   const scope = page.getByTestId("github-issues-33-48-scenario");
   await expect(scope).toHaveAttribute("data-issue", String(issue));
@@ -117,6 +119,136 @@ test("GitHub issue #38: ArrowDown advances defaultActiveIndex and emits the call
   await expect(surface).toBeFocused();
   await page.keyboard.press("ArrowDown");
   await expect(scope.getByTestId("issue-38-active-index")).toHaveText("1");
+});
+
+test("GitHub issue #38: controlled activeIndex and throttled navigation remain authoritative", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 38, "activeMode=controlled");
+  const root = scope.locator(".tdg-root");
+  const surface = scope.locator('[data-slot="grid-surface"]');
+  const activeIndex = scope.getByTestId("issue-38-active-index");
+
+  await surface.focus();
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("ArrowDown");
+  await expect(activeIndex).toHaveText("3");
+  await expect(root).toHaveAttribute("data-active-index", "3");
+
+  await scope.locator('[data-slot="grid-row"][data-row-index="6"]').click();
+  await expect(activeIndex).toHaveText("6");
+  await expect(root).toHaveAttribute("data-active-index", "6");
+
+  await scope.getByTestId("issue-38-outside-focus").focus();
+  await expect(activeIndex).toHaveText("-1");
+  await surface.focus();
+  await expect(activeIndex).toHaveText("6");
+  await expect(root).toHaveAttribute("data-active-index", "6");
+});
+
+test("GitHub issue #38: keyboard navigation, focus restoration, and virtual scrolling stay synchronized", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 38);
+  const root = scope.locator(".tdg-root");
+  const surface = scope.locator('[data-slot="grid-surface"]');
+  const activeIndex = scope.getByTestId("issue-38-active-index");
+  const rowAt = (index: number) =>
+    scope.locator(`[data-slot="grid-row"][data-row-index="${index}"]`);
+
+  await surface.focus();
+  await expect(surface).toBeFocused();
+  await expect(root).toHaveAttribute("data-focused", "true");
+  await expect(root).toHaveClass(/issue-38-grid-focused/);
+  await expect(root).toHaveAttribute("data-active-index", "0");
+  await expect(rowAt(0)).toHaveAttribute("data-active", "true");
+  await expect(rowAt(0)).toHaveAttribute("aria-current", "true");
+  await expect(rowAt(0)).toHaveClass(/issue-38-row-focused/);
+  await expect(rowAt(0)).toHaveClass(/issue-38-active-indicator/);
+  await expect(rowAt(0)).not.toHaveClass(/tdg-row--selected/);
+
+  await page.keyboard.press("End");
+  await expect(activeIndex).toHaveText("39");
+  await expect(rowAt(39)).toBeVisible();
+  await expect(rowAt(39)).toHaveAttribute("data-active", "true");
+
+  await page.keyboard.press("Home");
+  await expect(activeIndex).toHaveText("0");
+  await expect(rowAt(0)).toBeVisible();
+
+  await page.keyboard.press("PageDown");
+  await expect(activeIndex).toHaveText("5");
+  await page.keyboard.press("PageUp");
+  await expect(activeIndex).toHaveText("0");
+  await page.keyboard.press("Tab");
+  await expect(activeIndex).toHaveText("1");
+  await page.keyboard.press("Shift+Tab");
+  await expect(activeIndex).toHaveText("0");
+
+  await scope.getByTestId("issue-38-outside-focus").focus();
+  await expect(root).toHaveAttribute("data-focused", "false");
+  await expect(root).toHaveAttribute("data-active-index", "none");
+  await expect(activeIndex).toHaveText("-1");
+  await expect(
+    root.locator('[data-slot="grid-row"][data-active="true"]')
+  ).toHaveCount(0);
+
+  await surface.focus();
+  await expect(root).toHaveAttribute("data-active-index", "0");
+  await expect(activeIndex).toHaveText("0");
+});
+
+test("GitHub issue #38: pointer and keyboard selection match Inovua multi-select semantics", async ({
+  page,
+}) => {
+  const scope = await openIssue(page, 38);
+  const selection = scope.getByTestId("issue-38-selection");
+  const rowAt = (index: number) =>
+    scope.locator(`[data-slot="grid-row"][data-row-index="${index}"]`);
+
+  await rowAt(1).click();
+  await expect(selection).toHaveText(
+    '{"selected":["active-1"],"unselected":[]}'
+  );
+  await expect(rowAt(1)).toHaveAttribute("aria-selected", "true");
+
+  await rowAt(4).click({ modifiers: ["Shift"] });
+  await expect(selection).toHaveText(
+    '{"selected":["active-1","active-2","active-3","active-4"],"unselected":[]}'
+  );
+
+  await rowAt(7).click({ modifiers: ["Meta"] });
+  await expect(selection).toHaveText(
+    '{"selected":["active-1","active-2","active-3","active-4","active-7"],"unselected":[]}'
+  );
+
+  await rowAt(7).click();
+  await expect(selection).toHaveText(
+    '{"selected":["active-7"],"unselected":[]}'
+  );
+  await rowAt(7).click({ modifiers: ["Meta"] });
+  await expect(selection).toHaveText('{"selected":[],"unselected":[]}');
+
+  const surface = scope.locator('[data-slot="grid-surface"]');
+  await surface.focus();
+  await page.keyboard.press("Home");
+  await page.keyboard.press("Enter");
+  await expect(selection).toHaveText(
+    '{"selected":["active-0"],"unselected":[]}'
+  );
+  await page.keyboard.press("Meta+Enter");
+  await expect(selection).toHaveText('{"selected":[],"unselected":[]}');
+
+  await scope.getByTestId("issue-38-select-all-mode").click();
+  await expect(selection).toHaveText('{"selected":true,"unselected":[]}');
+  const firstRowCheckbox = rowAt(0).getByRole("checkbox");
+  await firstRowCheckbox.click();
+  await expect(selection).toHaveText(
+    '{"selected":true,"unselected":["active-0"]}'
+  );
+  await firstRowCheckbox.click();
+  await expect(selection).toHaveText('{"selected":true,"unselected":[]}');
 });
 
 test("GitHub issue #39: clicking a cell emits the active tuple and stable id selection key", async ({

--- a/tests/types/type-issue-38-active-row.ts
+++ b/tests/types/type-issue-38-active-row.ts
@@ -1,0 +1,69 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  type TypeBoolMap,
+  type TypeColumns,
+  type TypeComputedProps,
+  type TypeDataGridProps,
+  type TypeRowSelection,
+} from "@geovi/the-datagrid";
+
+const columns: TypeColumns = [
+  { name: "id", header: "ID" },
+  { name: "name", header: "Name" },
+];
+const rows = [{ id: "row-1", name: "Ada" }];
+const unselected: TypeBoolMap = { "row-2": true };
+
+const props = {
+  idProperty: "id",
+  columns,
+  dataSource: rows,
+  enableSelection: true,
+  multiSelect: true,
+  selected: true as TypeRowSelection,
+  unselected,
+  defaultUnselected: {},
+  toggleRowSelectOnClick: false,
+  activeIndex: 0,
+  defaultActiveIndex: 0,
+  activeIndexThrottle: 16,
+  enableKeyboardNavigation: true,
+  activateRowOnFocus: true,
+  keyPageStep: 10,
+  allowRowTabNavigation: true,
+  rowFocusClassName: "row-focused",
+  focusedClassName: "grid-focused",
+  showActiveRowIndicator: true,
+  activeRowIndicatorClassName: "active-indicator",
+  onActiveIndexChange: (activeIndex: number) => {
+    void activeIndex;
+  },
+  onSelectionChange: ({ selected, unselected: excluded }) => {
+    void selected;
+    void excluded;
+  },
+} satisfies TypeDataGridProps;
+
+React.createElement(ReactDataGrid, props);
+
+declare const api: TypeComputedProps;
+api.setActiveIndex?.(3);
+api.incrementActiveIndex?.(-1);
+api.getActiveItem?.();
+api.getFirstVisibleIndex?.();
+api.setSelected?.(true);
+api.setSelectedById?.("row-1", true);
+
+const activeIndex: number | undefined = api.computedActiveIndex;
+const lastActiveIndex: number | null | undefined = api.computedLastActiveIndex;
+const selectionEnabled: boolean | undefined = api.computedRowSelectionEnabled;
+const multiSelectionEnabled: boolean | undefined =
+  api.computedRowMultiSelectionEnabled;
+const focused: boolean | undefined = api.computedFocused;
+
+void activeIndex;
+void lastActiveIndex;
+void selectionEnabled;
+void multiSelectionEnabled;
+void focused;


### PR DESCRIPTION
## Summary

- implement controlled/uncontrolled active-row state, focus restoration, keyboard/page/optional Tab navigation, throttling, and virtualized scroll-to-visible
- complete Inovua-style plain, Ctrl/Cmd, Shift-range, Enter, select-all, and `selected=true`/`unselected` selection behavior
- expose live active/selection computed API fields, focus/active styling hooks, and ARIA row state across table and mobile layouts
- add public type coverage, a controlled/uncontrolled Playwright matrix, and update compatibility documentation

## Verification

- `yarn test:types`
- `yarn build`
- `yarn test:react-compat`
- `playwright test tests/playwright/github-issues-33-48.spec.ts --grep "issue #38"` (4 passed)
- surrounding selection, disabled-row, sorting, computed-API, and mobile sweep: 27 relevant tests passed; remaining failures correspond to other already-open compatibility issues

Closes #38