### PR TITLE
Complete Inovua filtering parity for issue #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ number comparison/range operators, and date/time comparison/range operators.
 Operator definitions can opt into empty-value filtering, initialize a value
 when selected, or disable the editor for value-free operations.
 
-Current caveat: an unseeded `bool`/`boolean` filter resolves through the generic
-`contains` fallback even though those registries expose only `eq`/`neq`. Seed an
-`eq` or `neq` filter entry until that implementation gap is corrected.
+Unseeded `bool` and `boolean` filters default to `eq`, matching their shipped
+operator registry. Other defaults are `contains` for strings, `gte` for
+numbers, `eq` for selects, and `afterOrOn` for date/time values.
 
 Custom filter types are shallow-merged by registry key with the built-ins:
 
@@ -847,15 +847,21 @@ those compatibility metrics.
 
 ### Filtering
 
-| Prop                            | Type                               | Default           | Description                                               |
-| ------------------------------- | ---------------------------------- | ----------------- | --------------------------------------------------------- |
-| `enableFiltering`               | `boolean`                          | inferred          | Explicitly show or hide the filter row                    |
-| `filterValue`                   | `TypeFilterValue`                  | -                 | Controlled display state; data ownership remains external |
-| `defaultFilterValue`            | `TypeFilterValue`                  | -                 | Uncontrolled initial state and local filtering input      |
-| `onFilterValueChange`           | `(value: TypeFilterValue) => void` | -                 | Fired on filter change                                    |
-| `filterTypes`                   | `TypeFilterTypes`                  | built-in registry | Extend or override filter types and operators             |
-| `enableColumnFilterContextMenu` | `boolean`                          | `true`            | Operator, activation, Clear, and Clear All menu           |
-| `filteredRowsCount`             | `(count: number) => void`          | -                 | Reports filtered row count                                |
+| Prop                                    | Type                                           | Default            | Description                                               |
+| --------------------------------------- | ---------------------------------------------- | ------------------ | --------------------------------------------------------- |
+| `enableFiltering`                       | `boolean`                                      | inferred           | Explicitly show or hide the filter row                    |
+| `filterValue`                           | `TypeFilterValue`                              | -                  | Controlled display state; data ownership remains external |
+| `defaultFilterValue`                    | `TypeFilterValue`                              | -                  | Uncontrolled initial state and local filtering input      |
+| `onFilterValueChange`                   | `(value: TypeFilterValue) => void`             | -                  | Fired on filter change                                    |
+| `filterTypes`                           | `TypeFilterTypes`                              | built-in registry  | Extend or override filter types and operators             |
+| `enableColumnFilterContextMenu`         | `boolean`                                      | `true`             | Operator, activation, Clear, and Clear All menu           |
+| `scrollTopOnFilter`                     | `boolean`                                      | `true`             | Reset vertical scroll after a filter commits              |
+| `renderColumnFilterContextMenu`         | `TypeRenderColumnFilterContextMenu`            | -                  | Render a custom operator menu with grid/cell context      |
+| `columnFilterContextMenuAlignPositions` | `string[]`                                     | built-in fallbacks | Configure custom/operator menu alignment candidates       |
+| `columnFilterContextMenuConstrainTo`    | `boolean \| HTMLElement \| string \| function` | `true`             | Supply the custom menu constraint target                  |
+| `columnFilterContextMenuPosition`       | `string`                                       | `"absolute"`       | Supply the custom menu positioning mode                   |
+| `updateMenuPositionOnScroll`            | `boolean`                                      | `true`             | Request custom menu repositioning while scrolling         |
+| `filteredRowsCount`                     | `(count: number) => void`                      | -                  | Reports filtered row count                                |
 
 For Inovua 5.10.2 compatibility, filter-row visibility and local array
 transformation are separate decisions. With no explicit `enableFiltering`, a

--- a/examples/src/BasicGridExample.tsx
+++ b/examples/src/BasicGridExample.tsx
@@ -24,7 +24,7 @@ const defaultFilterValue: TypeFilterValue = [
     name: "city",
     type: "select",
     operator: "eq",
-    value: "",
+    value: null,
   },
   {
     name: "amount",

--- a/examples/src/Issue34FilteringCompatPage.tsx
+++ b/examples/src/Issue34FilteringCompatPage.tsx
@@ -1,0 +1,1235 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  NumberFilter,
+  type TypeColumns,
+  type TypeComputedProps,
+  type TypeDataSource,
+  type TypeDataSourceArgs,
+  type TypeFilterValue,
+  type TypeSingleFilterValue,
+} from "../../src/main";
+import { Button } from "../../src/components/ui/button";
+import { applyLocalFilter } from "../../src/filters/utils";
+
+function GridShell(props: {
+  testId: string;
+  children: React.ReactNode;
+  height?: number;
+}): React.ReactElement {
+  return (
+    <section className="space-y-2" data-testid={props.testId}>
+      <h2 className="text-sm font-semibold">{props.testId}</h2>
+      <div
+        className="min-h-0 w-[760px] max-w-full overflow-hidden rounded-lg border"
+        style={{ height: props.height ?? 220 }}
+      >
+        {props.children}
+      </div>
+    </section>
+  );
+}
+
+function makeFilter(
+  value: Partial<TypeSingleFilterValue> &
+    Pick<TypeSingleFilterValue, "name" | "operator" | "value">
+): TypeSingleFilterValue {
+  return {
+    type: "string",
+    ...value,
+  };
+}
+
+type AliasRow = {
+  id: string;
+  profile: {
+    displayName: string;
+  };
+};
+
+const aliasRows: AliasRow[] = [
+  { id: "alias-ada", profile: { displayName: "Ada Lovelace" } },
+  { id: "alias-grace", profile: { displayName: "Grace Hopper" } },
+];
+
+function aliasColumns(): TypeColumns {
+  return [
+    { name: "id", header: "ID", width: 140, filterable: false },
+    {
+      name: "displayName",
+      filterName: "profileName",
+      header: "Display name",
+      width: 240,
+      type: "string",
+      filterType: "string",
+      getFilterValue: ({ data }) => (data as AliasRow).profile.displayName,
+    },
+    {
+      name: "visibleMeta",
+      header: "Visible metadata",
+      width: 180,
+      defaultVisible: true,
+    },
+    {
+      name: "hiddenByDefault",
+      header: "Hidden by default",
+      width: 180,
+      defaultHidden: true,
+    },
+    {
+      name: "notVisibleByDefault",
+      header: "Not visible by default",
+      width: 180,
+      defaultVisible: false,
+    },
+  ];
+}
+
+const aliasFilter = [
+  makeFilter({
+    name: "displayName",
+    type: undefined as unknown as string,
+    operator: "contains",
+    value: "Ada",
+  }),
+];
+
+function ProjectionScenario(): React.ReactElement {
+  const columns = React.useMemo(() => aliasColumns(), []);
+  const [remoteSnapshot, setRemoteSnapshot] = React.useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const remoteSource = React.useCallback((args: TypeDataSourceArgs) => {
+    const entry = args.filterValue?.[0];
+    setRemoteSnapshot({
+      filter: entry
+        ? {
+            name: entry.name,
+            type: entry.type ?? null,
+            operator: entry.operator,
+            value: entry.value,
+            hasGetter: typeof entry.getFilterValue === "function",
+          }
+        : null,
+      columnOrder: args.columnOrder,
+      columns: args.columns.map((column) => String(column.id ?? column.name)),
+    });
+    return aliasRows;
+  }, []) as TypeDataSource;
+
+  return (
+    <main
+      className="space-y-6 p-6"
+      data-testid="issue-34-projection"
+      aria-label="Issue 34 local and remote filter projection"
+    >
+      <GridShell testId="issue-34-local-alias">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={aliasRows}
+          defaultFilterValue={aliasFilter}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+
+      <output data-testid="issue-34-remote-snapshot">
+        {JSON.stringify(remoteSnapshot)}
+      </output>
+      <GridShell testId="issue-34-remote-alias">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={remoteSource}
+          defaultFilterValue={aliasFilter}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+type NestedRow = {
+  id: string;
+  profile: {
+    displayName: string;
+  };
+};
+
+function DescriptorScenario(): React.ReactElement {
+  const getterColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 140, filterable: false },
+      {
+        name: "displayName",
+        header: "Descriptor getter",
+        width: 240,
+        type: "string",
+      },
+    ],
+    []
+  );
+  const getterRows = React.useMemo<NestedRow[]>(
+    () => [
+      { id: "getter-ada", profile: { displayName: "Ada Lovelace" } },
+      { id: "getter-grace", profile: { displayName: "Grace Hopper" } },
+    ],
+    []
+  );
+  const getterFilter = React.useMemo<TypeFilterValue>(
+    () => [
+      {
+        name: "displayName",
+        type: "string",
+        operator: "contains",
+        value: "Ada",
+        getFilterValue: (args: unknown) =>
+          (args as { data: NestedRow }).data.profile.displayName,
+      },
+    ],
+    []
+  );
+  const functionColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 140, filterable: false },
+      {
+        name: "score",
+        header: "Descriptor function",
+        width: 240,
+        type: "number",
+      },
+    ],
+    []
+  );
+  const functionFilter = React.useMemo<TypeFilterValue>(
+    () => [
+      {
+        name: "score",
+        type: "number",
+        operator: "gt",
+        value: 10,
+        fn: (args: unknown) =>
+          (args as { data: { id: string } }).data.id === "fn-keep",
+      },
+    ],
+    []
+  );
+
+  return (
+    <main
+      className="space-y-6 p-6"
+      data-testid="issue-34-descriptors"
+      aria-label="Issue 34 descriptor hooks"
+    >
+      <GridShell testId="issue-34-descriptor-getter">
+        <ReactDataGrid
+          idProperty="id"
+          columns={getterColumns}
+          dataSource={getterRows}
+          defaultFilterValue={getterFilter}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-descriptor-function">
+        <ReactDataGrid
+          idProperty="id"
+          columns={functionColumns}
+          dataSource={[
+            { id: "fn-keep", score: 1 },
+            { id: "fn-drop", score: 100 },
+          ]}
+          defaultFilterValue={functionFilter}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+function ContractFilterEditor(
+  props: Record<string, unknown>
+): React.ReactElement {
+  const filterValue = props.filterValue as TypeSingleFilterValue | undefined;
+  const summary = {
+    filterEditorPropsType: typeof props.filterEditorProps,
+    hasI18n: Boolean(props.i18n),
+    hasTheme: typeof props.theme === "string",
+    hasRender: typeof props.render === "function",
+    hasCellProps: Boolean(props.cellProps),
+    hasCell: Boolean(props.cell),
+    hasEmptyValue: Object.hasOwn(props, "emptyValue"),
+    hasFilterType: Boolean(props.filterType),
+    hasOnChange: typeof props.onChange === "function",
+    filterDelay: props.filterDelay ?? null,
+    active: props.active ?? null,
+    operator: filterValue?.operator ?? null,
+  };
+
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      <output data-testid="issue-34-custom-editor-props">
+        {JSON.stringify(summary)}
+      </output>
+      <Button
+        type="button"
+        size="sm"
+        data-testid="issue-34-custom-editor-change"
+        onClick={() => {
+          const onChange = props.onChange as
+            | ((value: TypeSingleFilterValue) => void)
+            | undefined;
+          onChange?.({
+            name: filterValue?.name ?? "name",
+            type: filterValue?.type ?? "string",
+            operator: filterValue?.operator ?? "contains",
+            value: "Grace",
+          });
+        }}
+      >
+        Grace
+      </Button>
+    </div>
+  );
+}
+
+type EditorPropsCall = {
+  index: number | null;
+  value: unknown;
+  hasFilterValue: boolean;
+  hasColumn: boolean;
+  hasCellProps: boolean;
+};
+
+function EditorsScenario(): React.ReactElement {
+  const [filterEvents, setFilterEvents] = React.useState<TypeFilterValue[]>([]);
+  const numberCallsRef = React.useRef<EditorPropsCall[]>([]);
+  const [numberCalls, setNumberCalls] = React.useState<EditorPropsCall[]>([]);
+  const customEditorProps = React.useCallback(
+    () => ({
+      "data-consumer-prop": "preserved",
+    }),
+    []
+  );
+  const numberEditorProps = React.useCallback(
+    (editorProps: Record<string, unknown>, meta: { index?: number }) => {
+      numberCallsRef.current.push({
+        index: typeof meta?.index === "number" ? meta.index : null,
+        value: editorProps.value ?? null,
+        hasFilterValue: Boolean(editorProps.filterValue),
+        hasColumn: Boolean(editorProps.column),
+        hasCellProps: Boolean(editorProps.cellProps),
+      });
+      return {
+        placeholder: meta?.index === 0 ? "Minimum" : "Maximum",
+      };
+    },
+    []
+  );
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 110, filterable: false },
+      {
+        name: "name",
+        header: "Custom editor",
+        width: 330,
+        type: "string",
+        filterEditor: ContractFilterEditor,
+        filterEditorProps: customEditorProps,
+      },
+      {
+        name: "score",
+        header: "Number range",
+        width: 260,
+        type: "number",
+        filterEditor: NumberFilter,
+        filterEditorProps: numberEditorProps,
+      },
+    ],
+    [customEditorProps, numberEditorProps]
+  );
+
+  return (
+    <main
+      className="space-y-4 p-6"
+      data-testid="issue-34-editors"
+      aria-label="Issue 34 filter editor arguments"
+    >
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          size="sm"
+          data-testid="issue-34-capture-number-editor-calls"
+          onClick={() => setNumberCalls([...numberCallsRef.current])}
+        >
+          Capture number editor calls
+        </Button>
+        <output data-testid="issue-34-number-editor-calls">
+          {JSON.stringify(numberCalls)}
+        </output>
+        <output data-testid="issue-34-editor-filter-events">
+          {JSON.stringify(filterEvents)}
+        </output>
+      </div>
+      <GridShell testId="issue-34-editor-grid" height={245}>
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={[
+            { id: "editor-ada", name: "Ada", score: 2 },
+            { id: "editor-grace", name: "Grace", score: 4 },
+            { id: "editor-katherine", name: "Katherine", score: 8 },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "name",
+              operator: "contains",
+              value: "",
+              active: true,
+            }),
+            makeFilter({
+              name: "score",
+              type: "number",
+              operator: "inrange",
+              value: { start: 1, end: 5 },
+              active: true,
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+          onFilterValueChange={(next) =>
+            setFilterEvents((current) => [...current, next])
+          }
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+function BooleanFilterEditor(
+  props: Record<string, unknown>
+): React.ReactElement {
+  const filterValue = props.filterValue as TypeSingleFilterValue;
+  return (
+    <output data-testid={`issue-34-${String(props.columnId)}-operator`}>
+      {filterValue.operator}
+    </output>
+  );
+}
+
+function BooleanScenario(): React.ReactElement {
+  const boolColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 130, filterable: false },
+      {
+        name: "boolValue",
+        header: "bool value",
+        width: 180,
+        filterType: "bool",
+        filterEditor: BooleanFilterEditor,
+      },
+    ],
+    []
+  );
+  const booleanColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 130, filterable: false },
+      {
+        name: "booleanValue",
+        header: "boolean value",
+        width: 180,
+        filterType: "boolean",
+        filterEditor: BooleanFilterEditor,
+      },
+    ],
+    []
+  );
+
+  return (
+    <main
+      className="space-y-6 p-6"
+      data-testid="issue-34-booleans"
+      aria-label="Issue 34 boolean filtering"
+    >
+      <GridShell testId="issue-34-bool-default">
+        <ReactDataGrid
+          idProperty="id"
+          columns={boolColumns}
+          dataSource={[
+            { id: "bool-true", boolValue: true },
+            { id: "bool-false", boolValue: false },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "boolValue",
+              type: "bool",
+              operator: "",
+              value: true,
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-boolean-default">
+        <ReactDataGrid
+          idProperty="id"
+          columns={booleanColumns}
+          dataSource={[
+            { id: "boolean-true", booleanValue: true },
+            { id: "boolean-false", booleanValue: false },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "booleanValue",
+              type: "boolean",
+              operator: "",
+              value: true,
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-boolean-empty">
+        <ReactDataGrid
+          idProperty="id"
+          columns={booleanColumns}
+          dataSource={[
+            { id: "boolean-empty-true", booleanValue: true },
+            { id: "boolean-empty-false", booleanValue: false },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "booleanValue",
+              type: "boolean",
+              operator: "eq",
+              value: null,
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+function AuditTextFilterEditor(
+  props: Record<string, unknown>
+): React.ReactElement {
+  const auditInput = props.onAuditInput as (() => void) | undefined;
+  const onChange = props.onChange as ((value: string) => void) | undefined;
+  return (
+    <input
+      aria-label={String(props.auditLabel ?? "Audit filter")}
+      className="h-8 w-full rounded border px-2"
+      value={String(props.value ?? "")}
+      onChange={(event) => {
+        auditInput?.();
+        onChange?.(event.target.value);
+      }}
+    />
+  );
+}
+
+function DelayScenario(): React.ReactElement {
+  const [eventTimes, setEventTimes] = React.useState<number[]>([]);
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 130, filterable: false },
+      {
+        name: "name",
+        header: "Name",
+        width: 260,
+        type: "string",
+        filterDelay: 25,
+      },
+    ],
+    []
+  );
+
+  return (
+    <main
+      className="space-y-4 p-6"
+      data-testid="issue-34-delay"
+      aria-label="Issue 34 filter delay"
+    >
+      <output data-testid="issue-34-delay-event-times">
+        {JSON.stringify(eventTimes)}
+      </output>
+      <GridShell testId="issue-34-delay-grid">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={[
+            { id: "delay-ada", name: "Ada" },
+            { id: "delay-grace", name: "Grace" },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "name",
+              operator: "contains",
+              value: "",
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+          onFilterValueChange={() =>
+            setEventTimes((current) => [
+              ...current,
+              Math.round(performance.now()),
+            ])
+          }
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+const scrollRows = Array.from({ length: 180 }, (_, index) => ({
+  id: `scroll-${index + 1}`,
+  name: `Row ${index + 1}`,
+}));
+
+function ScrollGrid(props: {
+  testId: string;
+  scrollTopOnFilter: boolean;
+}): React.ReactElement {
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 140, filterable: false },
+      {
+        name: "name",
+        header: "Name",
+        width: 260,
+        type: "string",
+        filterEditor: AuditTextFilterEditor,
+        filterEditorProps: {
+          auditLabel: `${props.testId} filter`,
+        },
+      },
+    ],
+    [props.testId]
+  );
+
+  return (
+    <GridShell testId={props.testId} height={270}>
+      <ReactDataGrid
+        idProperty="id"
+        columns={columns}
+        dataSource={scrollRows}
+        defaultFilterValue={[
+          makeFilter({
+            name: "name",
+            operator: "contains",
+            value: "",
+          }),
+        ]}
+        scrollTopOnFilter={props.scrollTopOnFilter}
+        rowHeight={36}
+        virtualized
+        showColumnMenuTool={false}
+      />
+    </GridShell>
+  );
+}
+
+function ScrollScenario(): React.ReactElement {
+  return (
+    <main
+      className="space-y-6 p-6"
+      data-testid="issue-34-scroll"
+      aria-label="Issue 34 scroll reset"
+    >
+      <ScrollGrid testId="issue-34-scroll-enabled" scrollTopOnFilter />
+      <ScrollGrid testId="issue-34-scroll-disabled" scrollTopOnFilter={false} />
+    </main>
+  );
+}
+
+function MenuScenario(): React.ReactElement {
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 130, filterable: false },
+      { name: "name", header: "Name", width: 260, type: "string" },
+    ],
+    []
+  );
+  const filter = React.useMemo<TypeFilterValue>(
+    () => [
+      makeFilter({
+        name: "name",
+        operator: "contains",
+        value: "Ada",
+      }),
+    ],
+    []
+  );
+  const constrainTo = React.useCallback(() => document.body, []);
+  const renderMenu = React.useCallback(
+    (menuProps: Record<string, unknown>, context: Record<string, unknown>) => (
+      <div
+        role="menu"
+        data-testid="issue-34-custom-filter-menu"
+        data-position={String(
+          menuProps.position ??
+            (menuProps.style as { position?: string } | undefined)?.position ??
+            ""
+        )}
+        data-has-cell-props={String(Boolean(context.cellProps))}
+        data-has-grid={String(Boolean(context.grid))}
+        data-has-grid-props={String(Boolean(context.props))}
+        data-has-constrain-to={String(Boolean(menuProps.constrainTo))}
+        data-update-position-on-scroll={String(
+          menuProps.updatePositionOnScroll
+        )}
+        data-align-positions={JSON.stringify(menuProps.alignPositions ?? null)}
+      >
+        Custom filter menu
+      </div>
+    ),
+    []
+  );
+
+  return (
+    <main
+      className="space-y-6 p-6"
+      data-testid="issue-34-menu"
+      aria-label="Issue 34 filter context menu"
+    >
+      <GridShell testId="issue-34-standard-menu">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={[{ id: "menu-ada", name: "Ada" }]}
+          defaultFilterValue={filter}
+          enableColumnFilterContextMenu
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-custom-menu">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={[{ id: "custom-menu-ada", name: "Ada" }]}
+          defaultFilterValue={filter}
+          enableColumnFilterContextMenu
+          renderColumnFilterContextMenu={renderMenu}
+          columnFilterContextMenuAlignPositions={["tl-bl"]}
+          columnFilterContextMenuConstrainTo={constrainTo}
+          columnFilterContextMenuPosition="fixed"
+          updateMenuPositionOnScroll={false}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+function OperatorScenario(): React.ReactElement {
+  const stringColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 150, filterable: false },
+      { name: "value", header: "String value", width: 220, type: "string" },
+    ],
+    []
+  );
+  const numberColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 150, filterable: false },
+      { name: "value", header: "Number value", width: 220, type: "number" },
+    ],
+    []
+  );
+  const selectColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 150, filterable: false },
+      { name: "value", header: "Select value", width: 220, type: "select" },
+    ],
+    []
+  );
+  const dateColumns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 150, filterable: false },
+      { name: "value", header: "Date value", width: 220, type: "date" },
+    ],
+    []
+  );
+
+  return (
+    <main
+      className="space-y-6 p-6"
+      data-testid="issue-34-operators"
+      aria-label="Issue 34 operator semantics"
+    >
+      <GridShell testId="issue-34-string-falsy">
+        <ReactDataGrid
+          idProperty="id"
+          columns={stringColumns}
+          dataSource={[
+            { id: "string-number-zero", value: 0 },
+            { id: "string-text-zero", value: "0" },
+            { id: "string-false", value: false },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "value",
+              operator: "contains",
+              value: "0",
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-number-equality">
+        <ReactDataGrid
+          idProperty="id"
+          columns={numberColumns}
+          dataSource={[
+            { id: "number-native", value: 2 },
+            { id: "number-string", value: "2" },
+            { id: "number-other", value: 3 },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "value",
+              type: "number",
+              operator: "eq",
+              value: 2,
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-number-empty">
+        <ReactDataGrid
+          idProperty="id"
+          columns={numberColumns}
+          dataSource={[
+            { id: "number-empty-string", value: "" },
+            { id: "number-zero", value: 0 },
+            { id: "number-one", value: 1 },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "value",
+              type: "number",
+              operator: "eq",
+              value: "",
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-number-range">
+        <ReactDataGrid
+          idProperty="id"
+          columns={numberColumns}
+          dataSource={[
+            { id: "range-one", value: 1 },
+            { id: "range-two", value: 2 },
+            { id: "range-three", value: 3 },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "value",
+              type: "number",
+              operator: "inrange",
+              value: { start: 1, end: 2 },
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-select-list">
+        <ReactDataGrid
+          idProperty="id"
+          columns={selectColumns}
+          dataSource={[
+            { id: "select-a", value: "a" },
+            { id: "select-b", value: "b" },
+            { id: "select-c", value: "c" },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "value",
+              type: "select",
+              operator: "inlist",
+              value: ["a", "c"],
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+      <GridShell testId="issue-34-date-range">
+        <ReactDataGrid
+          idProperty="id"
+          columns={dateColumns}
+          dataSource={[
+            { id: "date-start", value: "2026-01-01" },
+            { id: "date-middle", value: "2026-01-15" },
+            { id: "date-outside", value: "2026-02-01" },
+          ]}
+          defaultFilterValue={[
+            makeFilter({
+              name: "value",
+              type: "date",
+              operator: "inrange",
+              value: {
+                start: "2026-01-01",
+                end: "2026-01-31",
+              },
+            }),
+          ]}
+          virtualized={false}
+          showColumnMenuTool={false}
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+type OperatorMatrixRow = {
+  id: string;
+  value: unknown;
+};
+
+function runOperatorCase(
+  rows: OperatorMatrixRow[],
+  type: string,
+  operator: string,
+  value: unknown
+): string[] {
+  return applyLocalFilter(
+    rows,
+    [
+      {
+        name: "value",
+        type,
+        operator,
+        value,
+      },
+    ],
+    {
+      columns: [
+        {
+          name: "value",
+          type,
+          dateFormat: "YYYY-MM-DD",
+        },
+      ],
+    }
+  ).map((row) => String(row.id));
+}
+
+function OperatorMatrixScenario(): React.ReactElement {
+  const matrix = React.useMemo(() => {
+    const stringRows: OperatorMatrixRow[] = [
+      { id: "empty", value: "" },
+      { id: "null", value: null },
+      { id: "number-zero", value: 0 },
+      { id: "text-zero", value: "0" },
+      { id: "false", value: false },
+      { id: "alpha", value: "Alpha" },
+      { id: "alphabet", value: "alphabet" },
+      { id: "beta", value: "Beta" },
+    ];
+    const numberRows: OperatorMatrixRow[] = [
+      { id: "null", value: null },
+      { id: "empty", value: "" },
+      { id: "zero", value: 0 },
+      { id: "one", value: 1 },
+      { id: "two", value: 2 },
+      { id: "text-two", value: "2" },
+      { id: "three", value: 3 },
+    ];
+    const booleanRows: OperatorMatrixRow[] = [
+      { id: "null", value: null },
+      { id: "false", value: false },
+      { id: "true", value: true },
+      { id: "zero", value: 0 },
+      { id: "one", value: 1 },
+    ];
+    const selectRows: OperatorMatrixRow[] = [
+      { id: "null", value: null },
+      { id: "empty", value: "" },
+      { id: "a", value: "a" },
+      { id: "b", value: "b" },
+      { id: "c", value: "c" },
+      { id: "zero", value: 0 },
+      { id: "false", value: false },
+    ];
+    const dateRows: OperatorMatrixRow[] = [
+      { id: "start", value: "2026-01-01" },
+      { id: "middle", value: "2026-01-15" },
+      { id: "end", value: "2026-01-31" },
+      { id: "outside", value: "2026-02-01" },
+    ];
+
+    return {
+      string: {
+        contains: runOperatorCase(stringRows, "string", "contains", "alp"),
+        notContains: runOperatorCase(
+          stringRows,
+          "string",
+          "notContains",
+          "alp"
+        ),
+        eq: runOperatorCase(stringRows, "string", "eq", "0"),
+        neq: runOperatorCase(stringRows, "string", "neq", "0"),
+        empty: runOperatorCase(stringRows, "string", "empty", ""),
+        notEmpty: runOperatorCase(stringRows, "string", "notEmpty", ""),
+        startsWith: runOperatorCase(stringRows, "string", "startsWith", "alp"),
+        endsWith: runOperatorCase(stringRows, "string", "endsWith", "a"),
+        falsyNumberFilter: runOperatorCase(stringRows, "string", "contains", 0),
+        falsyBooleanFilter: runOperatorCase(
+          stringRows,
+          "string",
+          "contains",
+          false
+        ),
+      },
+      number: {
+        gt: runOperatorCase(numberRows, "number", "gt", 1),
+        gte: runOperatorCase(numberRows, "number", "gte", 2),
+        lt: runOperatorCase(numberRows, "number", "lt", 2),
+        lte: runOperatorCase(numberRows, "number", "lte", 2),
+        eq: runOperatorCase(numberRows, "number", "eq", 2),
+        neq: runOperatorCase(numberRows, "number", "neq", 2),
+        inrange: runOperatorCase(numberRows, "number", "inrange", {
+          start: 1,
+          end: 2,
+        }),
+        notinrange: runOperatorCase(numberRows, "number", "notinrange", {
+          start: 1,
+          end: 2,
+        }),
+        emptyStringEq: runOperatorCase(numberRows, "number", "eq", ""),
+        nullEq: runOperatorCase(numberRows, "number", "eq", null),
+      },
+      bool: {
+        eq: runOperatorCase(booleanRows, "bool", "eq", true),
+        neq: runOperatorCase(booleanRows, "bool", "neq", true),
+        nullEq: runOperatorCase(booleanRows, "bool", "eq", null),
+      },
+      boolean: {
+        eq: runOperatorCase(booleanRows, "boolean", "eq", true),
+        neq: runOperatorCase(booleanRows, "boolean", "neq", true),
+        nullEq: runOperatorCase(booleanRows, "boolean", "eq", null),
+      },
+      select: {
+        inlist: runOperatorCase(selectRows, "select", "inlist", ["a", "c"]),
+        notinlist: runOperatorCase(selectRows, "select", "notinlist", [
+          "a",
+          "c",
+        ]),
+        eq: runOperatorCase(selectRows, "select", "eq", "a"),
+        neq: runOperatorCase(selectRows, "select", "neq", "a"),
+        emptyList: runOperatorCase(selectRows, "select", "inlist", []),
+        nullEq: runOperatorCase(selectRows, "select", "eq", null),
+        scalarList: runOperatorCase(selectRows, "select", "inlist", "ab"),
+      },
+      date: {
+        after: runOperatorCase(dateRows, "date", "after", "2026-01-15"),
+        afterOrOn: runOperatorCase(dateRows, "date", "afterOrOn", "2026-01-15"),
+        before: runOperatorCase(dateRows, "date", "before", "2026-01-15"),
+        beforeOrOn: runOperatorCase(
+          dateRows,
+          "date",
+          "beforeOrOn",
+          "2026-01-15"
+        ),
+        eq: runOperatorCase(dateRows, "date", "eq", "2026-01-15"),
+        neq: runOperatorCase(dateRows, "date", "neq", "2026-01-15"),
+        inrange: runOperatorCase(dateRows, "date", "inrange", {
+          start: "2026-01-01",
+          end: "2026-01-31",
+        }),
+        notinrange: runOperatorCase(dateRows, "date", "notinrange", {
+          start: "2026-01-01",
+          end: "2026-01-31",
+        }),
+        emptyEq: runOperatorCase(dateRows, "date", "eq", ""),
+      },
+    };
+  }, []);
+
+  return (
+    <main
+      className="space-y-4 p-6"
+      data-testid="issue-34-operator-matrix"
+      aria-label="Issue 34 complete operator matrix"
+    >
+      <output data-testid="issue-34-operator-matrix-output">
+        {JSON.stringify(matrix)}
+      </output>
+    </main>
+  );
+}
+
+function PerformanceScenario(): React.ReactElement {
+  const rowCount = 10_000;
+  const rows = React.useMemo(
+    () =>
+      Array.from({ length: rowCount }, (_, index) => ({
+        id: `filter-performance-${index}`,
+        token: `token-${index % 20}`,
+        value: index,
+      })),
+    []
+  );
+  const columns = React.useMemo<TypeColumns>(
+    () => [
+      { name: "id", header: "ID", width: 220, filterable: false },
+      { name: "token", header: "Token", width: 180, type: "string" },
+      { name: "value", header: "Value", width: 140, type: "number" },
+    ],
+    []
+  );
+  const apiRef = React.useRef<TypeComputedProps | null>(null);
+  const startedAtRef = React.useRef(0);
+  const dispatchDurationRef = React.useRef(0);
+  const runRef = React.useRef(0);
+  const [metrics, setMetrics] = React.useState<Record<string, unknown> | null>(
+    null
+  );
+
+  const recordSettledFilter = React.useCallback(() => {
+    if (!startedAtRef.current) return;
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        const scope = document.querySelector(
+          '[data-testid="issue-34-performance-grid"]'
+        );
+        const renderedRows = scope?.querySelectorAll('[data-slot="grid-row"]');
+        setMetrics({
+          run: runRef.current,
+          rowCount,
+          filteredCount: apiRef.current?.getCount() ?? null,
+          runtimeMode: import.meta.env.PROD ? "production" : "development",
+          dispatchDuration: dispatchDurationRef.current,
+          settledDuration: performance.now() - startedAtRef.current,
+          renderedRowCount: renderedRows?.length ?? 0,
+          firstRow: renderedRows?.[0]?.getAttribute("data-row-id") ?? null,
+        });
+        startedAtRef.current = 0;
+      });
+    });
+  }, []);
+
+  const runFilter = React.useCallback(() => {
+    const startedAt = performance.now();
+    runRef.current += 1;
+    startedAtRef.current = startedAt;
+    apiRef.current?.setFilterValue([
+      {
+        name: "token",
+        type: "string",
+        operator: "eq",
+        value: `token-${runRef.current % 5}`,
+      },
+    ]);
+    dispatchDurationRef.current = performance.now() - startedAt;
+  }, []);
+
+  return (
+    <main
+      className="space-y-4 p-6"
+      data-testid="issue-34-performance"
+      aria-label="Issue 34 filtering performance"
+    >
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          size="sm"
+          data-testid="issue-34-performance-run"
+          onClick={runFilter}
+        >
+          Benchmark filter
+        </Button>
+        <output data-testid="issue-34-performance-metrics">
+          {JSON.stringify(metrics)}
+        </output>
+      </div>
+      <GridShell testId="issue-34-performance-grid" height={420}>
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          defaultFilterValue={[
+            {
+              name: "token",
+              type: "string",
+              operator: "eq",
+              value: "",
+            },
+          ]}
+          rowHeight={36}
+          virtualized
+          showColumnMenuTool={false}
+          handle={(computedPropsRef) => {
+            apiRef.current = computedPropsRef.current;
+          }}
+          onFilterValueChange={recordSettledFilter}
+        />
+      </GridShell>
+    </main>
+  );
+}
+
+function readScenario():
+  | "projection"
+  | "descriptors"
+  | "editors"
+  | "booleans"
+  | "delay"
+  | "scroll"
+  | "menu"
+  | "operators"
+  | "operator-matrix"
+  | "performance" {
+  if (typeof window === "undefined") return "projection";
+  const scenario = new URLSearchParams(window.location.search).get("scenario");
+  if (
+    scenario === "descriptors" ||
+    scenario === "editors" ||
+    scenario === "booleans" ||
+    scenario === "delay" ||
+    scenario === "scroll" ||
+    scenario === "menu" ||
+    scenario === "operators" ||
+    scenario === "operator-matrix" ||
+    scenario === "performance"
+  ) {
+    return scenario;
+  }
+  return "projection";
+}
+
+export default function Issue34FilteringCompatPage(): React.ReactElement {
+  const scenario = readScenario();
+
+  if (scenario === "descriptors") return <DescriptorScenario />;
+  if (scenario === "editors") return <EditorsScenario />;
+  if (scenario === "booleans") return <BooleanScenario />;
+  if (scenario === "delay") return <DelayScenario />;
+  if (scenario === "scroll") return <ScrollScenario />;
+  if (scenario === "menu") return <MenuScenario />;
+  if (scenario === "operators") return <OperatorScenario />;
+  if (scenario === "operator-matrix") return <OperatorMatrixScenario />;
+  if (scenario === "performance") return <PerformanceScenario />;
+  return <ProjectionScenario />;
+}

--- a/examples/src/docs/docsContent.tsx
+++ b/examples/src/docs/docsContent.tsx
@@ -2136,14 +2136,14 @@ const columnSections: ReferenceSection[] = [
         type: "string",
         defaultValue: "-",
         description:
-          "Alternate local filter field. Filter descriptors can resolve the column through id, name, or filterName.",
+          "Alternate filter field. Local evaluation and remote data-source descriptors project through id/name to this alias.",
       },
       {
         name: "getFilterValue",
         type: "({ data, value }) => unknown",
         defaultValue: "-",
         description:
-          "Derives the local value tested by filter operators after filterName resolution.",
+          "Derives the local value tested by filter operators and is attached to projected remote filter descriptors.",
       },
       {
         name: "filterEditor",
@@ -2156,7 +2156,14 @@ const columnSections: ReferenceSection[] = [
         type: "object | ((columnContext, indexContext) => object)",
         defaultValue: "-",
         description:
-          "Object props, or a function called as ({ column, columnId }, { index: 0 }). They are resolved first; grid-owned filterValue, value, onChange, column, columnId, and disabled props take precedence so activation and state callbacks cannot be bypassed.",
+          "Static props are merged into the editor. Function values are passed through so range editors can resolve each input with the complete editor contract and { index, value } metadata.",
+      },
+      {
+        name: "filterDelay",
+        type: "boolean | number",
+        defaultValue: "250",
+        description:
+          "Per-column aggregate filter debounce in milliseconds. false or 0 commits immediately.",
       },
       {
         name: "filterCellPadding",
@@ -3758,15 +3765,17 @@ const inovuaCompatibilityRows: CompatibilityRow[] = [
         <code>defaultVisible=false</code> and <code>defaultHidden=true</code>{" "}
         seed grid-owned visibility. Local filtering resolves id/name/filterName
         aliases and invokes <code>{"getFilterValue({ data, value })"}</code>.
+        Remote arguments receive the same alias/type/getter projection and only
+        include visible rendered columns in <code>columnOrder</code>.
       </>
     ),
     requiredOutcome: (
       <>
-        Complete exact remote filter-descriptor projection before considering
-        the broader issue #34 contract closed.
+        Preserve local and remote projection, including inferred types,
+        descriptor getters, aliases, and visible rendered column order.
       </>
     ),
-    status: "known-gap",
+    status: "compatible",
   },
   {
     id: "imperative-placeholders",
@@ -4151,9 +4160,8 @@ const implementedSurfaceSections: ReferenceSection[] = [
             {
               name: "bool / boolean",
               type: "operators",
-              defaultValue: "seed eq or neq",
-              description:
-                "eq and neq. Current unseeded resolution falls back to contains, which this registry does not define, so initialize an eq/neq entry until that gap is corrected.",
+              defaultValue: "eq",
+              description: "eq and neq, with null as the empty value.",
             },
             {
               name: "number",
@@ -4189,11 +4197,10 @@ const implementedSurfaceSections: ReferenceSection[] = [
             no input editor.
           </li>
           <li>
-            Uncontrolled editor typing commits after 300ms; controlled changes
-            call onFilterValueChange immediately but render the supplied prop
-            until the parent updates it. Operator selection and clear are
-            immediate. Every edit requests skip 0; controlled pagination must
-            honor onSkipChange(0).
+            Editor typing commits after the column&apos;s filterDelay, or 250ms
+            by default; false and 0 commit immediately. Operator selection and
+            clear are immediate. Every edit requests skip 0; controlled
+            pagination must honor onSkipChange(0).
           </li>
           <li>
             <code>onColumnFilterValueChange</code> runs before the aggregate
@@ -4208,12 +4215,11 @@ const implementedSurfaceSections: ReferenceSection[] = [
             the descriptor&apos;s activation state; Clear All emits one
             aggregate update without per-column callbacks. Object/function{" "}
             <code>filterEditorProps</code> and custom editors are supported as
-            described in IColumn; resolved props are applied first and
-            grid-owned state, identity, callback, and disabled props win on
-            conflicts. Without a custom editor, only select +
-            filterEditorProps.options renders a select; other types use generic
-            text input. Use exported DateFilter, NumberFilter, or SelectFilter
-            explicitly when needed.
+            described in IColumn. Function-valued props remain available to the
+            editor, including per-input metadata for exported range editors.
+            Without a custom editor, only select + filterEditorProps.options
+            renders a select; other types use generic text input. Use exported
+            DateFilter, NumberFilter, or SelectFilter explicitly when needed.
           </li>
         </ul>
       </div>
@@ -4453,9 +4459,8 @@ const implementedSurfaceSections: ReferenceSection[] = [
         tone="warning"
       >
         <p>
-          Current partials include exact remote filterName projection, the
-          bool/boolean unseeded filter-operator mismatch, and broad imperative
-          placeholder methods. See the{" "}
+          Current partials are broad imperative placeholder methods and the
+          lifecycle details called out in the ledger. See the{" "}
           <DocsRouteLink
             group="migration"
             slug="inovua-status"
@@ -5208,10 +5213,9 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
         body: (
           <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
             <li>
-              Uncontrolled text/editor changes update the draft immediately and
-              commit after 300ms. Controlled changes call onFilterValueChange
-              immediately, while the rendered value stays on the supplied prop
-              until the parent updates it.
+              Text/editor changes update the draft immediately and commit after
+              the column&apos;s filterDelay, or 250ms by default. false and 0
+              commit immediately.
             </li>
             <li>
               Operator changes and clear actions commit immediately. Every edit
@@ -5226,10 +5230,10 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
             <li>
               empty and notEmpty run without an input while their descriptor is
               enabled. Custom filterEditor components receive
-              descriptor/value/change, column identity, disabled state, and
-              resolved filterEditorProps; those user props are applied first,
-              then grid-owned state and lifecycle props take precedence. Without
-              one, only select + options gets a select UI; use exported
+              descriptor/value/change, column identity, disabled state, theme,
+              localization, cell context, and the original filterEditorProps.
+              Function-valued editor props can resolve individual range inputs.
+              Without one, only select + options gets a select UI; use exported
               DateFilter/NumberFilter/SelectFilter explicitly.
             </li>
           </ul>
@@ -5273,8 +5277,8 @@ const [sortInfo, setSortInfo] = useState<TypeSortInfo>(null);
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
               The complete operator registry, default-operator behavior,
-              custom-registry merge rules, and the current bool/boolean default
-              caveat are catalogued in the{" "}
+              custom-registry merge rules, and bool/boolean defaults are
+              catalogued in the{" "}
               <DocsRouteLink
                 group="reference"
                 slug="implemented-surface"

--- a/examples/src/router.tsx
+++ b/examples/src/router.tsx
@@ -24,6 +24,7 @@ import InovuaPendingParityCompatPage from "./InovuaPendingParityCompatPage";
 import Issue48CompatPage from "./Issue48CompatPage";
 import Issue32DataSourceCompatPage from "./Issue32DataSourceCompatPage";
 import Issue33SortingCompatPage from "./Issue33SortingCompatPage";
+import Issue34FilteringCompatPage from "./Issue34FilteringCompatPage";
 import MemorySafetyCompatPage from "./MemorySafetyCompatPage";
 import MobileTransformExample from "./MobileTransformExample";
 import SearchDataSourceCompatPage from "./SearchDataSourceCompatPage";
@@ -341,6 +342,12 @@ const compatIssue33SortingRoute = createRoute({
   component: Issue33SortingCompatPage,
 });
 
+const compatIssue34FilteringRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/issue-34-filtering",
+  component: Issue34FilteringCompatPage,
+});
+
 const compatGitHubIssues33To48Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "compat/github-issues-33-48",
@@ -388,6 +395,7 @@ const routeTree = rootRoute.addChildren([
   compatGitHubIssues31And32Route,
   compatIssue32DataSourceRoute,
   compatIssue33SortingRoute,
+  compatIssue34FilteringRoute,
   compatGitHubIssues33To48Route,
   compatInovuaParityRoute,
   compatInovuaPendingParityRoute,

--- a/src/filters/editors/DateFilter.tsx
+++ b/src/filters/editors/DateFilter.tsx
@@ -65,6 +65,12 @@ export type DateFilterProps = {
   };
   value?: any;
   onChange?: (value: any) => void;
+  filterEditorProps?:
+    | Record<string, unknown>
+    | ((
+        editorProps: DateFilterProps,
+        meta: { index: number; value: unknown }
+      ) => Record<string, unknown> | undefined);
 
   /**
    * Inovua commonly passes placeholder via filterEditorProps.
@@ -95,6 +101,7 @@ export default function DateFilter(props: DateFilterProps): React.ReactElement {
     disabled,
     className,
     style,
+    filterEditorProps,
   } = props;
 
   const operator = filterValue?.operator;
@@ -105,11 +112,34 @@ export default function DateFilter(props: DateFilterProps): React.ReactElement {
     type === "time" ? "datetime-local" : "date";
 
   const raw = valueProp !== undefined ? valueProp : filterValue?.value;
+  const resolveInputProps = (value: unknown, index: number) => {
+    if (typeof filterEditorProps === "function") {
+      return filterEditorProps({ ...props, value }, { index, value }) ?? {};
+    }
+    return filterEditorProps ?? {};
+  };
 
   if (isRangeOperator(operator)) {
-    const arr = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
-    const start = toDate(arr[0]);
-    const end = toDate(arr[1]);
+    const startRaw = Array.isArray(raw)
+      ? raw[0]
+      : raw && typeof raw === "object"
+        ? raw.start
+        : raw;
+    const endRaw = Array.isArray(raw)
+      ? raw[1]
+      : raw && typeof raw === "object"
+        ? raw.end
+        : undefined;
+    const start = toDate(startRaw);
+    const end = toDate(endRaw);
+    const startInputProps = resolveInputProps(startRaw, 0);
+    const endInputProps = resolveInputProps(endRaw, 1);
+    const makeRangeValue = (nextStart: Date | null, nextEnd: Date | null) => {
+      if (!nextStart && !nextEnd) return null;
+      return Array.isArray(raw)
+        ? [nextStart, nextEnd]
+        : { start: nextStart, end: nextEnd };
+    };
 
     const startStr =
       inputMode === "datetime-local"
@@ -123,27 +153,31 @@ export default function DateFilter(props: DateFilterProps): React.ReactElement {
     return (
       <div className={cn("flex items-center gap-1", className)} style={style}>
         <Input
+          {...startInputProps}
           type={inputMode}
           value={startStr}
-          disabled={disabled}
-          className="h-8 w-full"
-          placeholder={startPlaceholder ?? placeholder ?? ""}
+          disabled={disabled || Boolean(startInputProps.disabled)}
+          className={cn("h-8 w-full", startInputProps.className as string)}
+          placeholder={String(
+            startInputProps.placeholder ?? startPlaceholder ?? placeholder ?? ""
+          )}
           onChange={(e) => {
             const nextStart = parseInputValue(e.target.value, inputMode);
-            const next: [Date | null, Date | null] = [nextStart, end];
-            onChange?.(next[0] || next[1] ? next : null);
+            onChange?.(makeRangeValue(nextStart, end));
           }}
         />
         <Input
+          {...endInputProps}
           type={inputMode}
           value={endStr}
-          disabled={disabled}
-          className="h-8 w-full"
-          placeholder={endPlaceholder ?? placeholder ?? ""}
+          disabled={disabled || Boolean(endInputProps.disabled)}
+          className={cn("h-8 w-full", endInputProps.className as string)}
+          placeholder={String(
+            endInputProps.placeholder ?? endPlaceholder ?? placeholder ?? ""
+          )}
           onChange={(e) => {
             const nextEnd = parseInputValue(e.target.value, inputMode);
-            const next: [Date | null, Date | null] = [start, nextEnd];
-            onChange?.(next[0] || next[1] ? next : null);
+            onChange?.(makeRangeValue(start, nextEnd));
           }}
         />
       </div>
@@ -156,15 +190,17 @@ export default function DateFilter(props: DateFilterProps): React.ReactElement {
     inputMode === "datetime-local"
       ? toInputDateTimeLocalValue(d)
       : toInputDateValue(d);
+  const inputProps = resolveInputProps(raw, 0);
 
   return (
     <Input
+      {...inputProps}
       type={inputMode}
       value={str}
-      disabled={disabled}
-      className={cn("h-8 w-full", className)}
+      disabled={disabled || Boolean(inputProps.disabled)}
+      className={cn("h-8 w-full", inputProps.className as string, className)}
       style={style}
-      placeholder={placeholder ?? ""}
+      placeholder={String(inputProps.placeholder ?? placeholder ?? "")}
       onChange={(e) => {
         const next = parseInputValue(e.target.value, inputMode);
         onChange?.(next);

--- a/src/filters/editors/NumberFilter.tsx
+++ b/src/filters/editors/NumberFilter.tsx
@@ -24,6 +24,12 @@ export type NumberFilterProps = {
   };
   value?: any;
   onChange?: (value: any) => void;
+  filterEditorProps?:
+    | Record<string, unknown>
+    | ((
+        editorProps: NumberFilterProps,
+        meta: { index: number; value: unknown }
+      ) => Record<string, unknown> | undefined);
 
   placeholder?: string;
   startPlaceholder?: string;
@@ -57,54 +63,83 @@ export default function NumberFilter(
     disabled,
     className,
     style,
+    filterEditorProps,
   } = props;
 
   const operator = filterValue?.operator;
   const raw = valueProp !== undefined ? valueProp : filterValue?.value;
+  const resolveInputProps = (value: unknown, index: number) => {
+    if (typeof filterEditorProps === "function") {
+      return filterEditorProps({ ...props, value }, { index, value }) ?? {};
+    }
+    return filterEditorProps ?? {};
+  };
 
   if (isRangeOperator(operator)) {
-    const arr = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
-    const start = toNumber(arr[0]);
-    const end = toNumber(arr[1]);
+    const startRaw = Array.isArray(raw)
+      ? raw[0]
+      : raw && typeof raw === "object"
+        ? raw.start
+        : raw;
+    const endRaw = Array.isArray(raw)
+      ? raw[1]
+      : raw && typeof raw === "object"
+        ? raw.end
+        : undefined;
+    const start = toNumber(startRaw);
+    const end = toNumber(endRaw);
+    const startInputProps = resolveInputProps(start, 0);
+    const endInputProps = resolveInputProps(end, 1);
+    const makeRangeValue = (
+      nextStart: number | null,
+      nextEnd: number | null
+    ) => {
+      if (nextStart == null && nextEnd == null) return null;
+      return Array.isArray(raw)
+        ? [nextStart, nextEnd]
+        : { start: nextStart, end: nextEnd };
+    };
 
     return (
       <div className={cn("flex items-center gap-1", className)} style={style}>
         <Input
+          {...startInputProps}
           type="number"
           value={start == null ? "" : String(start)}
-          disabled={disabled}
-          className="h-8 w-full"
-          placeholder={startPlaceholder ?? placeholder ?? ""}
-          step={step}
-          min={min}
-          max={max}
+          disabled={disabled || Boolean(startInputProps.disabled)}
+          className={cn("h-8 w-full", startInputProps.className as string)}
+          placeholder={String(
+            startInputProps.placeholder ?? startPlaceholder ?? placeholder ?? ""
+          )}
+          step={(startInputProps.step as number | undefined) ?? step}
+          min={(startInputProps.min as number | undefined) ?? min}
+          max={(startInputProps.max as number | undefined) ?? max}
           onChange={(e) => {
             const nextStart =
               e.target.value === "" ? null : Number(e.target.value);
-            const next: [number | null, number | null] = [
-              Number.isFinite(nextStart) ? nextStart : null,
-              end,
-            ];
-            onChange?.(next[0] != null || next[1] != null ? next : null);
+            onChange?.(
+              makeRangeValue(Number.isFinite(nextStart) ? nextStart : null, end)
+            );
           }}
         />
         <Input
+          {...endInputProps}
           type="number"
           value={end == null ? "" : String(end)}
-          disabled={disabled}
-          className="h-8 w-full"
-          placeholder={endPlaceholder ?? placeholder ?? ""}
-          step={step}
-          min={min}
-          max={max}
+          disabled={disabled || Boolean(endInputProps.disabled)}
+          className={cn("h-8 w-full", endInputProps.className as string)}
+          placeholder={String(
+            endInputProps.placeholder ?? endPlaceholder ?? placeholder ?? ""
+          )}
+          step={(endInputProps.step as number | undefined) ?? step}
+          min={(endInputProps.min as number | undefined) ?? min}
+          max={(endInputProps.max as number | undefined) ?? max}
           onChange={(e) => {
             const nextEnd =
               e.target.value === "" ? null : Number(e.target.value);
-            const next: [number | null, number | null] = [
-              start,
-              Number.isFinite(nextEnd) ? nextEnd : null,
-            ];
-            onChange?.(next[0] != null || next[1] != null ? next : null);
+            onChange?.(
+              makeRangeValue(start, Number.isFinite(nextEnd) ? nextEnd : null)
+            );
           }}
         />
       </div>
@@ -112,18 +147,20 @@ export default function NumberFilter(
   }
 
   const n = toNumber(raw);
+  const inputProps = resolveInputProps(n, 0);
 
   return (
     <Input
+      {...inputProps}
       type="number"
       value={n == null ? "" : String(n)}
-      disabled={disabled}
-      className={cn("h-8 w-full", className)}
+      disabled={disabled || Boolean(inputProps.disabled)}
+      className={cn("h-8 w-full", inputProps.className as string, className)}
       style={style}
-      placeholder={placeholder ?? ""}
-      step={step}
-      min={min}
-      max={max}
+      placeholder={String(inputProps.placeholder ?? placeholder ?? "")}
+      step={(inputProps.step as number | undefined) ?? step}
+      min={(inputProps.min as number | undefined) ?? min}
+      max={(inputProps.max as number | undefined) ?? max}
       onChange={(e) => {
         const next = e.target.value === "" ? null : Number(e.target.value);
         onChange?.(Number.isFinite(next) ? next : null);

--- a/src/filters/editors/SelectFilter.tsx
+++ b/src/filters/editors/SelectFilter.tsx
@@ -78,6 +78,12 @@ export type SelectFilterProps = {
   };
   value?: any;
   onChange?: (value: any) => void;
+  filterEditorProps?:
+    | Record<string, unknown>
+    | ((
+        editorProps: SelectFilterProps,
+        meta: { index: number; value: unknown }
+      ) => Record<string, unknown> | undefined);
 
   /**
    * Inovua uses `dataSource`.
@@ -104,6 +110,17 @@ export type SelectFilterProps = {
 export default function SelectFilter(
   props: SelectFilterProps
 ): React.ReactElement {
+  const resolvedFilterEditorProps =
+    typeof props.filterEditorProps === "function"
+      ? (props.filterEditorProps(
+          { ...props, value: props.value ?? props.filterValue?.value },
+          { index: 0, value: props.value ?? props.filterValue?.value }
+        ) ?? {})
+      : (props.filterEditorProps ?? {});
+  const mergedProps = {
+    ...resolvedFilterEditorProps,
+    ...props,
+  };
   const {
     filterValue,
     value: valueProp,
@@ -115,7 +132,7 @@ export default function SelectFilter(
     disabled,
     className,
     style,
-  } = props;
+  } = mergedProps;
 
   const current = valueProp !== undefined ? valueProp : filterValue?.value;
   const operator = filterValue?.operator;

--- a/src/filters/utils.ts
+++ b/src/filters/utils.ts
@@ -14,9 +14,8 @@ function isRecord(v: unknown): v is AnyRecord {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-function toStringSafe(v: unknown): string {
-  if (v == null) return "";
-  return String(v);
+function toInovuaString(v: unknown): string {
+  return String(v || "");
 }
 
 function tokenizeContainsOr(q: string): string[] {
@@ -24,12 +23,6 @@ function tokenizeContainsOr(q: string): string[] {
     .split(/[\s,;]+/g)
     .map((t) => t.trim())
     .filter(Boolean);
-}
-
-function toNumberSafe(v: unknown): number {
-  if (typeof v === "number") return v;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : Number.NaN;
 }
 
 function getRangeParts(filterValue: unknown): { start: unknown; end: unknown } {
@@ -44,27 +37,6 @@ function getRangeParts(filterValue: unknown): { start: unknown; end: unknown } {
   }
 
   return { start: undefined, end: undefined };
-}
-
-/**
- * Treat "range" objects/arrays as empty only when BOTH endpoints are empty.
- */
-function isEmptyLike(v: unknown): boolean {
-  if (v == null) return true;
-
-  if (typeof v === "string") return v.trim().length === 0;
-
-  if (Array.isArray(v)) {
-    if (v.length === 0) return true;
-    if (v.length === 2) return isEmptyLike(v[0]) && isEmptyLike(v[1]);
-    return false;
-  }
-
-  if (isRecord(v) && ("start" in v || "end" in v)) {
-    return isEmptyLike((v as any).start) && isEmptyLike((v as any).end);
-  }
-
-  return false;
 }
 
 /** Optional moment support (mirrors Inovua behavior, but without hard dependency). */
@@ -129,16 +101,16 @@ export const DEFAULT_FILTER_TYPES: TypeFilterTypes = {
       op({
         name: "contains",
         fn: ({ value, filterValue }) => {
-          const v = toStringSafe(value).toLowerCase();
-          const q = toStringSafe(filterValue).toLowerCase();
+          const v = toInovuaString(value).toLowerCase();
+          const q = toInovuaString(filterValue).toLowerCase();
           return !q ? true : v.includes(q);
         },
       }),
       op({
         name: "notContains",
         fn: ({ value, filterValue }) => {
-          const v = toStringSafe(value).toLowerCase();
-          const q = toStringSafe(filterValue).toLowerCase();
+          const v = toInovuaString(value).toLowerCase();
+          const q = toInovuaString(filterValue).toLowerCase();
           return !q ? true : !v.includes(q);
         },
       }),
@@ -146,8 +118,8 @@ export const DEFAULT_FILTER_TYPES: TypeFilterTypes = {
         // project-specific (used in your samples)
         name: "containsOr",
         fn: ({ value, filterValue }) => {
-          const v = toStringSafe(value).toLowerCase();
-          const q = toStringSafe(filterValue).toLowerCase();
+          const v = toInovuaString(value).toLowerCase();
+          const q = toInovuaString(filterValue).toLowerCase();
           const tokens = tokenizeContainsOr(q);
           if (tokens.length === 0) return true;
           return tokens.some((t) => v.includes(t));
@@ -156,29 +128,29 @@ export const DEFAULT_FILTER_TYPES: TypeFilterTypes = {
       op({
         name: "eq",
         fn: ({ value, filterValue }) => {
-          const v = toStringSafe(value).toLowerCase();
-          const q = toStringSafe(filterValue).toLowerCase();
+          const v = toInovuaString(value).toLowerCase();
+          const q = toInovuaString(filterValue).toLowerCase();
           return !q ? true : v === q;
         },
       }),
       op({
         name: "neq",
         fn: ({ value, filterValue }) => {
-          const v = toStringSafe(value).toLowerCase();
-          const q = toStringSafe(filterValue).toLowerCase();
+          const v = toInovuaString(value).toLowerCase();
+          const q = toInovuaString(filterValue).toLowerCase();
           return !q ? true : v !== q;
         },
       }),
       op({
         name: "empty",
-        fn: ({ value }) => toStringSafe(value) === "",
+        fn: ({ value }) => value === "",
         filterOnEmptyValue: true,
         valueOnOperatorSelect: "",
         disableFilterEditor: true,
       }),
       op({
         name: "notEmpty",
-        fn: ({ value }) => toStringSafe(value) !== "",
+        fn: ({ value }) => value !== "",
         filterOnEmptyValue: true,
         valueOnOperatorSelect: "",
         disableFilterEditor: true,
@@ -186,16 +158,16 @@ export const DEFAULT_FILTER_TYPES: TypeFilterTypes = {
       op({
         name: "startsWith",
         fn: ({ value, filterValue }) => {
-          const v = toStringSafe(value).toLowerCase();
-          const q = toStringSafe(filterValue).toLowerCase();
+          const v = toInovuaString(value).toLowerCase();
+          const q = toInovuaString(filterValue).toLowerCase();
           return !q ? true : v.startsWith(q);
         },
       }),
       op({
         name: "endsWith",
         fn: ({ value, filterValue }) => {
-          const v = toStringSafe(value).toLowerCase();
-          const q = toStringSafe(filterValue).toLowerCase();
+          const v = toInovuaString(value).toLowerCase();
+          const q = toInovuaString(filterValue).toLowerCase();
           return !q ? true : v.endsWith(q);
         },
       }),
@@ -210,18 +182,28 @@ export const DEFAULT_FILTER_TYPES: TypeFilterTypes = {
         name: "inlist",
         fn: ({ value, filterValue }) => {
           if (filterValue == null) return true;
-          const list = Array.isArray(filterValue) ? filterValue : [filterValue];
+          const list = filterValue as {
+            length?: number;
+            indexOf?: (item: unknown) => number;
+          };
           if (!list.length) return true;
-          return list.some((x) => x === value);
+          return typeof list.indexOf === "function"
+            ? list.indexOf(value) !== -1
+            : true;
         },
       }),
       op({
         name: "notinlist",
         fn: ({ value, filterValue }) => {
           if (filterValue == null) return true;
-          const list = Array.isArray(filterValue) ? filterValue : [filterValue];
+          const list = filterValue as {
+            length?: number;
+            indexOf?: (item: unknown) => number;
+          };
           if (!list.length) return true;
-          return !list.some((x) => x === value);
+          return typeof list.indexOf === "function"
+            ? list.indexOf(value) === -1
+            : true;
         },
       }),
       op({
@@ -279,74 +261,57 @@ export const DEFAULT_FILTER_TYPES: TypeFilterTypes = {
     operators: [
       op({
         name: "gt",
-        fn: ({ value, filterValue }) => {
-          const fv = toNumberSafe(filterValue);
-          if (!Number.isFinite(fv)) return true;
-          const v = toNumberSafe(value);
-          return Number.isFinite(v) ? v > fv : false;
-        },
+        fn: ({ value, filterValue }) =>
+          filterValue != null
+            ? (value as number) > (filterValue as number)
+            : true,
       }),
       op({
         name: "gte",
-        fn: ({ value, filterValue }) => {
-          const fv = toNumberSafe(filterValue);
-          if (!Number.isFinite(fv)) return true;
-          const v = toNumberSafe(value);
-          return Number.isFinite(v) ? v >= fv : false;
-        },
+        fn: ({ value, filterValue }) =>
+          filterValue != null
+            ? (value as number) >= (filterValue as number)
+            : true,
       }),
       op({
         name: "lt",
-        fn: ({ value, filterValue }) => {
-          const fv = toNumberSafe(filterValue);
-          if (!Number.isFinite(fv)) return true;
-          const v = toNumberSafe(value);
-          return Number.isFinite(v) ? v < fv : false;
-        },
+        fn: ({ value, filterValue }) =>
+          filterValue != null
+            ? (value as number) < (filterValue as number)
+            : true,
       }),
       op({
         name: "lte",
-        fn: ({ value, filterValue }) => {
-          const fv = toNumberSafe(filterValue);
-          if (!Number.isFinite(fv)) return true;
-          const v = toNumberSafe(value);
-          return Number.isFinite(v) ? v <= fv : false;
-        },
+        fn: ({ value, filterValue }) =>
+          filterValue != null
+            ? (value as number) <= (filterValue as number)
+            : true,
       }),
       op({
         name: "eq",
-        fn: ({ value, filterValue }) => {
-          const fv = toNumberSafe(filterValue);
-          if (!Number.isFinite(fv)) return true;
-          const v = toNumberSafe(value);
-          return Number.isFinite(v) ? v === fv : false;
-        },
+        fn: ({ value, filterValue, emptyValue }) =>
+          filterValue !== emptyValue ? value === filterValue : true,
       }),
       op({
         name: "neq",
-        fn: ({ value, filterValue }) => {
-          const fv = toNumberSafe(filterValue);
-          if (!Number.isFinite(fv)) return true;
-          const v = toNumberSafe(value);
-          return Number.isFinite(v) ? v !== fv : false;
-        },
+        fn: ({ value, filterValue, emptyValue }) =>
+          filterValue !== emptyValue ? value !== filterValue : true,
       }),
       op({
         name: "inrange",
         fn: ({ value, filterValue }) => {
           const { start, end } = getRangeParts(filterValue);
-          const s = toNumberSafe(start);
-          const e = toNumberSafe(end);
+          const hasStart = start != null && start !== "";
+          const hasEnd = end != null && end !== "";
 
-          const v = toNumberSafe(value);
-          if (!Number.isFinite(v)) return false;
-
-          const hasS = Number.isFinite(s);
-          const hasE = Number.isFinite(e);
-
-          if (hasS && hasE) return v >= s && v <= e;
-          if (hasS) return v >= s;
-          if (hasE) return v <= e;
+          if (hasStart && hasEnd) {
+            return (
+              (value as number) >= (start as number) &&
+              (value as number) <= (end as number)
+            );
+          }
+          if (hasStart) return (value as number) >= (start as number);
+          if (hasEnd) return (value as number) <= (end as number);
           return true;
         },
       }),
@@ -354,18 +319,17 @@ export const DEFAULT_FILTER_TYPES: TypeFilterTypes = {
         name: "notinrange",
         fn: ({ value, filterValue }) => {
           const { start, end } = getRangeParts(filterValue);
-          const s = toNumberSafe(start);
-          const e = toNumberSafe(end);
+          const hasStart = start != null && start !== "";
+          const hasEnd = end != null && end !== "";
 
-          const v = toNumberSafe(value);
-          if (!Number.isFinite(v)) return false;
-
-          const hasS = Number.isFinite(s);
-          const hasE = Number.isFinite(e);
-
-          if (hasS && hasE) return v < s || v > e;
-          if (hasS) return v < s;
-          if (hasE) return v > e;
+          if (hasStart && hasEnd) {
+            return (
+              (value as number) < (start as number) ||
+              (value as number) > (end as number)
+            );
+          }
+          if (hasStart) return (value as number) < (start as number);
+          if (hasEnd) return (value as number) > (end as number);
           return true;
         },
       }),
@@ -565,16 +529,18 @@ function isRunnableFilterEntry(
 ): boolean {
   const typeDef = allTypes[filter.type] ?? allTypes.string!;
   const opDef = getOperatorDef(typeDef, filter.operator);
-  const canRunWithoutValue =
-    Boolean(opDef?.filterOnEmptyValue) || Boolean(opDef?.disableFilterEditor);
-  const active =
-    filter.active !== undefined
-      ? filter.active
-      : canRunWithoutValue
-        ? true
-        : !isEmptyLike(filter.value);
+  if (filter.active === false) return false;
+  if (!opDef && typeof filter.fn !== "function") return false;
 
-  return active && (canRunWithoutValue || !isEmptyLike(filter.value));
+  const emptyValue =
+    filter.emptyValue !== undefined ? filter.emptyValue : typeDef.emptyValue;
+  const isEmptyValue = filter.value === emptyValue;
+
+  return (
+    !isEmptyValue ||
+    Boolean(opDef?.filterOnEmptyValue) ||
+    Boolean(opDef?.disableFilterEditor)
+  );
 }
 
 export function hasActiveLocalFilter(
@@ -699,6 +665,58 @@ export function clearAllFilters(
 }
 
 /**
+ * Projects public filter descriptors through their columns before local
+ * evaluation or a remote dataSource call.
+ *
+ * This mirrors Inovua's `getFilterValueForColumns`: the descriptor keeps its
+ * identity and operator/value state while inheriting the column's filter type,
+ * alias and value getter.
+ */
+export function resolveFilterValueForColumns(
+  filterValue: TypeFilterValue,
+  columns: TypeColumn[] = []
+): TypeFilterValue {
+  if (!filterValue?.length) return filterValue ?? null;
+
+  const columnsMap = new Map<string, TypeColumn>();
+  for (const column of columns) {
+    const id = getColumnId(column);
+    columnsMap.set(id, column);
+    if (typeof column.name === "string") columnsMap.set(column.name, column);
+  }
+
+  return filterValue.map((filter) => {
+    const column = columnsMap.get(filter.name);
+    const next: TypeSingleFilterValue = { ...filter };
+    const columnType =
+      typeof column?.filterType === "string"
+        ? column.filterType
+        : typeof column?.type === "string"
+          ? column.type
+          : undefined;
+
+    if (!next.type && columnType) next.type = columnType;
+    if (!next.operator) {
+      if (next.type === "number") next.operator = "gte";
+      else if (next.type === "select") next.operator = "eq";
+      else if (next.type === "bool" || next.type === "boolean")
+        next.operator = "eq";
+      else if (next.type === "date" || next.type === "time")
+        next.operator = "afterOrOn";
+      else next.operator = "contains";
+    }
+    if (typeof column?.getFilterValue === "function") {
+      next.getFilterValue = column.getFilterValue;
+    }
+    if (typeof column?.filterName === "string") {
+      next.name = column.filterName;
+    }
+
+    return next;
+  });
+}
+
+/**
  * Local filter (array dataSource).
  * Uses filterTypes + columnsMap so date operators can use column.dateFormat.
  */
@@ -710,6 +728,10 @@ export function applyLocalFilter(
   if (!filterValue || filterValue.length === 0) return data;
 
   const allTypes = { ...DEFAULT_FILTER_TYPES, ...(opts?.filterTypes ?? {}) };
+  const projectedFilterValue = resolveFilterValueForColumns(
+    filterValue,
+    opts?.columns
+  );
 
   const columnsMap: Record<string, TypeColumn> = {};
   for (const c of opts?.columns ?? []) {
@@ -720,7 +742,7 @@ export function applyLocalFilter(
   }
 
   return data.filter((row) => {
-    return filterValue.every((f) => {
+    return (projectedFilterValue ?? []).every((f) => {
       const typeDef = allTypes[f.type] ?? allTypes.string!;
       const opDef = getOperatorDef(typeDef, f.operator);
 
@@ -731,22 +753,26 @@ export function applyLocalFilter(
         typeof column?.filterName === "string" ? column.filterName : f.name;
       const rawValue = (row as any)?.[resolvedName];
       const raw =
-        typeof column?.getFilterValue === "function"
-          ? column.getFilterValue({ data: row, value: rawValue })
-          : rawValue;
+        typeof f.getFilterValue === "function"
+          ? f.getFilterValue({ data: row, value: rawValue })
+          : typeof column?.getFilterValue === "function"
+            ? column.getFilterValue({ data: row, value: rawValue })
+            : rawValue;
 
       const fn =
-        opDef?.fn ??
+        (typeof f.fn === "function" ? f.fn : opDef?.fn) ??
         allTypes.string!.operators.find((o) => o.name === "contains")!.fn;
 
-      return fn({
-        value: raw,
-        filterValue: f.value,
-        emptyValue: f.emptyValue ?? typeDef.emptyValue,
-        data: row,
-        _data: row,
-        column,
-      });
+      return (
+        fn({
+          value: raw,
+          filterValue: f.value,
+          emptyValue: f.emptyValue ?? typeDef.emptyValue,
+          data: row,
+          _data: row,
+          column,
+        }) === true
+      );
     });
   });
 }

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -63,6 +63,7 @@ import {
   hasActiveLocalFilter,
   isFilterEntryEmptyValue,
   normalizeFilterValue,
+  resolveFilterValueForColumns,
   upsertFilterEntry,
 } from "../filters/utils";
 import {
@@ -138,7 +139,12 @@ type ReactDataGridDefaultPropName =
   | "showColumnMenuTool"
   | "sortable"
   | "sortFunctions"
+  | "scrollTopOnFilter"
   | "scrollTopOnSort"
+  | "columnFilterContextMenuAlignPositions"
+  | "columnFilterContextMenuConstrainTo"
+  | "columnFilterContextMenuPosition"
+  | "updateMenuPositionOnScroll"
   | "rowHeight"
   | "minRowHeight"
   | "defaultShowZebraRows"
@@ -178,7 +184,12 @@ const REACT_DATA_GRID_DEFAULT_PROPS: ReactDataGridDefaultProps = {
   showColumnMenuTool: true,
   sortable: true,
   sortFunctions: DEFAULT_SORT_FUNCTIONS,
+  scrollTopOnFilter: true,
   scrollTopOnSort: true,
+  columnFilterContextMenuAlignPositions: ["tl-bl", "tr-br", "bl-tl", "br-tr"],
+  columnFilterContextMenuConstrainTo: true,
+  columnFilterContextMenuPosition: "absolute",
+  updateMenuPositionOnScroll: true,
   rowHeight: 40,
   minRowHeight: 20,
   defaultShowZebraRows: true,
@@ -588,6 +599,7 @@ function resolveDefaultFilterOperator(
   if (entry?.operator) return entry.operator;
   if (filterType === "number") return "gte";
   if (filterType === "select") return "eq";
+  if (filterType === "bool" || filterType === "boolean") return "eq";
   if (filterType === "date" || filterType === "time") return "afterOrOn";
   return "contains";
 }
@@ -724,8 +736,14 @@ function ReactDataGrid(props: TypeDataGridProps) {
     sortFunctions = REACT_DATA_GRID_DEFAULT_PROPS.sortFunctions,
     renderSortTool,
     scrollTopOnSort = REACT_DATA_GRID_DEFAULT_PROPS.scrollTopOnSort,
+    scrollTopOnFilter = REACT_DATA_GRID_DEFAULT_PROPS.scrollTopOnFilter,
 
     enableColumnFilterContextMenu = REACT_DATA_GRID_DEFAULT_PROPS.enableColumnFilterContextMenu,
+    renderColumnFilterContextMenu,
+    columnFilterContextMenuAlignPositions = REACT_DATA_GRID_DEFAULT_PROPS.columnFilterContextMenuAlignPositions,
+    columnFilterContextMenuConstrainTo = REACT_DATA_GRID_DEFAULT_PROPS.columnFilterContextMenuConstrainTo,
+    columnFilterContextMenuPosition = REACT_DATA_GRID_DEFAULT_PROPS.columnFilterContextMenuPosition,
+    updateMenuPositionOnScroll = REACT_DATA_GRID_DEFAULT_PROPS.updateMenuPositionOnScroll,
 
     enableColumnAutosize = REACT_DATA_GRID_DEFAULT_PROPS.enableColumnAutosize,
     skipHeaderOnAutoSize = REACT_DATA_GRID_DEFAULT_PROPS.skipHeaderOnAutoSize,
@@ -1393,20 +1411,26 @@ function ReactDataGrid(props: TypeDataGridProps) {
     [loadingStore]
   );
 
-  const computedFilterForFetch = filterValue;
-  const computedSortForFetch = sortInfo;
-
   const columnsForDs = React.useMemo(() => {
     return checkboxEnabled
       ? orderedColumns.filter((c) => getColumnId(c) !== checkboxColId)
       : orderedColumns;
   }, [checkboxColId, checkboxEnabled, orderedColumns]);
+  const computedFilterForFetch = React.useMemo(
+    () => resolveFilterValueForColumns(filterValue, columnsForDs),
+    [columnsForDs, filterValue]
+  );
+  const computedSortForFetch = sortInfo;
 
   const columnOrderForDs = React.useMemo(() => {
     return checkboxEnabled
       ? stripFromOrder(effectiveColumnOrder, checkboxColId)
       : effectiveColumnOrder;
   }, [checkboxColId, checkboxEnabled, effectiveColumnOrder]);
+  const dataSourceColumnOrder = React.useMemo(
+    () => columnsForDs.map((column) => getColumnId(column)),
+    [columnsForDs]
+  );
 
   const loadData = React.useCallback(async () => {
     if (!loadMountedRef.current) return;
@@ -1467,7 +1491,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
         ...(remotePagination && dsIsFn ? { skip: loadSkip, limit } : {}),
         sortInfo: computedSortForFetch,
         filterValue: computedFilterForFetch,
-        columnOrder: columnOrderForDs,
+        columnOrder: dataSourceColumnOrder,
         columns: columnsForDs,
         idProperty,
         theme: themeName,
@@ -1604,7 +1628,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
     remoteDataSource,
     remotePagination,
     themeName,
-    columnOrderForDs,
+    dataSourceColumnOrder,
     columnsForDs,
     filterTypes,
     localFilterValue,
@@ -1635,15 +1659,54 @@ function ReactDataGrid(props: TypeDataGridProps) {
     void loadData();
   }, [loadData]);
 
+  const filterCommitDelay = React.useMemo(() => {
+    const committedEntries = new Map(
+      (filterValue ?? []).map((entry) => [entry.name, entry])
+    );
+    const changedEntry = (draftFilterValue ?? []).find((entry) => {
+      const committed = committedEntries.get(entry.name);
+      return (
+        !committed ||
+        committed.operator !== entry.operator ||
+        committed.type !== entry.type ||
+        committed.active !== entry.active ||
+        !Object.is(committed.value, entry.value)
+      );
+    });
+    const removedEntry = (filterValue ?? []).find(
+      (entry) =>
+        !(draftFilterValue ?? []).some(
+          (draftEntry) => draftEntry.name === entry.name
+        )
+    );
+    const changedName = changedEntry?.name ?? removedEntry?.name;
+    const changedColumn = changedName
+      ? orderedColumns.find((column) => {
+          const columnId = getColumnId(column);
+          return (
+            columnId === changedName ||
+            column.name === changedName ||
+            column.filterName === changedName
+          );
+        })
+      : undefined;
+    const delay = changedColumn?.filterDelay;
+
+    if (delay === false || delay === 0) return 0;
+    return typeof delay === "number" && Number.isFinite(delay)
+      ? Math.max(0, delay)
+      : 250;
+  }, [draftFilterValue, filterValue, orderedColumns]);
+
   React.useEffect(() => {
-    if (filterControlled || Object.is(draftFilterValue, filterValue)) return;
+    if (Object.is(draftFilterValue, filterValue)) return;
 
     const handle = window.setTimeout(() => {
       setFilterValue(draftFilterValue);
-    }, 300);
+    }, filterCommitDelay);
 
     return () => window.clearTimeout(handle);
-  }, [draftFilterValue, filterControlled, filterValue, setFilterValue]);
+  }, [draftFilterValue, filterCommitDelay, filterValue, setFilterValue]);
 
   const autosizeSample = React.useMemo(() => {
     if (Array.isArray(dataSource)) {
@@ -2490,6 +2553,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const headerScrollRef = React.useRef<HTMLDivElement | null>(null);
   const previousSortForScrollRef = React.useRef(sortInfo);
+  const previousFilterForScrollRef = React.useRef(filterValue);
   const previousRowsForSortScrollRef = React.useRef(rows);
   React.useLayoutEffect(() => {
     const sortChanged = !Object.is(previousSortForScrollRef.current, sortInfo);
@@ -2505,6 +2569,17 @@ function ReactDataGrid(props: TypeDataGridProps) {
       scrollRef.current.scrollTop = 0;
     }
   }, [rows, scrollTopOnSort, sortInfo]);
+  React.useLayoutEffect(() => {
+    const filterChanged = !Object.is(
+      previousFilterForScrollRef.current,
+      filterValue
+    );
+    previousFilterForScrollRef.current = filterValue;
+
+    if (scrollTopOnFilter && filterChanged && scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+  }, [filterValue, scrollTopOnFilter]);
   const smoothScrollFrameIdsRef = React.useRef<Set<number>>(new Set());
   React.useEffect(
     () => () => {
@@ -6396,6 +6471,11 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           showHorizontalCellBorders={showHorizontalCellBorders}
                           showVerticalCellBorders={showVerticalCellBorders}
                           i18n={i18n}
+                          theme={themeName}
+                          gridRef={apiRef}
+                          gridProps={
+                            (apiRef.current ?? {}) as TypeComputedProps
+                          }
                           allowColumnReorder={allowColumnReorder}
                           allowColumnResize={resizable}
                           checkboxEnabled={checkboxEnabled}
@@ -6418,6 +6498,21 @@ function ReactDataGrid(props: TypeDataGridProps) {
                           setDraftFilterValue={setDraftFilterValue}
                           onColumnFilterValueChange={onColumnFilterValueChange}
                           filterTypes={filterTypes}
+                          renderColumnFilterContextMenu={
+                            renderColumnFilterContextMenu
+                          }
+                          columnFilterContextMenuAlignPositions={
+                            columnFilterContextMenuAlignPositions
+                          }
+                          columnFilterContextMenuConstrainTo={
+                            columnFilterContextMenuConstrainTo
+                          }
+                          columnFilterContextMenuPosition={
+                            columnFilterContextMenuPosition
+                          }
+                          updateMenuPositionOnScroll={
+                            updateMenuPositionOnScroll
+                          }
                           openFilterMenuColId={openFilterMenuColId}
                           setOpenFilterMenuColId={setOpenFilterMenuColId}
                           columnRenderItems={columnRenderItems}

--- a/src/grid/components/FilterCell.tsx
+++ b/src/grid/components/FilterCell.tsx
@@ -8,9 +8,11 @@ import type {
   TypeCellProps,
   TypeColumn,
   TypeColumnFilterValueChangeArg,
+  TypeComputedProps,
   TypeFilterTypes,
   TypeFilterValue,
   TypeI18n,
+  TypeRenderColumnFilterContextMenu,
   TypeSingleFilterValue,
 } from "../../types";
 
@@ -86,6 +88,18 @@ export type FilterCellProps = {
   showHorizontalCellBorders: boolean;
   showVerticalCellBorders: boolean;
   i18n?: TypeI18n;
+  theme: string;
+  gridRef: React.MutableRefObject<TypeComputedProps | null>;
+  gridProps: TypeComputedProps;
+  renderColumnFilterContextMenu?: TypeRenderColumnFilterContextMenu;
+  columnFilterContextMenuAlignPositions?: string[];
+  columnFilterContextMenuConstrainTo?:
+    | boolean
+    | HTMLElement
+    | string
+    | ((...args: unknown[]) => HTMLElement | null);
+  columnFilterContextMenuPosition?: string;
+  updateMenuPositionOnScroll: boolean;
 
   openFilterMenuColId: string | null;
   setOpenFilterMenuColId: (id: string | null) => void;
@@ -113,6 +127,7 @@ function resolveOperator(
 
   if (filterType === "number") return "gte";
   if (filterType === "select") return "eq";
+  if (filterType === "bool" || filterType === "boolean") return "eq";
   if (filterType === "date" || filterType === "time") return "afterOrOn";
 
   return "contains";
@@ -156,7 +171,6 @@ export function FilterCell(props: FilterCellProps) {
     checkboxEnabled,
     checkboxColId,
     filterControlled,
-    filterValue,
     draftFilterValue,
     setFilterValue,
     setDraftFilterValue,
@@ -166,6 +180,14 @@ export function FilterCell(props: FilterCellProps) {
     showHorizontalCellBorders,
     showVerticalCellBorders,
     i18n,
+    theme,
+    gridRef,
+    gridProps,
+    renderColumnFilterContextMenu,
+    columnFilterContextMenuAlignPositions,
+    columnFilterContextMenuConstrainTo,
+    columnFilterContextMenuPosition,
+    updateMenuPositionOnScroll,
     openFilterMenuColId,
     setOpenFilterMenuColId,
   } = props;
@@ -180,7 +202,7 @@ export function FilterCell(props: FilterCellProps) {
     colId
   );
 
-  const currentFilter = filterControlled ? filterValue : draftFilterValue;
+  const currentFilter = draftFilterValue;
   const entry = getFilterEntry(currentFilter, colId);
 
   const filterTypeName = resolveFilterType(col, entry);
@@ -218,12 +240,7 @@ export function FilterCell(props: FilterCellProps) {
     [col, colId, columnIndex]
   );
 
-  // Resolve filterEditorProps (supports function form)
   const filterEditorPropsAny = (col as any)?.filterEditorProps;
-  const resolvedEditorProps =
-    typeof filterEditorPropsAny === "function"
-      ? filterEditorPropsAny({ column: col, columnId: colId }, { index: 0 })
-      : filterEditorPropsAny;
 
   function applyFilterNow(next: TypeFilterValue) {
     setSkip(0);
@@ -290,28 +307,69 @@ export function FilterCell(props: FilterCellProps) {
   };
 
   const setEntryValue = (nextValueRaw: unknown) => {
-    const nextValue = normalizeEditorOutput(nextValueRaw);
-
-    const nextEntry: TypeSingleFilterValue = {
-      name: colId,
-      operator,
-      type: filterTypeName,
-      value: nextValue,
-      active: entry?.active,
-    };
+    const descriptor =
+      isPlainObject(nextValueRaw) &&
+      typeof nextValueRaw.name === "string" &&
+      "value" in nextValueRaw
+        ? (nextValueRaw as TypeSingleFilterValue)
+        : null;
+    const nextEntry: TypeSingleFilterValue = descriptor
+      ? {
+          ...descriptor,
+          active: descriptor.active ?? entry?.active,
+        }
+      : {
+          name: colId,
+          operator,
+          type: filterTypeName,
+          value: normalizeEditorOutput(nextValueRaw),
+          active: entry?.active,
+        };
 
     emitColumnFilterValueChange(nextEntry);
     setSkip(0);
-    if (filterControlled) {
-      setFilterValue(
-        upsertFilterEntry(filterValue, nextEntry, { filterTypes })
-      );
-    } else {
-      setDraftFilterValue(
-        upsertFilterEntry(draftFilterValue, nextEntry, { filterTypes })
-      );
-    }
+    setDraftFilterValue(
+      upsertFilterEntry(draftFilterValue, nextEntry, { filterTypes })
+    );
   };
+
+  const editorFilterValue: TypeSingleFilterValue = {
+    name: colId,
+    operator,
+    type: filterTypeName,
+    value: entry?.value ?? typeDef?.emptyValue,
+    emptyValue: entry?.emptyValue ?? typeDef?.emptyValue,
+    active: entry?.active,
+  };
+  const filterDelay =
+    col?.filterDelay === false ? 0 : (col?.filterDelay ?? 250);
+  const editorContract = {
+    filterValue: editorFilterValue,
+    value: editorFilterValue.value,
+    onChange: setEntryValue,
+    column: col,
+    columnId: colId,
+    disabled: editorDisabled,
+    active: entryEnabled,
+    emptyValue: editorFilterValue.emptyValue,
+    filterType: typeDef,
+    filterDelay,
+    filterEditorProps: filterEditorPropsAny,
+    i18n: (key: string, defaultValue?: string) =>
+      t(i18n, key, defaultValue ?? key),
+    theme,
+    cellProps: filterCellContext,
+    cell: {
+      onFilterValueChange: setEntryValue,
+      props: filterCellContext,
+    },
+    render: (node: React.ReactNode) => node,
+    renderInPortal: (node: React.ReactNode) => node,
+    nativeScroll: true,
+    rtl: false,
+  };
+  const resolvedEditorProps =
+    typeof filterEditorPropsAny === "function" ? {} : filterEditorPropsAny;
 
   // Built-in select support (single + multi)
   const options = Array.isArray((resolvedEditorProps as any)?.options)
@@ -383,19 +441,7 @@ export function FilterCell(props: FilterCellProps) {
                 ...(isPlainObject(resolvedEditorProps)
                   ? resolvedEditorProps
                   : {}),
-                filterValue: {
-                  name: colId,
-                  operator,
-                  type: filterTypeName,
-                  value: entry?.value ?? null,
-                  emptyValue: entry?.emptyValue,
-                  active: entry?.active,
-                },
-                value: entry?.value ?? null,
-                onChange: (next: unknown) => setEntryValue(next),
-                column: col,
-                columnId: colId,
-                disabled: editorDisabled,
+                ...editorContract,
               })
             ) : filterTypeName === "select" && options.length > 0 ? (
               multiple ? (
@@ -466,7 +512,8 @@ export function FilterCell(props: FilterCellProps) {
                     value === "" || value == null ? "__all__" : value
                   )}
                   onValueChange={(v: string) => {
-                    const nextValue = v === "__all__" ? "" : v;
+                    const nextValue =
+                      v === "__all__" ? (typeDef?.emptyValue ?? null) : v;
                     setEntryValue(nextValue);
                   }}
                   disabled={editorDisabled}
@@ -498,9 +545,23 @@ export function FilterCell(props: FilterCellProps) {
               )
             ) : (
               <Input
+                type="text"
                 value={String(value ?? "")}
                 disabled={editorDisabled}
-                onChange={(e) => setEntryValue(e.target.value)}
+                onChange={(e) => {
+                  if (filterTypeName !== "number") {
+                    setEntryValue(e.target.value);
+                    return;
+                  }
+                  const numericValue = Number(e.target.value);
+                  setEntryValue(
+                    e.target.value === ""
+                      ? null
+                      : Number.isFinite(numericValue)
+                        ? numericValue
+                        : e.target.value
+                  );
+                }}
                 className="h-8 w-full"
                 placeholder={String(
                   t(i18n, operator, humanizeOperatorName(operator))
@@ -551,6 +612,18 @@ export function FilterCell(props: FilterCellProps) {
               onDisable={() => onSetEnabled(false)}
               onSelectOperator={onSelectOperator}
               title={String(t(i18n, operator, humanizeOperatorName(operator)))}
+              renderColumnFilterContextMenu={renderColumnFilterContextMenu}
+              columnFilterContextMenuAlignPositions={
+                columnFilterContextMenuAlignPositions
+              }
+              columnFilterContextMenuConstrainTo={
+                columnFilterContextMenuConstrainTo
+              }
+              columnFilterContextMenuPosition={columnFilterContextMenuPosition}
+              updateMenuPositionOnScroll={updateMenuPositionOnScroll}
+              cellProps={filterCellContext}
+              gridRef={gridRef}
+              gridProps={gridProps}
             />
           )}
         </div>

--- a/src/grid/components/FilterOperatorMenu.tsx
+++ b/src/grid/components/FilterOperatorMenu.tsx
@@ -3,7 +3,12 @@
 import * as React from "react";
 import { IconFilter } from "@tabler/icons-react";
 
-import type { TypeI18n } from "../../types";
+import type {
+  TypeCellProps,
+  TypeComputedProps,
+  TypeI18n,
+  TypeRenderColumnFilterContextMenu,
+} from "../../types";
 import { cn } from "../../lib/utils";
 import { t } from "../../utils/helpers";
 
@@ -41,6 +46,18 @@ export type FilterOperatorMenuProps = {
   onSelectOperator: (opName: string) => void;
 
   title?: string;
+  renderColumnFilterContextMenu?: TypeRenderColumnFilterContextMenu;
+  columnFilterContextMenuAlignPositions?: string[];
+  columnFilterContextMenuConstrainTo?:
+    | boolean
+    | HTMLElement
+    | string
+    | ((...args: unknown[]) => HTMLElement | null);
+  columnFilterContextMenuPosition?: string;
+  updateMenuPositionOnScroll: boolean;
+  cellProps: TypeCellProps;
+  gridRef: React.MutableRefObject<TypeComputedProps | null>;
+  gridProps: TypeComputedProps;
 };
 
 export function FilterOperatorMenu(
@@ -62,6 +79,14 @@ export function FilterOperatorMenu(
     onDisable,
     onSelectOperator,
     title,
+    renderColumnFilterContextMenu,
+    columnFilterContextMenuAlignPositions,
+    columnFilterContextMenuConstrainTo,
+    columnFilterContextMenuPosition,
+    updateMenuPositionOnScroll,
+    cellProps,
+    gridRef,
+    gridProps,
   } = props;
 
   const selectAndClose = React.useCallback(
@@ -71,6 +96,52 @@ export function FilterOperatorMenu(
     },
     [onOpenChange]
   );
+  const menuInstanceId = React.useId();
+  const customMenu =
+    open && renderColumnFilterContextMenu
+      ? renderColumnFilterContextMenu(
+          {
+            autoFocus: true,
+            nativeScroll: true,
+            enableSelection: true,
+            position: columnFilterContextMenuPosition,
+            style: {
+              position: columnFilterContextMenuPosition as
+                | React.CSSProperties["position"]
+                | undefined,
+            },
+            constrainTo: columnFilterContextMenuConstrainTo,
+            alignPositions: columnFilterContextMenuAlignPositions,
+            updatePositionOnScroll: updateMenuPositionOnScroll,
+            selected: operator,
+            items: operators.map((operatorItem) => ({
+              value: operatorItem.name,
+              label: String(t(i18n, operatorItem.name, operatorItem.name)),
+            })),
+            onSelectionChange: (nextOperator) =>
+              selectAndClose(() => onSelectOperator(nextOperator)),
+            onDismiss: () => onOpenChange(false),
+          },
+          {
+            cellProps,
+            grid: gridRef,
+            props: gridProps,
+          }
+        )
+      : null;
+  const hasCustomMenu = customMenu != null && customMenu !== false;
+  React.useEffect(() => {
+    if (!open || hasCustomMenu) return;
+
+    const frame = requestAnimationFrame(() => {
+      const activeOperator = document.querySelector<HTMLElement>(
+        `[data-filter-operator-active="true"][data-filter-menu-instance="${menuInstanceId}"]`
+      );
+      activeOperator?.focus();
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [hasCustomMenu, menuInstanceId, open]);
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
@@ -94,74 +165,89 @@ export function FilterOperatorMenu(
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuGroup>
-          <DropdownMenuLabel>
-            {String(t(i18n, "filter", "Filter"))}
-          </DropdownMenuLabel>
-        </DropdownMenuGroup>
-
-        {operators.length > 0 ? (
+      {customMenu && React.isValidElement(customMenu) ? (
+        <DropdownMenuContent asChild>{customMenu}</DropdownMenuContent>
+      ) : hasCustomMenu ? (
+        <DropdownMenuContent align="end" className="w-56">
+          {customMenu}
+        </DropdownMenuContent>
+      ) : (
+        <DropdownMenuContent align="end" className="w-56">
           <DropdownMenuGroup>
             <DropdownMenuLabel>
-              {String(t(i18n, "operator", "Operator"))}
+              {String(t(i18n, "filter", "Filter"))}
             </DropdownMenuLabel>
-            <DropdownMenuRadioGroup
-              value={operator}
-              onValueChange={(nextOperator) =>
-                selectAndClose(() => onSelectOperator(nextOperator))
-              }
-            >
-              {operators.map((opItem) => {
-                const opName = String(opItem?.name ?? "");
-                if (!opName) return null;
-
-                return (
-                  <DropdownMenuRadioItem key={opName} value={opName}>
-                    <span className="truncate">
-                      {String(t(i18n, opName, opName))}
-                    </span>
-                  </DropdownMenuRadioItem>
-                );
-              })}
-            </DropdownMenuRadioGroup>
           </DropdownMenuGroup>
-        ) : null}
 
-        {operators.length > 0 ? <DropdownMenuSeparator /> : null}
+          {operators.length > 0 ? (
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>
+                {String(t(i18n, "operator", "Operator"))}
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={operator}
+                onValueChange={(nextOperator) =>
+                  selectAndClose(() => onSelectOperator(nextOperator))
+                }
+              >
+                {operators.map((opItem) => {
+                  const opName = String(opItem?.name ?? "");
+                  if (!opName) return null;
 
-        <DropdownMenuGroup>
-          <DropdownMenuItem
-            disabled={enabled}
-            onSelect={() => selectAndClose(onEnable)}
-          >
-            {String(t(i18n, "enable", "Enable"))}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={!enabled}
-            onSelect={() => selectAndClose(onDisable)}
-          >
-            {String(t(i18n, "disable", "Disable"))}
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
+                  return (
+                    <DropdownMenuRadioItem
+                      key={opName}
+                      value={opName}
+                      data-filter-operator-active={
+                        opName === operator ? "true" : undefined
+                      }
+                      data-filter-menu-instance={menuInstanceId}
+                    >
+                      <span className="truncate">
+                        {String(t(i18n, opName, opName))}
+                      </span>
+                    </DropdownMenuRadioItem>
+                  );
+                })}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuGroup>
+          ) : null}
 
-        <DropdownMenuSeparator />
+          {operators.length > 0 ? <DropdownMenuSeparator /> : null}
 
-        <DropdownMenuGroup>
-          <DropdownMenuItem
-            disabled={clearDisabled}
-            onSelect={() => selectAndClose(onClear)}
-          >
-            {String(t(i18n, "clear", "Clear"))}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={clearAllDisabled}
-            onSelect={() => selectAndClose(onClearAll)}
-          >
-            {String(t(i18n, "clearAll", "Clear All"))}
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              disabled={enabled}
+              onSelect={() => selectAndClose(onEnable)}
+            >
+              {String(t(i18n, "enable", "Enable"))}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!enabled}
+              onSelect={() => selectAndClose(onDisable)}
+            >
+              {String(t(i18n, "disable", "Disable"))}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              disabled={clearDisabled}
+              onSelect={() => selectAndClose(onClear)}
+            >
+              {String(t(i18n, "clear", "Clear"))}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={clearAllDisabled}
+              onSelect={() => selectAndClose(onClearAll)}
+            >
+              {String(t(i18n, "clearAll", "Clear All"))}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      )}
     </DropdownMenu>
   );
 }

--- a/src/grid/components/GridHeader.tsx
+++ b/src/grid/components/GridHeader.tsx
@@ -4,9 +4,11 @@ import * as React from "react";
 import type {
   TypeColumn,
   TypeColumnFilterValueChangeArg,
+  TypeComputedProps,
   TypeFilterTypes,
   TypeFilterValue,
   TypeI18n,
+  TypeRenderColumnFilterContextMenu,
   TypeRenderSortTool,
   TypeSortFunctions,
   TypeSortInfo,
@@ -40,6 +42,9 @@ export type GridHeaderProps = {
   showHorizontalCellBorders: boolean;
   showVerticalCellBorders: boolean;
   i18n?: TypeI18n;
+  theme: string;
+  gridRef: React.MutableRefObject<TypeComputedProps | null>;
+  gridProps: TypeComputedProps;
 
   // DnD reorder
   allowColumnReorder: boolean;
@@ -67,6 +72,15 @@ export type GridHeaderProps = {
   setDraftFilterValue: React.Dispatch<React.SetStateAction<TypeFilterValue>>;
   onColumnFilterValueChange?: (event: TypeColumnFilterValueChangeArg) => void;
   filterTypes: TypeFilterTypes;
+  renderColumnFilterContextMenu?: TypeRenderColumnFilterContextMenu;
+  columnFilterContextMenuAlignPositions?: string[];
+  columnFilterContextMenuConstrainTo?:
+    | boolean
+    | HTMLElement
+    | string
+    | ((...args: unknown[]) => HTMLElement | null);
+  columnFilterContextMenuPosition?: string;
+  updateMenuPositionOnScroll: boolean;
 
   openFilterMenuColId: string | null;
   setOpenFilterMenuColId: (id: string | null) => void;
@@ -108,6 +122,9 @@ export function GridHeader(props: GridHeaderProps) {
     showHorizontalCellBorders,
     showVerticalCellBorders,
     i18n,
+    theme,
+    gridRef,
+    gridProps,
     allowColumnReorder,
     allowColumnResize,
     checkboxEnabled,
@@ -128,6 +145,11 @@ export function GridHeader(props: GridHeaderProps) {
     setDraftFilterValue,
     onColumnFilterValueChange,
     filterTypes,
+    renderColumnFilterContextMenu,
+    columnFilterContextMenuAlignPositions,
+    columnFilterContextMenuConstrainTo,
+    columnFilterContextMenuPosition,
+    updateMenuPositionOnScroll,
     openFilterMenuColId,
     setOpenFilterMenuColId,
     columnRenderItems,
@@ -261,6 +283,20 @@ export function GridHeader(props: GridHeaderProps) {
                   setSkip={setSkip}
                   filterTypes={filterTypes}
                   i18n={i18n}
+                  theme={theme}
+                  gridRef={gridRef}
+                  gridProps={gridProps}
+                  renderColumnFilterContextMenu={renderColumnFilterContextMenu}
+                  columnFilterContextMenuAlignPositions={
+                    columnFilterContextMenuAlignPositions
+                  }
+                  columnFilterContextMenuConstrainTo={
+                    columnFilterContextMenuConstrainTo
+                  }
+                  columnFilterContextMenuPosition={
+                    columnFilterContextMenuPosition
+                  }
+                  updateMenuPositionOnScroll={updateMenuPositionOnScroll}
                   showHorizontalCellBorders={showHorizontalCellBorders}
                   showVerticalCellBorders={showVerticalCellBorders}
                   openFilterMenuColId={openFilterMenuColId}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ export type {
   TypeColumn,
   TypeCellProps,
   TypeColumnFilterValueChangeArg,
+  TypeColumnFilterContextMenuProps,
   TypeColumns,
   TypeComputedColumn,
   TypeComputedColumnsMap,
@@ -67,6 +68,7 @@ export type {
   TypeSortFunctions,
   TypeColumnSort,
   TypeRenderSortTool,
+  TypeRenderColumnFilterContextMenu,
   TypeSortToolProps,
   TypeSortInfo,
   // plus your checkbox/selection compat types if you added them

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,10 @@ export type TypeSingleFilterValue = {
   emptyValue?: unknown;
 
   fn?: (arg: unknown) => unknown;
-  getFilterValue?: (...args: unknown[]) => unknown;
+  getFilterValue?: (args: {
+    data: TypeColumnRenderArgs["data"];
+    value: unknown;
+  }) => unknown;
 
   /**
    * If not set, runtime derives active/inactive from operator and value.
@@ -492,6 +495,13 @@ export interface IColumn {
   }) => unknown;
   filterEditor?: React.ComponentType<Record<string, unknown>>;
   filterEditorProps?: unknown;
+  /**
+   * Debounce interval for committing this column's filter value.
+   *
+   * `false` and `0` commit immediately. When omitted, filter editors use the
+   * Inovua-compatible 250 ms default.
+   */
+  filterDelay?: boolean | number;
   filterCellPadding?: React.CSSProperties["padding"];
 
   /** Excludes this column from optional global search when false. */
@@ -515,6 +525,32 @@ export type TypeColumn = IColumn;
 export type TypeColumns = TypeColumn[];
 
 export type TypeI18n = { [key: string]: string | React.ReactNode };
+
+export type TypeColumnFilterContextMenuProps = {
+  position?: string;
+  style?: React.CSSProperties;
+  constrainTo?:
+    | boolean
+    | HTMLElement
+    | string
+    | ((...args: unknown[]) => HTMLElement | null);
+  alignPositions?: string[];
+  updatePositionOnScroll?: boolean;
+  selected?: string;
+  items?: Array<Record<string, unknown>>;
+  onSelectionChange?: (operator: string) => void;
+  onDismiss?: () => void;
+  [key: string]: unknown;
+};
+
+export type TypeRenderColumnFilterContextMenu = (
+  menuProps: TypeColumnFilterContextMenuProps,
+  context: {
+    cellProps: TypeCellProps;
+    grid: React.MutableRefObject<TypeComputedProps | null>;
+    props: TypeComputedProps;
+  }
+) => React.ReactNode;
 
 /**
  * Inovua selection in your codebase is an object map: { [id]: rowObject }.
@@ -1042,6 +1078,16 @@ export type TypeDataGridProps = {
   ) => void;
 
   filterTypes?: TypeFilterTypes;
+  scrollTopOnFilter?: boolean;
+  renderColumnFilterContextMenu?: TypeRenderColumnFilterContextMenu;
+  columnFilterContextMenuAlignPositions?: string[];
+  columnFilterContextMenuConstrainTo?:
+    | boolean
+    | HTMLElement
+    | string
+    | ((...args: unknown[]) => HTMLElement | null);
+  columnFilterContextMenuPosition?: string;
+  updateMenuPositionOnScroll?: boolean;
 
   filteredRowsCount?: (filteredRows: number) => void;
 

--- a/tests/playwright/issue-34-filtering.spec.ts
+++ b/tests/playwright/issue-34-filtering.spec.ts
@@ -1,0 +1,623 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+type RemoteProjectionSnapshot = {
+  filter: {
+    name: string;
+    type: string | null;
+    operator: string;
+    value: unknown;
+    hasGetter: boolean;
+  } | null;
+  columnOrder: string[];
+  columns: string[];
+};
+
+type EditorPropsSnapshot = {
+  filterEditorPropsType: string;
+  hasI18n: boolean;
+  hasTheme: boolean;
+  hasRender: boolean;
+  hasCellProps: boolean;
+  hasCell: boolean;
+  hasEmptyValue: boolean;
+  hasFilterType: boolean;
+  hasOnChange: boolean;
+  filterDelay: number | null;
+  active: boolean | null;
+  operator: string | null;
+};
+
+type NumberEditorPropsCall = {
+  index: number | null;
+  value: unknown;
+  hasFilterValue: boolean;
+  hasColumn: boolean;
+  hasCellProps: boolean;
+};
+
+type FilterLogEvent = {
+  kind: "column" | "aggregate";
+  columnId?: string;
+  filterValue: unknown;
+};
+
+const operatorExpectations = {
+  string: {
+    contains: ["alpha", "alphabet"],
+    notContains: ["empty", "null", "number-zero", "text-zero", "false", "beta"],
+    eq: ["text-zero"],
+    neq: ["empty", "null", "number-zero", "false", "alpha", "alphabet", "beta"],
+    empty: ["empty"],
+    notEmpty: [
+      "null",
+      "number-zero",
+      "text-zero",
+      "false",
+      "alpha",
+      "alphabet",
+      "beta",
+    ],
+    startsWith: ["alpha", "alphabet"],
+    endsWith: ["alpha", "beta"],
+    falsyNumberFilter: [
+      "empty",
+      "null",
+      "number-zero",
+      "text-zero",
+      "false",
+      "alpha",
+      "alphabet",
+      "beta",
+    ],
+    falsyBooleanFilter: [
+      "empty",
+      "null",
+      "number-zero",
+      "text-zero",
+      "false",
+      "alpha",
+      "alphabet",
+      "beta",
+    ],
+  },
+  number: {
+    gt: ["two", "text-two", "three"],
+    gte: ["two", "text-two", "three"],
+    lt: ["null", "empty", "zero", "one"],
+    lte: ["null", "empty", "zero", "one", "two", "text-two"],
+    eq: ["two"],
+    neq: ["null", "empty", "zero", "one", "text-two", "three"],
+    inrange: ["one", "two", "text-two"],
+    notinrange: ["null", "empty", "zero", "three"],
+    emptyStringEq: ["empty"],
+    nullEq: ["null", "empty", "zero", "one", "two", "text-two", "three"],
+  },
+  bool: {
+    eq: ["true"],
+    neq: ["null", "false", "zero", "one"],
+    nullEq: ["null", "false", "true", "zero", "one"],
+  },
+  boolean: {
+    eq: ["true"],
+    neq: ["null", "false", "zero", "one"],
+    nullEq: ["null", "false", "true", "zero", "one"],
+  },
+  select: {
+    inlist: ["a", "c"],
+    notinlist: ["null", "empty", "b", "zero", "false"],
+    eq: ["a"],
+    neq: ["null", "empty", "b", "c", "zero", "false"],
+    emptyList: ["null", "empty", "a", "b", "c", "zero", "false"],
+    nullEq: ["null", "empty", "a", "b", "c", "zero", "false"],
+    scalarList: ["empty", "a", "b"],
+  },
+  date: {
+    after: ["end", "outside"],
+    afterOrOn: ["middle", "end", "outside"],
+    before: ["start"],
+    beforeOrOn: ["start", "middle"],
+    eq: ["middle"],
+    neq: ["start", "end", "outside"],
+    inrange: ["start", "middle", "end"],
+    notinrange: ["outside"],
+    emptyEq: ["start", "middle", "end", "outside"],
+  },
+} as const;
+
+async function readJson<T>(locator: Locator): Promise<T> {
+  return JSON.parse((await locator.textContent())?.trim() || "null") as T;
+}
+
+async function rowIds(scope: Locator): Promise<(string | null)[]> {
+  return scope
+    .locator('[data-slot="grid-row"]')
+    .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-row-id")));
+}
+
+function filterCell(scope: Locator, columnId: string): Locator {
+  return scope.locator(`.tdg-filter-cell[data-column-id="${columnId}"]`);
+}
+
+async function openScenario(page: Page, scenario: string): Promise<Locator> {
+  await page.goto(`/compat/issue-34-filtering?scenario=${scenario}`);
+  const scope = page.getByTestId(`issue-34-${scenario}`);
+  await expect(scope).toBeVisible();
+  return scope;
+}
+
+test.describe("issue #34 complete filtering parity", () => {
+  test("retains filter-row inference and explicit visibility precedence", async ({
+    page,
+  }) => {
+    await page.goto("/compat/github-issues-31-32");
+    const probe = page.getByTestId("github-issue-31-probe");
+
+    const snapshots = await Promise.all(
+      [
+        "issue-31-filter-omitted",
+        "issue-31-filter-default-active",
+        "issue-31-filter-controlled",
+        "issue-31-filter-explicit-true",
+        "issue-31-filter-explicit-false-default",
+        "issue-31-filter-explicit-false-controlled",
+        "issue-31-filter-empty-default",
+        "issue-31-filter-inactive-default",
+      ].map(async (testId) => {
+        const grid = probe.getByTestId(testId).locator(".tdg-root");
+        await expect(grid).toBeVisible();
+        return grid.evaluate((element) => ({
+          filterRows: element.querySelectorAll(".tdg-filter-row").length,
+          dataRows: element.querySelectorAll('[data-slot="grid-row"]').length,
+        }));
+      })
+    );
+
+    expect(snapshots).toEqual([
+      { filterRows: 0, dataRows: 2 },
+      { filterRows: 1, dataRows: 1 },
+      { filterRows: 1, dataRows: 2 },
+      { filterRows: 1, dataRows: 2 },
+      { filterRows: 0, dataRows: 1 },
+      { filterRows: 0, dataRows: 2 },
+      { filterRows: 0, dataRows: 2 },
+      { filterRows: 1, dataRows: 2 },
+    ]);
+  });
+
+  test("uses column.filterName and column.getFilterValue for local rows", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "projection");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-local-alias")))
+      .toEqual(["alias-ada"]);
+  });
+
+  test("projects filter aliases, inferred types, and getters into remote args", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "projection");
+    const output = scope.getByTestId("issue-34-remote-snapshot");
+
+    await expect
+      .poll(async () => {
+        const snapshot = await readJson<RemoteProjectionSnapshot | null>(
+          output
+        );
+        return snapshot?.filter ?? null;
+      })
+      .toEqual({
+        name: "profileName",
+        type: "string",
+        operator: "contains",
+        value: "Ada",
+        hasGetter: true,
+      });
+  });
+
+  test("applies defaultVisible/defaultHidden before deriving remote columns", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "projection");
+    await expect
+      .poll(() =>
+        readJson<RemoteProjectionSnapshot | null>(
+          scope.getByTestId("issue-34-remote-snapshot")
+        )
+      )
+      .not.toBeNull();
+
+    const remote = await readJson<RemoteProjectionSnapshot>(
+      scope.getByTestId("issue-34-remote-snapshot")
+    );
+    expect(remote.columns).toEqual(["id", "displayName", "visibleMeta"]);
+  });
+
+  test("keeps default-hidden IDs out of remote rendered column order", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "projection");
+    await expect
+      .poll(() =>
+        readJson<RemoteProjectionSnapshot | null>(
+          scope.getByTestId("issue-34-remote-snapshot")
+        )
+      )
+      .not.toBeNull();
+    const remote = await readJson<RemoteProjectionSnapshot>(
+      scope.getByTestId("issue-34-remote-snapshot")
+    );
+
+    expect(remote.columnOrder).toEqual(["id", "displayName", "visibleMeta"]);
+  });
+
+  test("honors descriptor-level getFilterValue for local filtering", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "descriptors");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-descriptor-getter")))
+      .toEqual(["getter-ada"]);
+  });
+
+  test("honors descriptor-level fn before registered operators", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "descriptors");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-descriptor-function")))
+      .toEqual(["fn-keep"]);
+  });
+
+  test("passes the complete Inovua filter-editor contract to custom editors", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "editors");
+    await expect
+      .poll(() =>
+        readJson<EditorPropsSnapshot>(
+          scope.getByTestId("issue-34-custom-editor-props")
+        )
+      )
+      .toEqual({
+        filterEditorPropsType: "function",
+        hasI18n: true,
+        hasTheme: true,
+        hasRender: true,
+        hasCellProps: true,
+        hasCell: true,
+        hasEmptyValue: true,
+        hasFilterType: true,
+        hasOnChange: true,
+        filterDelay: 250,
+        active: true,
+        operator: "contains",
+      });
+  });
+
+  test("accepts full-descriptor onChange output from a custom editor", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "editors");
+    await scope.getByTestId("issue-34-custom-editor-change").click();
+    await expect
+      .poll(async () => {
+        const events = await readJson<unknown[]>(
+          scope.getByTestId("issue-34-editor-filter-events")
+        );
+        return events.at(-1);
+      })
+      .toEqual([
+        expect.objectContaining({
+          name: "name",
+          type: "string",
+          operator: "contains",
+          value: "Grace",
+        }),
+        expect.objectContaining({
+          name: "score",
+          type: "number",
+          operator: "inrange",
+        }),
+      ]);
+  });
+
+  test("invokes functional NumberFilter editor props for both range inputs", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "editors");
+    await scope.getByTestId("issue-34-capture-number-editor-calls").click();
+    const calls = await readJson<NumberEditorPropsCall[]>(
+      scope.getByTestId("issue-34-number-editor-calls")
+    );
+    const latestByIndex = new Map<number | null, NumberEditorPropsCall>();
+    for (const call of calls) latestByIndex.set(call.index, call);
+
+    expect([...latestByIndex.keys()].sort()).toEqual([0, 1]);
+    expect(latestByIndex.get(0)).toMatchObject({
+      value: 1,
+      hasFilterValue: true,
+      hasColumn: true,
+      hasCellProps: true,
+    });
+    expect(latestByIndex.get(1)).toMatchObject({
+      value: 5,
+      hasFilterValue: true,
+      hasColumn: true,
+      hasCellProps: true,
+    });
+  });
+
+  test("initializes both boolean type aliases with eq", async ({ page }) => {
+    const scope = await openScenario(page, "booleans");
+    await expect(scope.getByTestId("issue-34-boolValue-operator")).toHaveText(
+      "eq"
+    );
+    await expect(
+      scope.getByTestId("issue-34-booleanValue-operator").first()
+    ).toHaveText("eq");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-bool-default")))
+      .toEqual(["bool-true"]);
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-boolean-default")))
+      .toEqual(["boolean-true"]);
+  });
+
+  test("preserves null as the empty boolean value", async ({ page }) => {
+    const scope = await openScenario(page, "booleans");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-boolean-empty")))
+      .toEqual(["boolean-empty-true", "boolean-empty-false"]);
+  });
+
+  test("uses column.filterDelay instead of the fixed aggregate delay", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "delay");
+    const input = filterCell(
+      scope.getByTestId("issue-34-delay-grid"),
+      "name"
+    ).locator("input");
+    await input.evaluate((element) => {
+      element.addEventListener(
+        "input",
+        () => {
+          (
+            window as typeof window & {
+              __issue34FilterInputAt?: number;
+            }
+          ).__issue34FilterInputAt = performance.now();
+        },
+        { once: true }
+      );
+    });
+    await input.fill("Ada");
+    await expect
+      .poll(async () => {
+        const times = await readJson<number[]>(
+          scope.getByTestId("issue-34-delay-event-times")
+        );
+        return times.length;
+      })
+      .toBeGreaterThan(0);
+    const times = await readJson<number[]>(
+      scope.getByTestId("issue-34-delay-event-times")
+    );
+    const startedAt = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __issue34FilterInputAt?: number;
+          }
+        ).__issue34FilterInputAt ?? 0
+    );
+
+    // Explicit 25 ms debounce plus React rendering should remain well below
+    // the current hard-coded 300 ms path.
+    expect(times.at(-1)! - startedAt).toBeLessThan(225);
+  });
+
+  test("resets vertical scroll when scrollTopOnFilter is enabled", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "scroll");
+    const enabled = scope.getByTestId("issue-34-scroll-enabled");
+    const enabledViewport = enabled.locator(".tdg-body-viewport");
+
+    await enabledViewport.evaluate((element) => {
+      element.scrollTop = 640;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    await expect
+      .poll(() => enabledViewport.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+
+    await enabled
+      .getByRole("textbox", { name: "issue-34-scroll-enabled filter" })
+      .fill("Row 1");
+
+    await expect
+      .poll(() => enabledViewport.evaluate((element) => element.scrollTop))
+      .toBe(0);
+  });
+
+  test("retains vertical scroll when scrollTopOnFilter is disabled", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "scroll");
+    const disabled = scope.getByTestId("issue-34-scroll-disabled");
+    const disabledViewport = disabled.locator(".tdg-body-viewport");
+
+    await disabledViewport.evaluate((element) => {
+      element.scrollTop = 640;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    await expect
+      .poll(() => disabledViewport.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+
+    await disabled
+      .getByRole("textbox", { name: "issue-34-scroll-disabled filter" })
+      .fill("Row 1");
+    await page.waitForTimeout(450);
+    await expect
+      .poll(() => disabledViewport.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+  });
+
+  test("keeps the standard operator menu keyboard focus contract", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "menu");
+    const trigger = scope
+      .getByTestId("issue-34-standard-menu")
+      .getByRole("button", { name: "Filter" });
+    await trigger.click();
+    const activeOperator = page.getByRole("menuitemradio", {
+      name: "contains",
+      exact: true,
+    });
+    await expect(activeOperator).toBeVisible();
+    await expect(activeOperator).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("menu")).toHaveCount(0);
+    await expect(trigger).toBeFocused();
+  });
+
+  test("supports custom filter-menu rendering, constraints, and positioning", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "menu");
+    await scope
+      .getByTestId("issue-34-custom-menu")
+      .getByRole("button", { name: "Filter" })
+      .click();
+    const menu = page.getByTestId("issue-34-custom-filter-menu");
+
+    await expect(menu).toBeVisible();
+    await expect(menu).toHaveAttribute("data-position", "fixed");
+    await expect(menu).toHaveAttribute("data-has-cell-props", "true");
+    await expect(menu).toHaveAttribute("data-has-grid", "true");
+    await expect(menu).toHaveAttribute("data-has-grid-props", "true");
+    await expect(menu).toHaveAttribute("data-has-constrain-to", "true");
+    await expect(menu).toHaveAttribute(
+      "data-update-position-on-scroll",
+      "false"
+    );
+    await expect(menu).toHaveAttribute("data-align-positions", '["tl-bl"]');
+  });
+
+  test("matches exact string falsy semantics", async ({ page }) => {
+    const scope = await openScenario(page, "operators");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-string-falsy")))
+      .toEqual(["string-text-zero"]);
+  });
+
+  test("keeps number equality strict instead of coercing numeric strings", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "operators");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-number-equality")))
+      .toEqual(["number-native"]);
+  });
+
+  test("distinguishes the number empty value null from an empty string", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "operators");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-number-empty")))
+      .toEqual(["number-empty-string"]);
+  });
+
+  test("keeps number/date ranges and select lists inclusive and exact", async ({
+    page,
+  }) => {
+    const scope = await openScenario(page, "operators");
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-number-range")))
+      .toEqual(["range-one", "range-two"]);
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-select-list")))
+      .toEqual(["select-a", "select-c"]);
+    await expect
+      .poll(() => rowIds(scope.getByTestId("issue-34-date-range")))
+      .toEqual(["date-start", "date-middle"]);
+  });
+
+  for (const [filterType, expected] of Object.entries(operatorExpectations)) {
+    test(`matches every documented ${filterType} operator`, async ({
+      page,
+    }) => {
+      const scope = await openScenario(page, "operator-matrix");
+      const matrix = await readJson<Record<string, Record<string, string[]>>>(
+        scope.getByTestId("issue-34-operator-matrix-output")
+      );
+
+      expect(matrix[filterType]).toEqual(expected);
+    });
+  }
+
+  test("preserves PR #30 per-column callback ordering", async ({ page }) => {
+    await page.goto("/compat/inovua-pending-parity?scenario=filter-callback");
+    const scope = page.getByTestId("inovua-pending-parity-scenario");
+    await scope.getByTestId("pending-name-filter").fill("Grace");
+    await expect
+      .poll(async () => {
+        const events = await readJson<FilterLogEvent[]>(
+          scope.getByTestId("filter-event-log")
+        );
+        return events.map((event) => event.kind);
+      })
+      .toEqual(["column", "aggregate"]);
+  });
+
+  test("keeps repeated 10k-row local filters responsive and virtualized @production-performance", async ({
+    page,
+  }) => {
+    await page.goto("/compat/issue-34-filtering?scenario=performance");
+    const scope = page.getByTestId("issue-34-performance");
+    const run = scope.getByTestId("issue-34-performance-run");
+    const output = scope.getByTestId("issue-34-performance-metrics");
+    const samples: Array<{
+      run: number;
+      rowCount: number;
+      filteredCount: number;
+      runtimeMode: string;
+      dispatchDuration: number;
+      settledDuration: number;
+      renderedRowCount: number;
+      firstRow: string;
+    }> = [];
+
+    for (let index = 1; index <= 5; index += 1) {
+      await run.click();
+      await expect
+        .poll(async () => {
+          const metrics = await readJson<{ run?: number }>(output);
+          return metrics?.run ?? 0;
+        })
+        .toBe(index);
+      samples.push(await readJson<(typeof samples)[number]>(output));
+    }
+
+    for (const sample of samples) {
+      expect(sample.rowCount).toBe(10_000);
+      expect(sample.filteredCount).toBe(500);
+      expect(sample.runtimeMode).toBe("production");
+      expect(sample.dispatchDuration).toBeLessThan(16);
+      expect(sample.settledDuration).toBeLessThan(250);
+      expect(sample.renderedRowCount).toBeGreaterThan(0);
+      expect(sample.renderedRowCount).toBeLessThan(100);
+      expect(sample.firstRow).toMatch(/^filter-performance-/);
+    }
+
+    const settledDurations = samples
+      .map((sample) => sample.settledDuration)
+      .sort((first, second) => first - second);
+    expect(settledDurations[2]).toBeLessThan(175);
+  });
+});

--- a/tests/types/type-issue-34-filtering.ts
+++ b/tests/types/type-issue-34-filtering.ts
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import ReactDataGrid, {
+  type TypeColumnFilterContextMenuProps,
+  type TypeColumns,
+  type TypeDataGridProps,
+  type TypeRenderColumnFilterContextMenu,
+} from "@geovi/the-datagrid";
+
+const columns: TypeColumns = [
+  { name: "id", filterable: false },
+  {
+    name: "name",
+    type: "string",
+    filterName: "profileName",
+    filterDelay: 25,
+    getFilterValue: ({ data }) => (data as { profileName: string }).profileName,
+  },
+  {
+    name: "enabled",
+    filterType: "boolean",
+    filterDelay: false,
+  },
+];
+
+const renderColumnFilterContextMenu: TypeRenderColumnFilterContextMenu = (
+  menuProps,
+  { cellProps, grid, props }
+) => {
+  const typedMenuProps: TypeColumnFilterContextMenuProps = menuProps;
+  const columnId: string | undefined = cellProps.columnId;
+  const currentGrid = grid.current;
+  const count = props.getCount();
+  void typedMenuProps;
+  void columnId;
+  void currentGrid;
+  void count;
+  return React.createElement("div", { role: "menu" });
+};
+
+const props = {
+  idProperty: "id",
+  columns,
+  dataSource: [{ id: 1, profileName: "Ada", enabled: true }],
+  defaultFilterValue: [
+    {
+      name: "name",
+      type: "string",
+      operator: "contains",
+      value: "Ada",
+    },
+  ],
+  scrollTopOnFilter: false,
+  renderColumnFilterContextMenu,
+  columnFilterContextMenuAlignPositions: ["tl-bl"],
+  columnFilterContextMenuConstrainTo: () => document.body,
+  columnFilterContextMenuPosition: "fixed",
+  updateMenuPositionOnScroll: false,
+} satisfies TypeDataGridProps;
+
+React.createElement(ReactDataGrid, props);


### PR DESCRIPTION
## What

- resolve filter aliases, inferred types, value getters, default visibility, and rendered column order consistently for local and remote data sources
- complete custom and functional filter editor contracts, boolean defaults/empty values, per-column `filterDelay`, and `scrollTopOnFilter`
- implement custom filter-menu rendering, positioning metadata, constraints, selection callbacks, and keyboard focus behavior
- align string, number, boolean, select, date, range, list, null, empty, and coercion behavior with Inovua 5.10.2
- add a runnable issue #34 compatibility fixture, exhaustive browser/type contracts, documentation updates, and a repeated 10,000-row production benchmark

## Why

The public types accepted much of the upstream filtering vocabulary, but the runtime did not consistently project or execute it. That left local and remote behavior different, editor and menu extension points incomplete, and several operator edge cases observably incompatible.

## Impact

This completes the filtering contracts tracked by issue #34 without removing existing props or changing the data-source ownership model. It adds the missing Inovua-compatible root filtering options and the column-level `filterDelay` field. The Basic Grid select filter now uses its canonical `null` empty value.

Closes #34

## Validation

- `yarn test:types`
- `yarn build`
- issue #34 browser contracts: 28 passed
- full browser regression: 292 passed, 10 intentionally skipped
- production performance suite: 2 passed, including five repeated 10,000-row filtering runs under dispatch, settle, and virtualization budgets
- packed React compatibility: 16.8, 17, 18, and 19 passed
- packed declarations: modern and Node 10 resolution passed
- Prettier on every changed file and `git diff --check` passed

## Review result

The final source/API review found no remaining acceptance-criterion gap from issue #34. The issue can close automatically and safely when this PR is merged.