### PR TITLE
fix: issue 58 rowstyle override

### DIFF
--- a/examples/src/Issue58RowStyleColorCompatPage.tsx
+++ b/examples/src/Issue58RowStyleColorCompatPage.tsx
@@ -1,0 +1,51 @@
+import ReactDataGrid, {
+  type TypeColumns,
+  type TypeRowStyleArgs,
+} from "../../src/main";
+
+// Regression fixture for GitHub issue #58: a `color` returned from `rowStyle`
+// must reach the cell text. Previously `.InovuaReactDataGrid__cell` asserted
+// its own `color`, which beat any color inherited from the row and silently
+// dropped the `rowStyle` color.
+const columns: TypeColumns = [
+  { name: "id", header: "ID", width: 88 },
+  { name: "name", header: "Name", width: 240 },
+];
+const columnOrder = ["id", "name"];
+const rows = [
+  { id: 1, name: "Ada Lovelace" },
+  { id: 2, name: "Grace Hopper" },
+  { id: 3, name: "Katherine Johnson" },
+];
+
+// A vivid, unambiguous color so the computed value is easy to assert against.
+const ROW_COLOR = "rgb(220, 20, 60)";
+
+export default function Issue58RowStyleColorCompatPage() {
+  return (
+    <main
+      data-testid="issue-58-scenario"
+      data-issue="58"
+      className="mx-auto flex w-full max-w-3xl flex-col gap-4"
+    >
+      <header className="space-y-1">
+        <p className="text-sm font-medium text-muted-foreground">
+          Issue #58 compatibility fixture
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          rowStyle color reaches cell text
+        </h1>
+      </header>
+      <div className="h-[220px] min-h-0 rounded-lg border">
+        <ReactDataGrid
+          idProperty="id"
+          columns={columns}
+          dataSource={rows}
+          columnOrder={columnOrder}
+          virtualized={false}
+          rowStyle={(_args: TypeRowStyleArgs) => ({ color: ROW_COLOR })}
+        />
+      </div>
+    </main>
+  );
+}

--- a/examples/src/router.tsx
+++ b/examples/src/router.tsx
@@ -22,6 +22,7 @@ import InovuaParityCompatPage from "./InovuaParityCompatPage";
 import InovuaParityExamplePage from "./InovuaParityExamplePage";
 import InovuaPendingParityCompatPage from "./InovuaPendingParityCompatPage";
 import Issue48CompatPage from "./Issue48CompatPage";
+import Issue58RowStyleColorCompatPage from "./Issue58RowStyleColorCompatPage";
 import Issue32DataSourceCompatPage from "./Issue32DataSourceCompatPage";
 import Issue33SortingCompatPage from "./Issue33SortingCompatPage";
 import Issue34FilteringCompatPage from "./Issue34FilteringCompatPage";
@@ -385,6 +386,12 @@ const compatIssue48Route = createRoute({
   component: Issue48CompatPage,
 });
 
+const compatIssue58RowStyleColorRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "compat/issue-58-row-style-color",
+  component: Issue58RowStyleColorCompatPage,
+});
+
 const compatSearchDataSourceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "compat/search-data-source",
@@ -408,6 +415,7 @@ const routeTree = rootRoute.addChildren([
   compatInovuaParityRoute,
   compatInovuaPendingParityRoute,
   compatIssue48Route,
+  compatIssue58RowStyleColorRoute,
   compatMemorySafetyRoute,
   compatSearchDataSourceRoute,
   examplesOverviewRoute,

--- a/src/runtime.css
+++ b/src/runtime.css
@@ -920,7 +920,11 @@
 
 .tdg-root .InovuaReactDataGrid__cell {
   box-sizing: border-box !important;
-  color: var(--tdg-color-foreground) !important;
+  /* Inherit color from the row so a `rowStyle` color (applied inline on the
+     `<tr>`) and row-state colors (selected/active/hover) reach the cell text.
+     A directly-set cell color would beat any inherited row color, so the cell
+     must not assert its own. The default foreground comes from `.tdg-root`. */
+  color: inherit !important;
   padding: 0.5rem !important;
   position: relative !important;
 }

--- a/tests/playwright/issue-58-row-style-color.spec.ts
+++ b/tests/playwright/issue-58-row-style-color.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+// GitHub issue #58: a `color` returned from `rowStyle` was dropped because
+// `.InovuaReactDataGrid__cell` asserted its own `color`, which beat the color
+// inherited from the row. The cell now inherits color, so the row style wins.
+const ROW_COLOR = "rgb(220, 20, 60)";
+
+test("GitHub issue #58: rowStyle color is applied to cell text", async ({
+  page,
+}) => {
+  await page.goto("/compat/issue-58-row-style-color");
+
+  const scope = page.getByTestId("issue-58-scenario");
+  await expect(scope).toHaveAttribute("data-issue", "58");
+
+  const cells = scope.locator(
+    '[data-slot="grid-row"] .InovuaReactDataGrid__cell'
+  );
+  await expect(cells.first()).toBeVisible();
+
+  const count = await cells.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let index = 0; index < count; index += 1) {
+    await expect(cells.nth(index)).toHaveCSS("color", ROW_COLOR);
+  }
+});


### PR DESCRIPTION
### Summary
make .InovuaReactDataGrid__cell inherit its text color from the row (color: inherit) instead of hardcoding color: var(--tdg-color-foreground), so a color returned from rowStyle reaches the cell text
add an issue [#58](https://github.com/geo-vi/the-datagrid/issues/58) compatibility fixture (/compat/issue-58-row-style-color) and a browser regression test asserting every cell's computed color matches the rowStyle color
Why this fix exists
When rowStyle returned a color, it was applied inline on the <tr> but never showed on the cell text. The rule at src/runtime.css set the cell's own color with !important:

```
.tdg-root .InovuaReactDataGrid__cell {
  color: var(--tdg-color-foreground) !important;
}
```
A color a cell sets directly always beats a color it would inherit from its parent row — !important or not — so the cell declaration silently swallowed the rowStyle color (and, by the same mechanism, the row's selected/active/hover colors, which the grid applies as classes on the <tr>, not the cell).

The fix makes the cell inherit from the row, mirroring Inovua's own cell CSS. The default foreground is unchanged because it still cascades from .tdg-root (src/runtime.css):

```
.tdg-root .InovuaReactDataGrid__cell {
  color: inherit !important;
}
```
This is a styling-only change — no public props or exported types are added or modified.

### Verification
npx tsc -p examples/tsconfig.json — new fixture and route type-check clean (no new errors)
Prettier passes on all changed files
Behavior confirmed in a live browser against the running grid:
with rowStyle={() => ({ color: 'rgb(220,20,60)' })}, all six cell texts compute to rgb(220, 20, 60) (previously the default foreground)
re-inserting the old !important rule at runtime reverts cells to oklch(0.145 0 0), isolating this rule as the cause
a grid without rowStyle still inherits the normal foreground — no regression to the default
Added spec to run in CI: yarn playwright test tests/playwright/issue-58-row-style-color.spec.ts
Fixes [#58](https://github.com/geo-vi/the-datagrid/issues/58).