### PR TITLE
test: make published-entry and npm pack e2e checks run on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,40 @@ jobs:
 
       - name: Run end-to-end tests
         run: yarn test:e2e
+
+  windows-packaged-consumer:
+    name: Windows packaged-consumer tests
+    runs-on: windows-latest
+    # Use bash so the corepack/yarn steps match the Linux jobs verbatim.
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack and pin Yarn
+        run: |
+          corepack enable
+          corepack prepare "yarn@${YARN_VERSION}" --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build the package
+        run: yarn build
+
+      # --with-deps is Linux-only and fails on Windows runners.
+      - name: Install Playwright Chromium
+        run: yarn playwright install chromium
+
+      - name: Run published-entry specs
+        run: yarn playwright test tests/playwright/published-search.spec.ts tests/playwright/published-column-visibility.spec.ts tests/playwright/published-combined-provider.spec.ts
+
+      - name: Run packed-consumer test (issue #44)
+        run: yarn playwright test tests/playwright/github-issues-33-48.spec.ts -g "GitHub issue #44"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,4 +125,5 @@ jobs:
         run: yarn playwright test tests/playwright/published-search.spec.ts tests/playwright/published-column-visibility.spec.ts tests/playwright/published-combined-provider.spec.ts
 
       - name: Run packed-consumer test (issue #44)
-        run: yarn playwright test tests/playwright/github-issues-33-48.spec.ts -g "GitHub issue #44"
+        run: |
+          yarn playwright test tests/playwright/github-issues-33-48.spec.ts -g "GitHub issue #44"

--- a/tests/playwright/github-issues-33-48.spec.ts
+++ b/tests/playwright/github-issues-33-48.spec.ts
@@ -2110,10 +2110,17 @@ test("GitHub issue #44: a browser consumer loads documented module and styleshee
   const manifest = JSON.parse(await readFile("package.json", "utf8")) as {
     exports?: Record<string, PackageExportValue>;
   };
+  // Node's post-CVE-2024-27980 hardening refuses to spawn .cmd/.bat files
+  // unless `shell: true`, so npm.cmd must run through the shell on Windows.
+  const isWindows = process.platform === "win32";
   const { stdout } = await execFile(
-    process.platform === "win32" ? "npm.cmd" : "npm",
+    isWindows ? "npm.cmd" : "npm",
     ["pack", "--dry-run", "--json"],
-    { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 }
+    {
+      cwd: process.cwd(),
+      maxBuffer: 10 * 1024 * 1024,
+      ...(isWindows ? { shell: true } : {}),
+    }
   );
   const pack = JSON.parse(stdout) as Array<{
     files?: Array<{ path: string }>;

--- a/tests/playwright/helpers/vite-fs-url.ts
+++ b/tests/playwright/helpers/vite-fs-url.ts
@@ -1,0 +1,20 @@
+import { resolve } from "node:path";
+
+/**
+ * Vite serves absolute filesystem paths under `/@fs/`.
+ *
+ * A POSIX path already starts with a slash (`/home/…`), but a Windows path
+ * resolves to `C:\…` with backslashes and no leading slash, so concatenating it
+ * onto `/@fs` produces `/@fsC:/…`, which Vite answers with a 404. Normalise the
+ * separators and guarantee exactly one slash after the prefix so both shapes
+ * end up as `/@fs/<absolute path>`.
+ */
+export function toViteFsUrl(absolutePath: string): string {
+  const normalized = absolutePath.replace(/\\/g, "/");
+  return `/@fs/${normalized.replace(/^\/+/, "")}`;
+}
+
+/** Resolve a repo-relative path against the cwd and express it as a `/@fs/` URL. */
+export function viteFsUrl(filePath: string): string {
+  return toViteFsUrl(resolve(process.cwd(), filePath));
+}

--- a/tests/playwright/published-column-visibility.spec.ts
+++ b/tests/playwright/published-column-visibility.spec.ts
@@ -1,14 +1,6 @@
-import { resolve } from "node:path";
 import { expect, test } from "@playwright/test";
 
-// Vite serves absolute filesystem paths under `/@fs/`. A Windows path resolves
-// to `C:\...` with no leading slash and with backslashes, so it has to be
-// normalised into the `/@fs/C:/...` form Vite recognises; POSIX paths already
-// supply their own leading slash.
-function viteFsUrl(filePath: string): string {
-  const absolutePath = resolve(process.cwd(), filePath).replace(/\\/g, "/");
-  return `/@fs/${absolutePath.replace(/^\//, "")}`;
-}
+import { viteFsUrl } from "./helpers/vite-fs-url";
 
 test("published core and column-visibility entries hide and show a column", async ({
   page,

--- a/tests/playwright/published-column-visibility.spec.ts
+++ b/tests/playwright/published-column-visibility.spec.ts
@@ -1,8 +1,13 @@
 import { resolve } from "node:path";
 import { expect, test } from "@playwright/test";
 
+// Vite serves absolute filesystem paths under `/@fs/`. A Windows path resolves
+// to `C:\...` with no leading slash and with backslashes, so it has to be
+// normalised into the `/@fs/C:/...` form Vite recognises; POSIX paths already
+// supply their own leading slash.
 function viteFsUrl(filePath: string): string {
-  return `/@fs${resolve(process.cwd(), filePath)}`;
+  const absolutePath = resolve(process.cwd(), filePath).replace(/\\/g, "/");
+  return `/@fs/${absolutePath.replace(/^\//, "")}`;
 }
 
 test("published core and column-visibility entries hide and show a column", async ({

--- a/tests/playwright/published-combined-provider.spec.ts
+++ b/tests/playwright/published-combined-provider.spec.ts
@@ -1,15 +1,6 @@
-import { resolve } from "node:path";
-
 import { expect, test } from "@playwright/test";
 
-// Vite serves absolute filesystem paths under `/@fs/`. A Windows path resolves
-// to `C:\...` with no leading slash and with backslashes, so it has to be
-// normalised into the `/@fs/C:/...` form Vite recognises; POSIX paths already
-// supply their own leading slash.
-function viteFsUrl(filePath: string): string {
-  const absolutePath = resolve(process.cwd(), filePath).replace(/\\/g, "/");
-  return `/@fs/${absolutePath.replace(/^\//, "")}`;
-}
+import { viteFsUrl } from "./helpers/vite-fs-url";
 
 test("published combined provider shares legacy search and visibility contexts", async ({
   page,

--- a/tests/playwright/published-combined-provider.spec.ts
+++ b/tests/playwright/published-combined-provider.spec.ts
@@ -2,8 +2,13 @@ import { resolve } from "node:path";
 
 import { expect, test } from "@playwright/test";
 
+// Vite serves absolute filesystem paths under `/@fs/`. A Windows path resolves
+// to `C:\...` with no leading slash and with backslashes, so it has to be
+// normalised into the `/@fs/C:/...` form Vite recognises; POSIX paths already
+// supply their own leading slash.
 function viteFsUrl(filePath: string): string {
-  return `/@fs${resolve(process.cwd(), filePath)}`;
+  const absolutePath = resolve(process.cwd(), filePath).replace(/\\/g, "/");
+  return `/@fs/${absolutePath.replace(/^\//, "")}`;
 }
 
 test("published combined provider shares legacy search and visibility contexts", async ({

--- a/tests/playwright/published-search.spec.ts
+++ b/tests/playwright/published-search.spec.ts
@@ -1,8 +1,13 @@
 import { resolve } from "node:path";
 import { expect, test } from "@playwright/test";
 
+// Vite serves absolute filesystem paths under `/@fs/`. A Windows path resolves
+// to `C:\...` with no leading slash and with backslashes, so it has to be
+// normalised into the `/@fs/C:/...` form Vite recognises; POSIX paths already
+// supply their own leading slash.
 function viteFsUrl(filePath: string): string {
-  return `/@fs${resolve(process.cwd(), filePath)}`;
+  const absolutePath = resolve(process.cwd(), filePath).replace(/\\/g, "/");
+  return `/@fs/${absolutePath.replace(/^\//, "")}`;
 }
 
 test("published core and search entries share a working search runtime", async ({

--- a/tests/playwright/published-search.spec.ts
+++ b/tests/playwright/published-search.spec.ts
@@ -1,14 +1,6 @@
-import { resolve } from "node:path";
 import { expect, test } from "@playwright/test";
 
-// Vite serves absolute filesystem paths under `/@fs/`. A Windows path resolves
-// to `C:\...` with no leading slash and with backslashes, so it has to be
-// normalised into the `/@fs/C:/...` form Vite recognises; POSIX paths already
-// supply their own leading slash.
-function viteFsUrl(filePath: string): string {
-  const absolutePath = resolve(process.cwd(), filePath).replace(/\\/g, "/");
-  return `/@fs/${absolutePath.replace(/^\//, "")}`;
-}
+import { viteFsUrl } from "./helpers/vite-fs-url";
 
 test("published core and search entries share a working search runtime", async ({
   page,

--- a/tests/playwright/vite-fs-url.spec.ts
+++ b/tests/playwright/vite-fs-url.spec.ts
@@ -1,0 +1,41 @@
+import { posix, win32 } from "node:path";
+import { expect, test } from "@playwright/test";
+
+import { toViteFsUrl } from "./helpers/vite-fs-url";
+
+/**
+ * Pins the `/@fs/` URL construction used by the packed-consumer specs. These
+ * run on every platform, so the Windows shape is asserted from a `path.win32`
+ * result rather than from whatever the host happens to produce.
+ */
+test.describe("vite /@fs URL normalization", () => {
+  test("turns a Windows absolute path into a single-slash /@fs URL", () => {
+    const absolute = win32.resolve("C:\\Users\\dev\\the-datagrid", "dist/index.js");
+
+    expect(absolute).toBe("C:\\Users\\dev\\the-datagrid\\dist\\index.js");
+    expect(toViteFsUrl(absolute)).toBe(
+      "/@fs/C:/Users/dev/the-datagrid/dist/index.js"
+    );
+  });
+
+  test("keeps a POSIX absolute path on exactly one slash", () => {
+    const absolute = posix.resolve("/home/dev/the-datagrid", "dist/index.js");
+
+    expect(absolute).toBe("/home/dev/the-datagrid/dist/index.js");
+    expect(toViteFsUrl(absolute)).toBe("/@fs/home/dev/the-datagrid/dist/index.js");
+  });
+
+  test("never emits the /@fsC: shape that Vite answers with a 404", () => {
+    for (const absolute of [
+      "C:\\Users\\dev\\dist\\index.js",
+      "D:\\a\\the-datagrid\\the-datagrid\\dist\\search.js",
+      "/home/runner/work/the-datagrid/dist/search.js",
+    ]) {
+      const url = toViteFsUrl(absolute);
+
+      expect(url.startsWith("/@fs/")).toBe(true);
+      expect(url).not.toContain("\\");
+      expect(url).not.toMatch(/^\/@fs\/\//);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #69.

## Summary

Two host-path bugs kept four Playwright specs from running on a Windows checkout. Both are test-side only — no library code changes.

- The three `published-*` specs built module URLs as `/@fs${resolve(...)}`. On Windows that yields `/@fsC:\...`, which Vite does not recognise as its `/@fs/` prefix, so every import 404d and the grid never mounted. Separators are now normalised and a single leading slash is always emitted, which leaves the existing POSIX URLs byte-identical.
- Issue #44's probe spawned `npm.cmd` without a shell and failed with `spawn EINVAL` (Node's post-CVE-2024-27980 hardening). It now uses the same `shell: true` workaround `scripts/test-published-types.mjs` already documents.

## Verification

`published-search`, `published-column-visibility`, `published-combined-provider` and the full `github-issues-33-48` suite (64 tests, including #44 and #46) pass locally on Windows. Linux CI is unaffected: the POSIX branch of both code paths is unchanged.
