### PR TITLE
fix: restore scrollbar thumb proportion and resize-handle clearance

### DIFF
--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -158,10 +158,12 @@ function ScrollBar({
       orientation={orientation}
       className={cn(
         "group z-30 flex touch-none transition-colors select-none data-[state=hidden]:hidden",
+        // Main-axis alignment stays at the default start: Radix positions the
+        // thumb by transform from its laid-out offset.
         orientation === "vertical" &&
-          "w-2.5 flex-col items-center justify-center border-l border-l-transparent",
+          "w-2.5 flex-col items-center border-l border-l-transparent",
         orientation === "horizontal" &&
-          "h-2.5 flex-row items-center justify-center border-t border-t-transparent",
+          "h-2.5 flex-row items-center border-t border-t-transparent",
         className
       )}
       {...props}
@@ -169,7 +171,9 @@ function ScrollBar({
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
         className={cn(
-          "relative flex-1 rounded-full bg-[var(--tdg-color-ring)] transition-[width,height,background-color] hover:bg-[var(--tdg-color-muted-foreground)]",
+          // No `flex-1`: the main axis is the scroll axis, so growing would
+          // stretch the thumb over the whole track. Radix sizes that axis.
+          "relative rounded-full bg-[var(--tdg-color-ring)] transition-[width,height,background-color] hover:bg-[var(--tdg-color-muted-foreground)]",
           orientation === "vertical" &&
             "group-hover:!w-[var(--tdg-scroll-thumb-over-width)]",
           orientation === "horizontal" &&

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -1358,6 +1358,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
     1,
     25
   );
+  // Track + margin of an overlay vertical scrollbar, resolved as `ScrollArea`
+  // resolves it. `runtime.css` needs it to pull the trailing resize handle
+  // clear of the bar, and `scrollProps` can change it.
+  const computedVerticalScrollbarFootprint =
+    (scrollProps?.scrollThumbOverWidth ?? scrollProps?.scrollThumbWidth ?? 10) +
+    (scrollProps?.scrollThumbMargin ?? 0);
   const disabledRowsRef = React.useRef(disabledRows);
   disabledRowsRef.current = disabledRows;
   const getDisabledRowState = React.useCallback(
@@ -9665,6 +9671,7 @@ function ReactDataGrid(props: TypeDataGridProps) {
           ...style,
           "--tdg-column-resize-handle-width": `${computedColumnResizeHandleWidth}px`,
           "--tdg-column-resize-proxy-width": `${computedColumnResizeProxyWidth}px`,
+          "--tdg-scroll-vertical-footprint": `${computedVerticalScrollbarFootprint}px`,
         } as React.CSSProperties
       }
       onKeyDown={handleGridKeyDown}

--- a/src/runtime.css
+++ b/src/runtime.css
@@ -990,19 +990,23 @@
  * Radix scrollbars overlay the viewport instead of consuming layout space.
  * When the vertical bar is visible, move the final 24px hit target fully to
  * its left. The header still reaches the viewport edge, so column geometry
- * and horizontal scroll alignment remain unchanged.
+ * and horizontal scroll alignment remain unchanged. A smaller offset leaves
+ * the handle over the track, which swallows the pointer.
  *
- * 0.75rem is the bar's full footprint: the 8px track plus its 4px margin.
- * Anything smaller leaves the handle overlapping the track, which swallows
- * the pointer and makes the last column unresizable.
+ * :not([data-state="hidden"]), not [data-state="visible"]: Radix omits
+ * data-state entirely on an always-visible bar (autoHide: false).
  */
 .tdg-root:has(
-    [data-slot="scroll-area-scrollbar"][data-orientation="vertical"][data-state="visible"]
+    [data-slot="scroll-area-scrollbar"][data-orientation="vertical"]:not(
+        [data-state="hidden"]
+      )
   )
   .tdg-header-row
   > .tdg-header-cell:last-child
   .tdg-column-resizer {
-  right: calc(0.75rem - 0.5rem) !important;
+  right: calc(
+    var(--tdg-scroll-vertical-footprint, 0.75rem) - 0.5rem
+  ) !important;
 }
 
 .tdg-root .tdg-column-resizer:focus-visible {

--- a/src/runtime.css
+++ b/src/runtime.css
@@ -991,6 +991,10 @@
  * When the vertical bar is visible, move the final 24px hit target fully to
  * its left. The header still reaches the viewport edge, so column geometry
  * and horizontal scroll alignment remain unchanged.
+ *
+ * 0.75rem is the bar's full footprint: the 8px track plus its 4px margin.
+ * Anything smaller leaves the handle overlapping the track, which swallows
+ * the pointer and makes the last column unresizable.
  */
 .tdg-root:has(
     [data-slot="scroll-area-scrollbar"][data-orientation="vertical"][data-state="visible"]
@@ -998,7 +1002,7 @@
   .tdg-header-row
   > .tdg-header-cell:last-child
   .tdg-column-resizer {
-  right: calc(0.625rem - 0.5rem) !important;
+  right: calc(0.75rem - 0.5rem) !important;
 }
 
 .tdg-root .tdg-column-resizer:focus-visible {

--- a/tests/playwright/github-issues-33-48.spec.ts
+++ b/tests/playwright/github-issues-33-48.spec.ts
@@ -1864,6 +1864,44 @@ test("GitHub issue #43: Community scrollbar defaults are applied without overrid
   await expect(
     scrollbars.nth(1).locator('[data-slot="scroll-area-thumb"]')
   ).toHaveCSS("height", "6px");
+
+  // Thickness above is the cross axis; the scroll-axis length must stay
+  // proportional to the visible fraction, or the thumb reads as a solid rail.
+  const thumbLengthRatios = await scope.evaluate((root) => {
+    const measure = (orientation: "vertical" | "horizontal") => {
+      const bar = root.querySelector(
+        `[data-slot="scroll-area-scrollbar"][data-orientation="${orientation}"]`
+      );
+      const thumb = bar?.querySelector('[data-slot="scroll-area-thumb"]');
+      if (!bar || !thumb) return null;
+      const barRect = bar.getBoundingClientRect();
+      const thumbRect = thumb.getBoundingClientRect();
+      return orientation === "vertical"
+        ? thumbRect.height / barRect.height
+        : thumbRect.width / barRect.width;
+    };
+    const viewport = root.querySelector(".tdg-body-viewport") as HTMLElement;
+    return {
+      vertical: measure("vertical"),
+      horizontal: measure("horizontal"),
+      expectedVertical: viewport.clientHeight / viewport.scrollHeight,
+      expectedHorizontal: viewport.clientWidth / viewport.scrollWidth,
+    };
+  });
+
+  expect(thumbLengthRatios.vertical).not.toBeNull();
+  expect(thumbLengthRatios.horizontal).not.toBeNull();
+  // Both axes must actually overflow, otherwise the ratios below prove nothing.
+  expect(thumbLengthRatios.expectedVertical).toBeLessThan(0.9);
+  expect(thumbLengthRatios.expectedHorizontal).toBeLessThan(0.9);
+  expect(thumbLengthRatios.vertical!).toBeCloseTo(
+    thumbLengthRatios.expectedVertical,
+    1
+  );
+  expect(thumbLengthRatios.horizontal!).toBeCloseTo(
+    thumbLengthRatios.expectedHorizontal,
+    1
+  );
 });
 
 test("GitHub issue #43: a user scroll after filtering is not overwritten by delayed reset work", async ({

--- a/tests/playwright/github-issues-33-48.spec.ts
+++ b/tests/playwright/github-issues-33-48.spec.ts
@@ -1904,6 +1904,118 @@ test("GitHub issue #43: Community scrollbar defaults are applied without overrid
   );
 });
 
+// Overlay scrollbars take no layout width, so the trailing resize handle must
+// be pulled clear of the bar or the bar wins hit-testing. `scrollProps` changes
+// the footprint, hence both geometries.
+for (const scenario of [
+  { mode: "defaults", label: "default", footprint: 8 + 4 },
+  { mode: "custom", label: "always-visible custom", footprint: 15 + 3 },
+]) {
+  test(`GitHub issue #43: the trailing resize handle clears the ${scenario.label} vertical scrollbar`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    const scope = await openIssue(page, 43, `scrollMode=${scenario.mode}`);
+    const grid = scope.locator(".tdg-root");
+    const viewport = grid.locator('[data-slot="scroll-area-viewport"]').first();
+    const verticalBar = grid.locator(
+      '[data-slot="scroll-area-scrollbar"][data-orientation="vertical"]'
+    );
+
+    // Only at the far right can the handle and the bar collide.
+    await viewport.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth;
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    await expect
+      .poll(() =>
+        viewport.evaluate(
+          (element) =>
+            element.scrollWidth - element.clientWidth - element.scrollLeft
+        )
+      )
+      .toBeLessThanOrEqual(1);
+
+    // autoHide=true mounts the bar on pointer entry; requiring it visible stops
+    // the assertions below short-circuiting on a missing rect.
+    await viewport.hover({ position: { x: 8, y: 40 } });
+    await expect(verticalBar).toBeVisible();
+
+    const layout = await grid.evaluate((gridElement) => {
+      const bar = gridElement.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-scrollbar"][data-orientation="vertical"]'
+      );
+      const headers = [
+        ...gridElement.querySelectorAll<HTMLElement>(
+          ".tdg-header-row > .tdg-header-cell"
+        ),
+      ];
+      const lastHeader = headers[headers.length - 1];
+      const handle = lastHeader?.querySelector<HTMLElement>(
+        '[data-slot="column-resizer"]'
+      );
+      if (!bar || !lastHeader || !handle) return null;
+
+      const barRect = bar.getBoundingClientRect();
+      const handleRect = handle.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        handleRect.left + handleRect.width / 2,
+        handleRect.top + handleRect.height / 2
+      );
+
+      return {
+        // Asserted so a scenario cannot silently use default geometry.
+        barFootprint: Math.round(
+          barRect.width + parseFloat(getComputedStyle(bar).marginRight)
+        ),
+        clearsScrollbar: handleRect.right <= barRect.left + 1,
+        overlap: Math.round(handleRect.right - barRect.left),
+        handleWinsHitTest:
+          hit === handle || Boolean(hit && handle.contains(hit)),
+        columnId: lastHeader.getAttribute("data-column-id"),
+      };
+    });
+
+    expect(layout).not.toBeNull();
+    expect(layout!.barFootprint).toBe(scenario.footprint);
+    expect(layout!.overlap).toBeLessThanOrEqual(1);
+    expect(layout!.clearsScrollbar).toBe(true);
+    expect(layout!.handleWinsHitTest).toBe(true);
+
+    // Clearing the bar only matters if the handle is actually draggable.
+    const lastHeader = grid.locator(
+      `.tdg-header-row > .tdg-header-cell[data-column-id="${layout!.columnId}"]`
+    );
+    const initialWidth = await lastHeader.evaluate((element) =>
+      Math.round(element.getBoundingClientRect().width)
+    );
+    const handleBox = await lastHeader
+      .locator('[data-slot="column-resizer"]')
+      .boundingBox();
+    expect(handleBox).not.toBeNull();
+
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2 + 40,
+      handleBox!.y + handleBox!.height / 2,
+      { steps: 4 }
+    );
+    await page.mouse.up();
+
+    await expect
+      .poll(() =>
+        lastHeader.evaluate((element) =>
+          Math.round(element.getBoundingClientRect().width)
+        )
+      )
+      .toBeGreaterThan(initialWidth + 20);
+  });
+}
+
 test("GitHub issue #43: a user scroll after filtering is not overwritten by delayed reset work", async ({
   page,
 }) => {


### PR DESCRIPTION
Fixes two scrollbar-geometry regressions from #67. Styling only; no grid or layout behaviour is changed.

## 1. Thumbs filled their whole track

#67 flipped each track's flex direction (vertical `row` to `flex-col`, horizontal `column` to `flex-row`) but left `flex-1` on the thumb. `flex-1` sizes the main axis, which after the flip is the scroll axis, so it overrode the proportional length Radix sets inline. The horizontal thumb spanned the full bottom edge of the table and read as a solid rail with rows hidden under it.

- Drops `flex-1` from the thumb; thickness is already set from `scrollProps`, so the class has no remaining job.
- Drops `justify-center` from both tracks, which would offset the thumb once it is no longer full length, since Radix positions it by transform from its laid-out offset.

Thumb length as a fraction of its track, `/examples/columns` at 900x800:

| | vertical | horizontal |
| --- | --- | --- |
| `98d985b` (before #67) | 0.06 | 0.60 |
| `9c5f2d4` (0.0.10) | 1.00 | 1.00 |
| this branch | 0.06 | 0.60 |
| viewport `clientSize / scrollSize` | 0.06 | 0.60 |

The last two rows were derived independently and agree, so the restored values are the contract rather than a tuned number.

## 2. The final resize handle overlapped the vertical bar

The trailing handle is pulled left when the bar is visible, but the rule was written for the pre-#67 `0.625rem`/10px track and missed two cases. Thanks for the custom-path repro — it was exactly right.

- **Selector.** It matched `[data-state="visible"]`, but Radix only sets `data-state` for the hover and scroll scrollbar types. An always-visible bar (`autoHide: false`) carries no such attribute, so the rule never applied and the handle kept its uncompensated offset. Now `:not([data-state="hidden"])`, which covers both.
- **Footprint.** It was a stylesheet constant. `scrollProps` changes the footprint, so the grid now publishes track + margin as `--tdg-scroll-vertical-footprint`, resolved the same way `ScrollArea` resolves the values it renders with (`scrollThumbOverWidth ?? scrollThumbWidth ?? 10`, plus `scrollThumbMargin ?? 0`).

Trailing handle against the bar's left edge, at 1280x900 scrolled fully right:

| | footprint | overlap | hit target |
| --- | --- | --- | --- |
| `9c5f2d4` default | 12px | 0px | handle |
| `9c5f2d4` custom `autoHide: false` | 18px | **18px** | **thumb** |
| this branch, default | 12px | 0px | handle |
| this branch, custom | 18px | 0px | handle |

## Coverage

- Two-axis thumb-ratio assertion on the #43 defaults scenario. Fails on the unfixed code: received `1`, expected `0.057`.
- New `the trailing resize handle clears the … vertical scrollbar` test, parameterised over the default and the custom `autoHide: false` / 15px / 3px geometry. It requires the bar to be visible before measuring so the assertions cannot short-circuit on a missing rect, scrolls fully right, asserts the measured track + margin matches the expected footprint, that the handle clears the bar and wins hit-testing, then drag-resizes the final column.
- Verified against each defect separately: 18px overlap with the old selector, 6px with the constant footprint. Both fail only on the custom scenario.

## Validation

- `github-issues-33-48.spec.ts --grep "issue #43"` including the two new cases — 10 passed
- `github-issues-33-48` + `mobile-transform` + `overflow` + `github-issues-4-16` — 88 specs, 1 failure, `issue #44: a browser consumer loads documented module and stylesheet exports`, which also fails on `main` (see below)
- `mobile-transform.spec.ts --grep "resize handle fully accessible" --repeat-each 5 --retries 0` — 5 passed
- `tsc --noEmit` — passed. ESLint on `ReactDataGrid.tsx` reports 39 pre-existing `no-explicit-any` errors, the same count as on `main`, none in the added lines.
- #43's scrollbar defaults are unchanged: 6px thumb, 8px track, 4px margin, 8px on hover; thumb position still tracks 0.0 / 0.5 / 1.0 on both axes.

Not run locally: `yarn build`, full `yarn test:e2e`, `yarn test:react-compat`, performance config.

## The earlier CI failure on this branch

`mobile-transform.spec.ts:61` was the part-2 defect, not something introduced here. Before the fix, every value that assertion reads was identical on `main` and this branch — `scrollbarLeft` 1234, `handleRight` 1236, `false` on both — and the only value the thumb change moves is thumb length. The same spec also failed on `agent/issue-61-theme-inovua-removal`, which contains none of these changes, then passed on a re-run. It passed only when the bar happened to be hidden at measurement time.

## Out of scope

- No RTL counterpart exists for the scrollbar-visible resizer rule, so the mirrored case stays uncompensated. #67 added RTL variants for the two neighbouring rules but not this one.
- `main` resolves to `dist/index.cjs`, and `injectLibraryCssEntry` skips the CSS side-effect import for `.cjs`, so that entry ships with no stylesheet reference while `dist/index.js` has `import "./index.css"`. Consumers resolving through `require` get an unstyled grid, and it is why issue #44's packed-consumer spec fails with or without this branch. Happy to open a separate issue.

Closes #71
