### PR TITLE
fix: restore active-row indicator visibility and pointer activation

### DIFF
--- a/examples/src/themes/hf-dark.scss
+++ b/examples/src/themes/hf-dark.scss
@@ -29,7 +29,9 @@
   --tdg-row-odd-selected-bg: #1a2740;
   --tdg-row-even-selected-bg: #1a2740;
   --tdg-row-selected-hover-bg: #26324a;
-  --tdg-row-active-color: #e5e5e5;
+  --tdg-row-active-color: #c5cae9;
+  --tdg-row-active-border-width: 2px;
+  --tdg-row-active-border-color: #26324a;
 
   --tdg-input-bg: #191919;
   --tdg-input-color: #e5e5e5;

--- a/examples/src/themes/hf-light.scss
+++ b/examples/src/themes/hf-light.scss
@@ -30,6 +30,8 @@
   --tdg-row-even-selected-bg: #f0f3fb;
   --tdg-row-selected-hover-bg: #f6f8fc;
   --tdg-row-active-color: #333333;
+  --tdg-row-active-border-width: 2px;
+  --tdg-row-active-border-color: #f6f8fc;
 
   --tdg-input-bg: #fefefe;
   --tdg-input-color: #333333;

--- a/examples/src/themes/ikarus-dark.scss
+++ b/examples/src/themes/ikarus-dark.scss
@@ -31,7 +31,10 @@
   --tdg-row-selected-bg: #252525;
   --tdg-row-odd-selected-bg: #252525;
   --tdg-row-even-selected-bg: #252525;
-  --tdg-row-active-color: #ffffff;
+  --tdg-row-active-color: #c5cae9;
+  // Pinned: this theme sets no --tdg-color-accent for the border to inherit.
+  --tdg-row-active-border-width: 2px;
+  --tdg-row-active-border-color: #252525;
 
   --tdg-input-bg: #464d56;
   --tdg-input-color: #ffffff;

--- a/examples/src/themes/ikarus-light.scss
+++ b/examples/src/themes/ikarus-light.scss
@@ -33,6 +33,9 @@
   --tdg-row-odd-selected-bg: #ece5cf;
   --tdg-row-even-selected-bg: #ece5cf;
   --tdg-row-active-color: #555e68;
+  // Solid amber, not the pale --tdg-color-accent the border would inherit.
+  --tdg-row-active-border-width: 2px;
+  --tdg-row-active-border-color: #caae53;
 
   // Inputs and selects intentionally follow the grid's own border chrome
   // (#e4e3e2) rather than the legacy toolkit's control border, so a custom

--- a/src/grid/ReactDataGrid.tsx
+++ b/src/grid/ReactDataGrid.tsx
@@ -7857,6 +7857,29 @@ function ReactDataGrid(props: TypeDataGridProps) {
     );
   }, []);
 
+  /**
+   * Pressing a row focuses the surface on pointerdown, before the row's own
+   * click handler runs, so activateRowOnFocus would light up the first visible
+   * row and the click would immediately move it — a flash on the wrong row.
+   * Scoped to the press in flight: a press while already focused fires no focus
+   * event to consume it, and a stale flag would swallow the next focus restore.
+   */
+  const pointerActivatesRowRef = React.useRef(false);
+
+  const handleGridPointerDownCapture = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const target = event.target;
+      pointerActivatesRowRef.current =
+        target instanceof Element &&
+        Boolean(target.closest('[data-slot="grid-row"]'));
+    },
+    []
+  );
+
+  const clearPointerActivatesRow = React.useCallback(() => {
+    pointerActivatesRowRef.current = false;
+  }, []);
+
   const handleGridFocus = React.useCallback(
     (event: React.FocusEvent<HTMLDivElement>) => {
       onFocusProp?.(event);
@@ -7870,8 +7893,12 @@ function ReactDataGrid(props: TypeDataGridProps) {
         return;
       }
 
+      const pressedRow = pointerActivatesRowRef.current;
+      pointerActivatesRowRef.current = false;
+
       setGridFocused(true);
       if (
+        !pressedRow &&
         enableKeyboardNavigation &&
         activateRowOnFocus &&
         normalizedActiveIndex < 0 &&
@@ -7908,6 +7935,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
       ) {
         return;
       }
+
+      // A press that released outside the grid never reached the pointer-up.
+      pointerActivatesRowRef.current = false;
 
       onBlurProp?.(event);
       if (event.defaultPrevented) return;
@@ -9663,6 +9693,9 @@ function ReactDataGrid(props: TypeDataGridProps) {
         } as React.CSSProperties
       }
       onKeyDown={handleGridKeyDown}
+      onPointerDownCapture={handleGridPointerDownCapture}
+      onPointerUpCapture={clearPointerActivatesRow}
+      onPointerCancelCapture={clearPointerActivatesRow}
       onFocus={handleGridFocus}
       onBlur={handleGridBlur}
     >

--- a/src/grid/components/GridBody.tsx
+++ b/src/grid/components/GridBody.tsx
@@ -662,11 +662,14 @@ export function GridBody(props: GridBodyProps) {
               showHoverRows && "hover:bg-[var(--tdg-row-selected-hover-bg)]"
             )
         : "",
-      rowIsActive ? "tdg-row--active InovuaReactDataGrid__row--active" : "",
+      rowIsActive
+        ? "tdg-row--active InovuaReactDataGrid__row--active [color:var(--tdg-row-active-color)]"
+        : "",
       rowIsActive && gridFocused
         ? cn(
             "tdg-row--focused InovuaReactDataGrid__row--focused",
             rowFocusClassName,
+            showActiveRowIndicator ? "tdg-row--active-indicator" : "",
             showActiveRowIndicator ? activeRowIndicatorClassName : ""
           )
         : "",
@@ -674,20 +677,6 @@ export function GridBody(props: GridBodyProps) {
         ? "tdg-row--disabled InovuaReactDataGrid__row--disabled pointer-events-none opacity-50"
         : ""
     );
-  }
-
-  function getRowThemeStyle(
-    rowIsActive: boolean
-  ): React.CSSProperties | undefined {
-    if (!rowIsActive || !gridFocused || !showActiveRowIndicator) {
-      return undefined;
-    }
-
-    return {
-      outline:
-        "var(--tdg-row-active-border-width) var(--tdg-row-active-border-style) var(--tdg-row-active-border-color)",
-      outlineOffset: "-1px",
-    };
   }
 
   function getResolvedRowHeight(rowIndex: number): number | null {
@@ -762,7 +751,6 @@ export function GridBody(props: GridBodyProps) {
     row: any,
     rowIndex: number,
     rowIsSelected: boolean,
-    rowIsActive: boolean,
     disabledRow: boolean | null | undefined,
     virtualSize?: number
   ): React.CSSProperties {
@@ -784,7 +772,6 @@ export function GridBody(props: GridBodyProps) {
       Number.isFinite(maxRowHeight)
         ? { maxHeight: maxRowHeight }
         : {}),
-      ...getRowThemeStyle(rowIsActive),
     };
 
     const configuredStyle =
@@ -1690,14 +1677,7 @@ export function GridBody(props: GridBodyProps) {
       "aria-current": rowIsActive || undefined,
       "aria-selected": selectionEnabled ? rowIsSelected : undefined,
       style: {
-        ...getRowStyle(
-          row,
-          rowIndex,
-          rowIsSelected,
-          rowIsActive,
-          disabledRow,
-          virtualSize
-        ),
+        ...getRowStyle(row, rowIndex, rowIsSelected, disabledRow, virtualSize),
         ...(inheritedRowProps.style ?? {}),
       },
       onClick: (event: React.MouseEvent<HTMLTableRowElement>) => {

--- a/src/runtime.css
+++ b/src/runtime.css
@@ -442,7 +442,9 @@
   --tdg-row-even-selected-hover-bg: var(--tdg-row-selected-hover-bg);
   --tdg-row-active-border-width: 1px;
   --tdg-row-active-border-style: solid;
-  --tdg-row-active-border-color: var(--tdg-color-accent);
+  /* Not --tdg-color-accent: unlike Inovua's ACCENT_COLOR, that token is a pale
+     hover surface here, which left this indicator near-invisible. */
+  --tdg-row-active-border-color: var(--tdg-color-ring);
   --tdg-row-active-color: var(--tdg-color-foreground);
   --tdg-field-active-bg: var(--tdg-row-selected-bg);
   --tdg-column-header-resizer-constrained-color: var(--tdg-color-accent);
@@ -1146,6 +1148,35 @@
   transform: translateX(
     var(--tdg-locked-column-viewport-offset, 0px)
   ) !important;
+}
+
+/* Active-row indicator, drawn per cell rather than as an outline on the row:
+   locked cells are sticky with an opaque inherited background, so they paint
+   over anything the row draws beneath them. */
+.tdg-root .tdg-row--active-indicator > * {
+  position: relative;
+}
+
+.tdg-root .tdg-row--active-indicator > *::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  border-top: var(--tdg-row-active-border-width)
+    var(--tdg-row-active-border-style) var(--tdg-row-active-border-color);
+  border-bottom: var(--tdg-row-active-border-width)
+    var(--tdg-row-active-border-style) var(--tdg-row-active-border-color);
+}
+
+.tdg-root .tdg-row--active-indicator > *:first-child::after {
+  border-left: var(--tdg-row-active-border-width)
+    var(--tdg-row-active-border-style) var(--tdg-row-active-border-color);
+}
+
+.tdg-root .tdg-row--active-indicator > *:last-child::after {
+  border-right: var(--tdg-row-active-border-width)
+    var(--tdg-row-active-border-style) var(--tdg-row-active-border-color);
 }
 
 .tdg-root .tdg-locked-column--start-boundary {

--- a/tests/playwright/active-row-indicator.spec.ts
+++ b/tests/playwright/active-row-indicator.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+
+// The active-row indicator was an outline on the row element. Locked columns are
+// sticky cells that open their own stacking context and inherit an opaque row
+// background, so they painted over anything the row drew beneath them: the
+// border vanished behind the checkbox and action columns and showed through only
+// on hover, where the hover token is a translucent color-mix. It is drawn per
+// cell now, so every cell paints its own segment above its own background.
+//
+// These assertions are deliberately about rendering. The issue #38 coverage
+// already pins the active-row *state* (`data-active-index`, `aria-current`,
+// `data-active` and the caller's class names), and all of it stayed green
+// throughout the regression, because none of it looks at what is painted.
+
+// Ikarus Light declares `--tdg-row-active-border-color: #caae53` at 2px, a value
+// no other token in that theme shares, so a segment picking up the wrong token
+// cannot coincidentally match.
+const AMBER = "rgb(202, 174, 83)";
+
+// The actions example is the one that locks a column at each edge: a checkbox
+// column at the start and the action buttons at the end.
+async function activateMiddleRow(page: import("@playwright/test").Page) {
+  await page.goto("/actions");
+  await page.getByRole("button", { name: "Ikarus Light", exact: true }).click();
+
+  const grid = page.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toHaveAttribute("data-theme", "ikarus-light");
+
+  const row = grid.locator('[data-slot="grid-row"]').nth(2);
+  await row.scrollIntoViewIfNeeded();
+  // A plain data cell, so no editor or action control swallows the click.
+  await row.locator("td").nth(3).click();
+
+  return { grid, row };
+}
+
+test("the active-row indicator paints on the locked cells at both edges", async ({
+  page,
+}) => {
+  const { row } = await activateMiddleRow(page);
+  await expect(row).toHaveClass(/tdg-row--active-indicator/);
+
+  const segments = await row.evaluate((element) => {
+    const cells = [...element.children] as HTMLElement[];
+    const read = (cell: HTMLElement) => {
+      const after = getComputedStyle(cell, "::after");
+
+      return {
+        position: getComputedStyle(cell).position,
+        top: `${after.borderTopWidth} ${after.borderTopStyle} ${after.borderTopColor}`,
+        bottomWidth: after.borderBottomWidth,
+        leftWidth: after.borderLeftWidth,
+        rightWidth: after.borderRightWidth,
+      };
+    };
+
+    return {
+      lockedStart: read(cells[0]),
+      middle: read(cells[Math.floor(cells.length / 2)]),
+      lockedEnd: read(cells[cells.length - 1]),
+    };
+  });
+
+  // Guards the premise: if these stop being sticky the regression this test
+  // describes can no longer happen, and a passing run would mean nothing.
+  expect(segments.lockedStart.position, "start cell is locked").toBe("sticky");
+  expect(segments.lockedEnd.position, "end cell is locked").toBe("sticky");
+
+  for (const [name, segment] of Object.entries(segments)) {
+    expect(segment.top, `${name} top segment`).toBe(`2px solid ${AMBER}`);
+    expect(segment.bottomWidth, `${name} bottom segment`).toBe("2px");
+  }
+
+  // Only the outer edges close, so the row reads as one rectangle rather than a
+  // box drawn around every individual cell.
+  expect(segments.lockedStart.leftWidth, "start cell closes the left edge").toBe(
+    "2px"
+  );
+  expect(segments.lockedEnd.rightWidth, "end cell closes the right edge").toBe(
+    "2px"
+  );
+  expect(segments.middle.leftWidth, "middle cell stays open").toBe("0px");
+  expect(segments.middle.rightWidth, "middle cell stays open").toBe("0px");
+});
+
+test("clicking a row activates it without flashing the indicator elsewhere", async ({
+  page,
+}) => {
+  await page.goto("/actions");
+
+  const grid = page.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toHaveAttribute("data-active-index", "none");
+
+  // Record every write synchronously. A polled assertion samples between frames
+  // and would step straight over an index that is replaced a commit later.
+  await grid.evaluate((root) => {
+    const writes: (string | null)[] = [];
+    (window as Window & { __activeIndexWrites?: (string | null)[] })
+      .__activeIndexWrites = writes;
+
+    new MutationObserver(() =>
+      writes.push(root.getAttribute("data-active-index"))
+    ).observe(root, {
+      attributes: true,
+      attributeFilter: ["data-active-index"],
+    });
+  });
+
+  const row = grid.locator('[data-slot="grid-row"]').nth(3);
+  await row.scrollIntoViewIfNeeded();
+  await row.locator("td").nth(3).click();
+  await expect(grid).toHaveAttribute("data-active-index", "3");
+
+  // Pressing a row focuses the grid surface before the row's click handler runs.
+  // activateRowOnFocus used to claim the first visible row in that window, so
+  // the indicator painted on row 0 and only then jumped to the pressed row.
+  const writes = await page.evaluate(
+    () =>
+      (window as Window & { __activeIndexWrites?: (string | null)[] })
+        .__activeIndexWrites
+  );
+  expect(writes, "data-active-index writes for a single click").toEqual(["3"]);
+});
+
+test("keyboard focus still activates a row on entry", async ({ page }) => {
+  await page.goto("/actions");
+
+  const grid = page.locator(".InovuaReactDataGrid.tdg-root").first();
+  await expect(grid).toHaveAttribute("data-active-index", "none");
+
+  // The pointer-intent flag above must not leak into focus that no press
+  // caused, which is what activateRowOnFocus exists to serve.
+  await grid.locator('[data-slot="grid-surface"]').focus();
+  await expect(grid).toHaveAttribute("data-focused", "true");
+  await expect(grid).toHaveAttribute("data-active-index", "0");
+});

--- a/tests/playwright/issue-61-theme-tokens.spec.ts
+++ b/tests/playwright/issue-61-theme-tokens.spec.ts
@@ -16,6 +16,14 @@ type ThemeCase = {
   /** Authored `--tdg-row-odd-bg` / `--tdg-row-even-bg`, as declared by the theme. */
   rowOddBg: string;
   rowEvenBg: string;
+  /**
+   * Authored `--tdg-row-active-border-color` / `--tdg-row-active-color`. Both
+   * are pinned per theme rather than derived: the border used to follow
+   * `--tdg-color-accent`, which these themes set to a pale hover tint, so it
+   * resolved to a near-invisible near-white.
+   */
+  rowActiveBorderColor: string;
+  rowActiveColor: string;
 };
 
 // Values come straight from examples/src/themes/*.scss. HF Dark deliberately
@@ -27,18 +35,24 @@ const THEME_SEQUENCE: ThemeCase[] = [
     theme: "ikarus-dark",
     rowOddBg: "#282828",
     rowEvenBg: "#343434",
+    rowActiveBorderColor: "#252525",
+    rowActiveColor: "#c5cae9",
   },
   {
     button: "Ikarus Light",
     theme: "ikarus-light",
     rowOddBg: "#f8f8f8",
     rowEvenBg: "#ffffff",
+    rowActiveBorderColor: "#caae53",
+    rowActiveColor: "#555e68",
   },
   {
     button: "HF Dark",
     theme: "hf-dark",
     rowOddBg: "#191919",
     rowEvenBg: "#191919",
+    rowActiveBorderColor: "#26324a",
+    rowActiveColor: "#c5cae9",
   },
   // Re-entering the first theme catches a switch that only works on the way out.
   {
@@ -46,6 +60,8 @@ const THEME_SEQUENCE: ThemeCase[] = [
     theme: "ikarus-dark",
     rowOddBg: "#282828",
     rowEvenBg: "#343434",
+    rowActiveBorderColor: "#252525",
+    rowActiveColor: "#c5cae9",
   },
 ];
 
@@ -98,6 +114,12 @@ test("GitHub issue #61: custom-to-custom theme switches update row tokens", asyn
         inlineTokens,
         rowOddVar: rootStyle.getPropertyValue("--tdg-row-odd-bg").trim(),
         rowEvenVar: rootStyle.getPropertyValue("--tdg-row-even-bg").trim(),
+        rowActiveBorderVar: rootStyle
+          .getPropertyValue("--tdg-row-active-border-color")
+          .trim(),
+        rowActiveColorVar: rootStyle
+          .getPropertyValue("--tdg-row-active-color")
+          .trim(),
         oddRowBackgroundColor: oddRow
           ? getComputedStyle(oddRow).backgroundColor
           : null,
@@ -134,6 +156,14 @@ test("GitHub issue #61: custom-to-custom theme switches update row tokens", asyn
       rowState.evenRowBackgroundColor,
       `${themeCase.theme} even row background`
     ).toBe(hexToRgb(themeCase.rowEvenBg));
+    expect(
+      rowState.rowActiveBorderVar,
+      `${themeCase.theme} --tdg-row-active-border-color`
+    ).toBe(themeCase.rowActiveBorderColor);
+    expect(
+      rowState.rowActiveColorVar,
+      `${themeCase.theme} --tdg-row-active-color`
+    ).toBe(themeCase.rowActiveColor);
 
     // No inline theme state means nothing can go stale on the next switch.
     expect(

--- a/tests/playwright/issue-61-theme-tokens.spec.ts
+++ b/tests/playwright/issue-61-theme-tokens.spec.ts
@@ -49,14 +49,16 @@ const THEME_SEQUENCE: ThemeCase[] = [
   },
 ];
 
-// The only `--tdg-*` custom properties the grid legitimately writes inline are
-// these two, derived from the `columnResizeHandleWidth` /
-// `columnResizeProxyWidth` props rather than from a theme. Asserting the exact
-// set (not just "no row tokens") means a reintroduced runtime theme bridge fails
-// this test whichever token it decides to inline.
+// The only `--tdg-*` custom properties the grid legitimately writes inline come
+// from props or runtime measurement rather than from a theme: the first two
+// from `columnResizeHandleWidth` / `columnResizeProxyWidth`, the third from the
+// measured scrollbar footprint. Asserting the exact set (not just "no row
+// tokens") means a reintroduced runtime theme bridge fails this test whichever
+// token it decides to inline. Kept sorted, since the assertion sorts.
 const PROP_DRIVEN_INLINE_TOKENS = [
   "--tdg-column-resize-handle-width",
   "--tdg-column-resize-proxy-width",
+  "--tdg-scroll-vertical-footprint",
 ];
 
 function hexToRgb(hex: string): string {


### PR DESCRIPTION
Fixes #73. Three things were wrong with the active-row indicator. Rendering and focus bookkeeping only. Selection, keyboard navigation and the active-row API are untouched.

## The border didn't cross locked columns

It was an `outline` on the row element, and locked columns are sticky cells with their own stacking context and an opaque background, so they simply painted over it. It bled through on hover only because the hover colour is a semi-transparent `color-mix`, which is what made it look intermittent rather than missing.

Each cell now draws its own segment as an `::after` overlay above that cell's background, the same job Inovua's `row-active-borders` element did with a high `z-index`. Only the outer edges close, so the row still reads as one rectangle. It's a pseudo-element rather than an inset `box-shadow` because a shadow would flatten `dashed` to solid and lose `--tdg-row-active-border-style`.

On `/examples/actions` with Ikarus Light, the checkbox and actions cells went from painting nothing to `2px #caae53`, matching the middle cells.

## It flashed on the wrong row

Pressing a row focuses the grid surface on `pointerdown`, so the focus handler ran before the row's own click handler. With no active row yet, `activateRowOnFocus` claimed the first visible row, and the click then moved the indicator across. Two renders, so you saw it on row 0 first.

The grid now notices when focus arrived from pressing a row and skips the focus-time activation in that case, the click sets the index itself, so nothing is lost. Keyboard and programmatic focus behave exactly as before. Clicking row 3 used to write `data-active-index` twice, `0` then `3`; it writes `3` once now.

The flag only describes the press in flight. A press made while the grid is already focused fires no focus event to consume it, so it's also cleared on pointer-up and when focus leaves. Without that it went stale and swallowed the next focus restore, the existing #38 controlled-`activeIndex` test caught exactly that.

## The colour was nearly invisible

`--tdg-row-active-border-color` came from `--tdg-color-accent`. In Inovua that was the brand colour, but the shadcn token of the same name is a pale hover surface, so the border resolved to `oklch(0.97 0 0)` on light and `oklch(0.269 0 0)` on dark — near the row background either way. It now comes from `--tdg-color-ring`, the focus-indicator token.

The example themes needed fixing separately. Neither active-row token was ever declared in their own SCSS, so both drifted in #68:

| theme | border colour | active text |
| --- | --- | --- |
| ikarus-light | `#f7f3e5` → `#caae53` | unchanged |
| ikarus-dark | base fallback → `#252525` | `#ffffff` → `#c5cae9` |
| hf-light | unchanged | `#333333`, left alone |
| hf-dark | unchanged | `#e5e5e5` → `#c5cae9` |

All four also get the presets' 2px width back, having fallen to the 1px default. I read these by compiling the pre-refactor SCSS against its Inovua preset rather than inferring them from the themes' own variables, which never held most of them. `hf-light`'s `#333333` matches its own `--tdg-color-foreground`.

The active row also takes `--tdg-row-active-color` now. Hover and selected rows already used it; the active row never did, though Inovua set it through `.row--active .cell`.

## Tests

New `active-row-indicator.spec.ts`, plus the two active-row tokens added to the #61 theme table. I checked each one actually fails without its fix:

- **Border on locked cells.** Activates a row on `/examples/actions` and checks each cell's own segment, with only the outer edges closed. It also asserts those cells are still sticky, so it can't quietly pass because the situation stopped being reachable. Put the row `outline` back, keeping the class, and it fails: `0px` instead of `2px solid rgb(202, 174, 83)`.
- **No flash.** Watches `data-active-index` with a `MutationObserver` rather than polling, since the wrong value is replaced a render later and polling steps straight over it. Without the fix: `["0", "3"]` instead of `["3"]`.
- **Keyboard focus still activates a row.** The other direction. This is the case that caught the stale flag above.
- **Theme tokens.** Without the theme fix: `oklch(0.556 0 0)` instead of `#252525`.

Worth saying plainly: the #38 suite covers `data-active-index`, `aria-current`, `data-active` and the caller's class names, and every one of those stayed green through all three bugs, because none of them look at what ends up on screen.

## Checks

Full Playwright suite, 371 passed. `yarn build` clean, including CSS scope and the boundary assertions. `tsc` clean, and eslint unchanged from `main`.

The default 12-worker run turns up ~6 failures that all pass single-worker and on a like-for-like re-run at 4 workers — the load-sensitive specs, not regressions.

## One unrelated commit

`main` is red on its own right now. #68 added a test pinning the exact set of inline `--tdg-*` tokens, and #72 added `--tdg-scroll-vertical-footprint` to the grid root. Neither conflicted textually, so both merged green alone and the combination fails — reproducible on `5f1ee46` with none of this branch's commits. The footprint is measured at runtime rather than themed, which is the category that allowlist already covers, so one commit here admits it. Happy to split it out if you'd rather it landed separately.
