### PR TITLE
fix: keep the filter input's focus ring inside the cell clip

### DIFF
--- a/src/runtime.css
+++ b/src/runtime.css
@@ -1092,6 +1092,8 @@
   min-width: 0 !important;
   align-items: center !important;
   gap: 0 !important;
+  /* Focus-ring room. */
+  padding-inline: var(--tdg-filter-cell-focus-ring-width, 1px) !important;
   overflow: hidden !important;
   position: relative !important;
 }


### PR DESCRIPTION
fixes https://github.com/geo-vi/the-datagrid/issues/75

### Summary
- Focusing a text input in the filter row drew its focus ring on three sides only and the leading edge was cut off.
- The ring is a box-shadow drawn outside the control's box, and the control sits flush against the filter cell's content box, which clips. So there was no room for it.
- Fixed by reserving the ring's width as inline padding on the clipping element. Overflow clips to the padding box, so the ring now falls inside it. At the leading edge the first painted pixel changes from the control's own border (#e5e5e5) to the ring (oklch(0.708 0 0)).


### Checks

- Full Playwright suite, 366 passed. The two failures (#38 selected identities, #46) pass 6/6 single-worker — the usual load-sensitive ones, not regressions.
- yarn test:css-scope passes.
- The #34 custom-editor case passes 4/4 repeated. Worth calling out because the two approaches I tried first — overflow: visible and overflow: clip — both restored the ring and both broke it 4/4, which is how the scroll-container constraint surfaced.
- Confirmed the filter cell is still a scroll container after the change, so the over-wide-editor behaviour is intact.
- Checked the other inputs while I was there: the global search box was never clipped, and the filter cells in locked columns on /examples/actions have ~43px of slack.
