### PR TITLE
fix(grid): raise the column resize guide above the sticky header

### DIFF
--- a/src/runtime.css
+++ b/src/runtime.css
@@ -1051,7 +1051,8 @@
   top: 0 !important;
   bottom: 0 !important;
   left: 0 !important;
-  z-index: 20 !important;
+  /* Above the sticky header layer (20); it renders later, so equal z-index loses. */
+  z-index: 30 !important;
   width: var(--tdg-column-resize-proxy-width, 5px) !important;
   pointer-events: none !important;
   will-change: transform !important;

--- a/tests/playwright/live-column-resize.spec.ts
+++ b/tests/playwright/live-column-resize.spec.ts
@@ -227,6 +227,40 @@ test.describe("live column resizing", () => {
     ).toHaveCount(0);
   });
 
+  test("keeps the drag guide above the sticky header layer", async ({
+    page,
+  }) => {
+    const { grid } = await openScenario(page, "resize-callback");
+    const resizer = header(grid, "description").locator(
+      '[data-slot="column-resizer"]'
+    );
+    const start = await dragStartPoint(resizer);
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 100, start.y, { steps: 12 });
+    await settleFrames(page);
+
+    await expect(
+      grid.locator(".InovuaReactDataGrid__resize-proxy")
+    ).toBeVisible();
+
+    // The proxy renders before the header layer, so an equal z-index is not a
+    // tie: the sticky header and filter rows paint over the guide. The filter
+    // row lives in that same layer, so clearing it clears both.
+    const [proxyZ, headerLayerZ] = await grid.evaluate((root) => [
+      Number(
+        getComputedStyle(
+          root.querySelector(".InovuaReactDataGrid__resize-proxy")!
+        ).zIndex
+      ),
+      Number(getComputedStyle(root.querySelector(".tdg-header-layer")!).zIndex),
+    ]);
+    expect(proxyZ).toBeGreaterThan(headerLayerZ);
+
+    await page.mouse.up();
+  });
+
   test("previews a controlled width but leaves ownership with the consumer", async ({
     page,
   }) => {


### PR DESCRIPTION
# fix: raise the column resize guide above the sticky header

fixes https://github.com/geo-vi/the-datagrid/issues/81

### Summary

- The drag guide shown while resizing a column was painted behind the header and filter rows, so it looked like it started below the header instead of spanning the grid.
- Its geometry was never wrong. `.InovuaReactDataGrid__resize-proxy` is absolutely positioned against the grid surface with `top: 0; bottom: 0`, so it already reaches across the header. The bug is paint order: the proxy and the sticky `.tdg-header-layer` were both `z-index: 20`, and the proxy renders first inside the surface, so the later header layer won the tie.
- Raised to `30`: above the header layer, still below the dialog portal at `50`, so menus keep covering the guide. One line of CSS.
- Not a two-tables problem. The header and body tables share one scroller, and the guide is a sibling of the whole scroll area rather than of either table.
- Affects the default configuration — the proxy renders only when `liveColumnResize` is `false`, which is the default.

### Checks

- New case in `tests/playwright/live-column-resize.spec.ts` drives a real pointer drag and asserts the guide's computed `z-index` beats the header layer's. It fails on the parent commit with `Expected: > 20, Received: 20`.
- `live-column-resize.spec.ts` single-worker: **7 passed**.
- Full Playwright suite: **369 passed, 3 failed**; all three pass on a single-worker re-run (**63 passed**).
- The one remaining single-worker failure, `#42` "virtual offsets and scroll anchoring update when a preceding row grows", was checked against the unmodified stylesheet and fails there too (2 of 3 runs). Pre-existing flake, not a regression.
- Diagnosis was verified in the browser before the change, by hit-testing a probe carrying the proxy's own class: covered by the header and filter rows at `z-index: 20`, on top of both at `30`.
- Not verified visually in every theme. The change is a single stacking value with no colour or geometry effect, and no theme overrides this rule.
